### PR TITLE
docs: update homepage spec for 12-asset limit

### DIFF
--- a/specs/511-homepage-feature/plan.md
+++ b/specs/511-homepage-feature/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Implement homepage dashboard displaying up to 6 watchlist assets tagged as "homepage", showing real-time prices, variation %, MA50 indicator, and TradingView chart links. Backend fetches from DynamoDB watchlist table with "homepage" label filter. Frontend displays in responsive grid with navigation to asset detail pages.
+Implement homepage dashboard displaying up to 12 watchlist assets tagged as "homepage", showing real-time prices, variation %, MA50 indicator, and TradingView chart links. Backend fetches from DynamoDB watchlist table with "homepage" label filter. Frontend displays in responsive grid with navigation to asset detail pages.
 
 ## Technical Context
 
@@ -18,7 +18,7 @@ Implement homepage dashboard displaying up to 6 watchlist assets tagged as "home
 **Target Platform**: Web application (FastAPI + React/Vite)
 **Project Type**: Full-stack web application
 **Performance Goals**: <2s page load, real-time price updates
-**Constraints**: Maximum 6 assets, DynamoDB query limit
+**Constraints**: Maximum 12 assets, DynamoDB query limit
 **Scale/Scope**: Single page feature, ~500 LOC total
 
 ## Constitution Check
@@ -101,7 +101,7 @@ frontend/src/components/HomepageCard.css # Card styles
 
 **Key Design Decisions**:
 - Reused existing watchlist infrastructure (no new tables)
-- Limited to 6 assets via slice operation
+- Limited to 12 assets via validation on label update
 - MA50 calculated on-demand using existing CandlesService
 - Supported both Saxo and Binance exchanges
 

--- a/specs/511-homepage-feature/spec.md
+++ b/specs/511-homepage-feature/spec.md
@@ -13,11 +13,11 @@ As a trader, I want to see my most important assets at a glance on the homepage 
 
 **Why this priority**: Homepage is the first touchpoint - critical for daily workflow
 
-**Independent Test**: Navigate to homepage, verify 6 tagged assets display with live prices
+**Independent Test**: Navigate to homepage, verify 12 tagged assets display with live prices
 
 **Acceptance Scenarios**:
 
-1. **Given** I have assets tagged with "homepage" in my watchlist, **When** I load the homepage, **Then** I see up to 6 assets displayed
+1. **Given** I have assets tagged with "homepage" in my watchlist, **When** I load the homepage, **Then** I see up to 12 assets displayed
 2. **Given** assets are displayed on homepage, **When** prices update, **Then** I see current price and variation percentage
 3. **Given** assets with TradingView links, **When** I click an asset, **Then** I navigate to asset detail page
 
@@ -40,7 +40,7 @@ As a trader, I want to see MA50 (50-period moving average) for each homepage ass
 
 ### Edge Cases
 
-- What happens when user has fewer than 6 assets tagged as "homepage"? (Display all available)
+- What happens when user has fewer than 12 assets tagged as "homepage"? (Display all available)
 - What happens when user has no assets tagged? (Empty state message)
 - What happens when price data is unavailable? (Show last known price or "N/A")
 - What happens when MA50 cannot be calculated? (Insufficient historical data - show "N/A")
@@ -51,7 +51,7 @@ As a trader, I want to see MA50 (50-period moving average) for each homepage ass
 
 - **FR-001**: System MUST fetch watchlist items from DynamoDB
 - **FR-002**: System MUST filter items by "homepage" tag
-- **FR-003**: System MUST limit display to maximum 6 assets
+- **FR-003**: System MUST limit display to maximum 12 assets
 - **FR-004**: System MUST retrieve current price and variation % for each asset
 - **FR-005**: System MUST calculate MA50 indicator (daily timeframe)
 - **FR-006**: System MUST determine if current price is above/below MA50


### PR DESCRIPTION
## Summary
- Update `specs/511-homepage-feature/spec.md` and `plan.md` to reflect the new 12-asset homepage limit

## Test plan
- Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)