### PR TITLE
feat: add Binance support to search UI

### DIFF
--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -39,6 +39,7 @@ export function AssetDetail() {
     try {
       setLoading(true);
       setError(null);
+      // Handle both Saxo (CODE:MARKET) and Binance (SYMBOL) formats
       const parts = assetSymbol.split(':');
       const code = parts[0];
       const countryCode = parts.length > 1 ? parts[1] : '';
@@ -56,7 +57,7 @@ export function AssetDetail() {
     try {
       setIndicatorLoading(true);
       setIndicatorError(null);
-      // Parse symbol to extract code and country_code
+      // Handle both Saxo (CODE:MARKET) and Binance (SYMBOL) formats
       const parts = assetSymbol.split(':');
       const code = parts[0];
       const countryCode = parts.length > 1 ? parts[1] : '';
@@ -100,7 +101,7 @@ export function AssetDetail() {
       setWatchlistError(null);
       setWatchlistSuccess(null);
 
-      // Parse symbol to extract code and country_code
+      // Handle both Saxo (CODE:MARKET) and Binance (SYMBOL) formats
       const parts = symbol.split(':');
       const code = parts[0];
       const countryCode = parts.length > 1 ? parts[1] : '';

--- a/frontend/src/pages/SearchResults.css
+++ b/frontend/src/pages/SearchResults.css
@@ -21,6 +21,51 @@
   padding: 0.5rem 0;
 }
 
+.results-table {
+  overflow-x: auto;
+}
+
+.results-table table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.results-table thead {
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+}
+
+.results-table th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  color: #8b949e;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.results-table tbody tr {
+  border-bottom: 1px solid #21262d;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.results-table tbody tr:hover {
+  background: #161b22;
+}
+
+.results-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.results-table td {
+  padding: 1rem;
+}
+
 .result-row .symbol {
   color: #58a6ff;
   font-weight: 600;
@@ -36,8 +81,24 @@
   font-size: 0.9rem;
 }
 
-.result-row .identifier {
-  color: #8b949e;
-  font-family: monospace;
-  font-size: 0.9rem;
+.exchange-badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  display: inline-block;
+}
+
+.exchange-badge.saxo {
+  background: rgba(136, 192, 208, 0.15);
+  color: #88c0d0;
+  border: 1px solid rgba(136, 192, 208, 0.3);
+}
+
+.exchange-badge.binance {
+  background: rgba(240, 185, 11, 0.15);
+  color: #f0b90b;
+  border: 1px solid rgba(240, 185, 11, 0.3);
 }

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -72,20 +72,24 @@ export function SearchResults() {
                   <th>Symbol</th>
                   <th>Description</th>
                   <th>Type</th>
-                  <th>Identifier</th>
+                  <th>Exchange</th>
                 </tr>
               </thead>
               <tbody>
-                {results.map((result) => (
+                {results.map((result, index) => (
                   <tr
-                    key={result.identifier}
+                    key={`${result.exchange}-${result.symbol}-${index}`}
                     onClick={() => handleAssetClick(result.symbol, result.description)}
                     className="result-row"
                   >
                     <td className="symbol">{result.symbol}</td>
                     <td className="description">{result.description}</td>
                     <td className="asset-type">{result.asset_type}</td>
-                    <td className="identifier">{result.identifier}</td>
+                    <td className="exchange">
+                      <span className={`exchange-badge ${result.exchange}`}>
+                        {result.exchange}
+                      </span>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -45,8 +45,9 @@ export const fundService = {
 export interface SearchResultItem {
   symbol: string;
   description: string;
-  identifier: number;
+  identifier: number | null;
   asset_type: string;
+  exchange: string;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
## Summary

Completes issue #472 by adding frontend support for Binance search results.

Closes #472

## Changes

- Updated `SearchResultItem` interface with `exchange` field and nullable `identifier`
- Replaced Identifier column with Exchange column in search results
- Added colored badges for Saxo (blue) and Binance (yellow)
- Matched watchlist table design
- Added symbol format handling comments in AssetDetail

## Testing

- ✅ Search displays results from both exchanges
- ✅ Exchange badges show correctly
- ✅ UI matches watchlist design
- ✅ Clicking assets navigates to detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>