### PR TITLE
feat: add custom TradingView links for assets

### DIFF
--- a/.claude/issue-451-plan.md
+++ b/.claude/issue-451-plan.md
@@ -67,32 +67,35 @@ The TradingView link generation currently uses a simple mapping of Saxo country 
 
 ---
 
-### Frontend Changes (TODO)
+### Frontend Changes ✅ COMPLETED
 
-9. **Update API client** (`frontend/src/services/api.ts`)
-   - Add `setTradingViewLink(assetId: string, url: string)` function
-   - Update `AssetIndicatorsResponse` interface to include optional `tradingview_url?: string`
-   - Update `WatchlistItem` interface to include optional `tradingview_url?: string`
+9. ✅ **Update API client** (`frontend/src/services/api.ts`)
+   - Added `tradingViewService.setTradingViewLink(assetId: string, url: string)` function
+   - Updated `AssetIndicatorsResponse` interface to include optional `tradingview_url?: string`
+   - Updated `WatchlistItem` interface to include optional `tradingview_url?: string`
+   - Added `SetTradingViewLinkResponse` interface
 
-10. **Update TradingView utility** (`frontend/src/utils/tradingview.ts`)
-    - Modify signature: `getTradingViewUrl(assetSymbol: string, customUrl?: string)`
-    - Return customUrl if provided, otherwise fall back to current mapping logic
+10. ✅ **Update TradingView utility** (`frontend/src/utils/tradingview.ts`)
+    - Modified signature: `getTradingViewUrl(assetSymbol: string, customUrl?: string)`
+    - Returns customUrl if provided, otherwise falls back to default mapping logic
 
-11. **Update IndicatorCard** (`frontend/src/components/IndicatorCard.tsx`)
-    - Use `getTradingViewUrl(indicators.asset_symbol, indicators.tradingview_url)`
-    - Add small edit button (✏️) next to TradingView link when not in edit mode
-    - Create modal component for editing TradingView URL:
-      - Input field for URL
-      - Save/Cancel buttons
-      - Handle API call to save the URL
-      - Show success/error messages
+11. ✅ **Update IndicatorCard** (`frontend/src/components/IndicatorCard.tsx`)
+    - Updated TradingView link to use `getTradingViewUrl(indicators.asset_symbol, indicators.tradingview_url)`
+    - Added edit button (✏️) next to TradingView link
+    - Created modal component for editing TradingView URL:
+      - Input field for URL with placeholder
+      - Save/Cancel buttons with loading states
+      - API call to save the URL using `tradingViewService`
+      - Error message display
+    - Added CSS styling in `IndicatorCard.css` for modal and edit button
 
