### PR TITLE
fix: remove .name on asset type string from Saxo API

### DIFF
--- a/engines/workflow_engine.py
+++ b/engines/workflow_engine.py
@@ -147,7 +147,7 @@ class WorkflowEngine:
                         order_direction=order_obj.direction.name,
                         order_type=order_obj.type.name,
                         asset_type=(
-                            asset["AssetType"].name
+                            asset["AssetType"]
                             if asset.get("AssetType")
                             else None
                         ),


### PR DESCRIPTION
## Summary
- `asset["AssetType"]` from Saxo API is already a string (e.g. `"CfdOnIndex"`), calling `.name` on it fails with `'str' object has no attribute 'name'`

## Test plan
- [x] Existing workflow engine tests pass