-12. **Update AssetDetail page** (`frontend/src/pages/AssetDetail.tsx`)
-    - Pass tradingview_url from indicatorData to IndicatorCard
-    - (Already passed via indicators prop, just need to ensure it's in the data)
+12. ✅ **Update AssetDetail page** (`frontend/src/pages/AssetDetail.tsx`)
+    - Added `onTradingViewUrlUpdated` callback to IndicatorCard
+    - Updates local state when URL is changed
 
-13. **Update Watchlist** (`frontend/src/pages/Watchlist.tsx`)
-    - Use `getTradingViewUrl(item.asset_symbol, item.tradingview_url)` for sidebar links
+13. ✅ **Update Watchlist** (`frontend/src/pages/Watchlist.tsx`)
+    - Updated to use `getTradingViewUrl(item.asset_symbol, item.tradingview_url)` for TradingView links
+    - Fixed CSS styling in `Watchlist.css` for proper table layout
 
 ---
 
@@ -101,19 +104,25 @@ The TradingView link generation currently uses a simple mapping of Saxo country 
 1. ✅ **Infrastructure** (DynamoDB table, IAM policies, Pulumi deployment) - COMPLETED
 2. ✅ **Backend data layer** (AWS client methods) - COMPLETED
 3. ✅ **Backend API** (models, router, service updates) - COMPLETED
-4. **Frontend API client** updates - TODO
-5. **Frontend UI** (modal, link updates) - TODO
+4. ✅ **Frontend API client** updates - COMPLETED
+5. ✅ **Frontend UI** (modal, link updates) - COMPLETED
 
 ## Progress Summary
 
 **Completed:**
-- Infrastructure setup with DynamoDB table
-- Complete backend API implementation
-- All backend tests passing
-- PR created: https://github.com/RNiveau/saxo-order/pull/463
+- ✅ Infrastructure setup with DynamoDB table
+- ✅ Complete backend API implementation
+- ✅ All backend tests passing
+- ✅ Backend PR created: https://github.com/RNiveau/saxo-order/pull/463
+- ✅ Complete frontend implementation
+  - API client with TradingView service
+  - TradingView utility with custom URL support
+  - IndicatorCard with edit modal
+  - AssetDetail page integration
+  - Watchlist custom URL support
+  - All CSS styling completed
 
-**Remaining:**
-- Frontend implementation (separate PR after backend is merged)
+**Status:** Feature fully implemented and ready for testing
 
 ---
 
@@ -136,11 +145,13 @@ The TradingView link generation currently uses a simple mapping of Saxo country 
 - `api/services/watchlist_service.py` - ✅ Query and include link
 
 ### Frontend
-- `frontend/src/services/api.ts` - API client
-- `frontend/src/utils/tradingview.ts` - URL generation utility
-- `frontend/src/components/IndicatorCard.tsx` - Display and edit modal
-- `frontend/src/pages/AssetDetail.tsx` - Pass data to IndicatorCard
-- `frontend/src/pages/Watchlist.tsx` - Use custom URLs
+- `frontend/src/services/api.ts` - ✅ API client with TradingView service
+- `frontend/src/utils/tradingview.ts` - ✅ URL generation utility
+- `frontend/src/components/IndicatorCard.tsx` - ✅ Display and edit modal
+- `frontend/src/components/IndicatorCard.css` - ✅ Modal and edit button styling
+- `frontend/src/pages/AssetDetail.tsx` - ✅ Pass data to IndicatorCard with callback
+- `frontend/src/pages/Watchlist.tsx` - ✅ Use custom URLs
+- `frontend/src/pages/Watchlist.css` - ✅ Fixed table layout styling
 
 ---
 

--- a/frontend/src/components/IndicatorCard.css
+++ b/frontend/src/components/IndicatorCard.css
@@ -62,6 +62,142 @@
   transform: translateY(0);
 }
 
+.edit-tradingview-btn {
+  padding: 6px 10px;
+  background: transparent;
+  border: 1px solid #666;
+  color: #e0e0e0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.edit-tradingview-btn:hover {
+  background: #2a2a2a;
+  border-color: #888;
+  transform: translateY(-1px);
+}
+
+.edit-tradingview-btn:active {
+  transform: translateY(0);
+}
+
+.edit-tradingview-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 500px;
+  width: 90%;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.modal-content h3 {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.modal-description {
+  margin: 0 0 16px 0;
+  font-size: 14px;
+  color: #999;
+}
+
+.tradingview-input {
+  width: 100%;
+  padding: 10px;
+  background: #252525;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 14px;
+  margin-bottom: 16px;
+  box-sizing: border-box;
+}
+
+.tradingview-input:focus {
+  outline: none;
+  border-color: #2962ff;
+}
+
+.tradingview-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-message {
+  background: #2f1a1a;
+  border: 1px solid #f44336;
+  color: #ef5350;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.btn-cancel,
+.btn-save {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+}
+
+.btn-cancel {
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border: 1px solid #3a3a3a;
+}
+
+.btn-cancel:hover:not(:disabled) {
+  background: #3a3a3a;
+}
+
+.btn-save {
+  background: #2962ff;
+  color: white;
+}
+
+.btn-save:hover:not(:disabled) {
+  background: #1e53e5;
+}
+
+.btn-cancel:disabled,
+.btn-save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .price-section {
   margin-bottom: 24px;
 }

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -227,7 +227,12 @@ export function AssetDetail() {
       {indicatorLoading && <div className="loading">Loading indicators...</div>}
       {indicatorError && <div className="error">{indicatorError}</div>}
       {!indicatorLoading && !indicatorError && indicatorData && (
-        <IndicatorCard indicators={indicatorData} />
+        <IndicatorCard
+          indicators={indicatorData}
+          onTradingViewUrlUpdated={(url) => {
+            setIndicatorData({ ...indicatorData, tradingview_url: url });
+          }}
+        />
       )}
 
       {/* Workflows Section */}

--- a/frontend/src/pages/Watchlist.css
+++ b/frontend/src/pages/Watchlist.css
@@ -97,3 +97,93 @@
   color: #e6edf3;
   font-family: monospace;
 }
+
+.watchlist-table {
+  overflow-x: auto;
+}
+
+.watchlist-table table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.watchlist-table thead {
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.watchlist-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  color: #8b949e;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.watchlist-table tbody tr {
+  border-bottom: 1px solid #21262d;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.watchlist-table tbody tr:hover {
+  background: #161b22;
+}
+
+.watchlist-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.watchlist-table td {
+  padding: 1rem;
+}
+
+.watchlist-row .variation {
+  font-family: monospace;
+  font-weight: 600;
+}
+
+.watchlist-row .variation.positive {
+  color: #3fb950;
+}
+
+.watchlist-row .variation.negative {
+  color: #f85149;
+}
+
+.loading-indicator {
+  font-size: 1rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error {
+  background: #da3633;
+  color: #ffffff;
+  padding: 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  border: 1px solid #f85149;
+}
+
+.no-items {
+  background: #161b22;
+  color: #8b949e;
+  padding: 2rem;
+  border-radius: 6px;
+  text-align: center;
+  border: 1px solid #30363d;
+}

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -129,7 +129,7 @@ export function Watchlist() {
                       <div className="description-with-icon">
                         <span className="description-text">{item.description || item.asset_symbol}</span>
                         <a
-                          href={getTradingViewUrl(item.asset_symbol)}
+                          href={getTradingViewUrl(item.asset_symbol, item.tradingview_url)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="tradingview-icon"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -147,6 +147,7 @@ export interface AssetIndicatorsResponse {
   currency: string;
   unit_time: string;
   moving_averages: MovingAverageInfo[];
+  tradingview_url?: string;
 }
 
 export const indicatorService = {
@@ -177,6 +178,7 @@ export interface WatchlistItem {
   currency: string;
   added_at: string;
   labels: string[];
+  tradingview_url?: string;
 }
 
 export interface WatchlistResponse {
@@ -388,6 +390,25 @@ export interface ReportConfig {
 export const reportConfigService = {
   getConfig: async (): Promise<ReportConfig> => {
     const response = await api.get<ReportConfig>('/api/report/config');
+    return response.data;
+  },
+};
+
+export interface SetTradingViewLinkResponse {
+  message: string;
+  asset_id: string;
+  tradingview_url: string;
+}
+
+export const tradingViewService = {
+  setTradingViewLink: async (
+    assetId: string,
+    tradingviewUrl: string
+  ): Promise<SetTradingViewLinkResponse> => {
+    const response = await api.put<SetTradingViewLinkResponse>(
+      `/api/asset-details/${assetId}/tradingview`,
+      { tradingview_url: tradingviewUrl }
+    );
     return response.data;
   },
 };

--- a/frontend/src/utils/tradingview.ts
+++ b/frontend/src/utils/tradingview.ts
@@ -1,4 +1,10 @@
-export function getTradingViewUrl(assetSymbol: string): string {
+export function getTradingViewUrl(assetSymbol: string, customUrl?: string): string {
+  // If custom URL is provided, use it
+  if (customUrl) {
+    return customUrl;
+  }
+
+  // Otherwise, generate default URL
   // Parse asset_symbol to get code and country_code
   const [code, countryCode = 'xpar'] = assetSymbol.split(':');
 


### PR DESCRIPTION
## Summary
Implement custom TradingView URL support for assets to fix incorrect links caused by different trigrams between Saxo and TradingView.

### Frontend Changes
- Added TradingView service with `setTradingViewLink()` method
- Updated `getTradingViewUrl()` utility to accept optional custom URL
- Added edit button and modal to IndicatorCard component
- Implemented modal with input field, save/cancel buttons, and error handling
- Updated AssetDetail page to handle URL updates
- Updated Watchlist to use custom TradingView URLs
- Fixed Watchlist table CSS layout

## Related Issues
Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)