### PR TITLE
fix: close unclosed aiohttp client session in CLI commands

### DIFF
--- a/engines/workflow_loader.py
+++ b/engines/workflow_loader.py
@@ -34,8 +34,7 @@ async def _load_from_dynamodb(logger) -> List[Dict[str, Any]]:
     Raises:
         Exception: If DynamoDB query fails
     """
-    dynamodb_client, dynamodb_resource = await create_dynamodb_client()
-    try:
+    async with create_dynamodb_client() as dynamodb_client:
         workflows_data = await dynamodb_client.get_all_workflows()
 
         enabled_workflows = [
@@ -45,8 +44,6 @@ async def _load_from_dynamodb(logger) -> List[Dict[str, Any]]:
             f"Loaded {len(enabled_workflows)} enabled workflows from DynamoDB"
         )
         return enabled_workflows
-    finally:
-        await dynamodb_resource.__aexit__(None, None, None)
 
 
 def _load_from_yaml(logger, force_from_disk: bool) -> List[Dict[str, Any]]:

--- a/saxo_order/async_utils.py
+++ b/saxo_order/async_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+from contextlib import asynccontextmanager
 
 import aioboto3
 
@@ -14,12 +15,13 @@ def run_async(func):
     return wrapper
 
 
+@asynccontextmanager
 async def create_dynamodb_client():
     """Create an async DynamoDBClient with managed resource for CLI use."""
     from client.aws_client import DynamoDBClient
 
     session = aioboto3.Session()
-    resource = await session.resource(
+    async with session.resource(
         "dynamodb", region_name="eu-west-1"
-    ).__aenter__()
-    return DynamoDBClient(dynamodb_resource=resource), resource
+    ) as resource:
+        yield DynamoDBClient(dynamodb_resource=resource)

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -378,8 +378,19 @@ async def run_alerting(
     saxo_client = SaxoClient(configuration)
     slack_client = WebClient(token=configuration.slack_token)
 
-    dynamodb_client, dynamodb_resource = await create_dynamodb_client()
+    async with create_dynamodb_client() as dynamodb_client:
+        await _run_alerting_with_client(
+            config, assets, saxo_client, slack_client, dynamodb_client
+        )
 
+
+async def _run_alerting_with_client(
+    config: str,
+    assets: Optional[List[Dict]],
+    saxo_client: SaxoClient,
+    slack_client: WebClient,
+    dynamodb_client,
+) -> None:
     if assets is None:
         # Fetch French stocks from API with fallback to JSON
         try:

--- a/saxo_order/commands/workflow.py
+++ b/saxo_order/commands/workflow.py
@@ -123,8 +123,7 @@ async def execute_workflow(
     saxo_client = SaxoClient(configuration)
     candles_service = CandlesService(saxo_client)
 
-    dynamodb_client, dynamodb_resource = await create_dynamodb_client()
-    try:
+    async with create_dynamodb_client() as dynamodb_client:
         workflows = await load_workflows(force_from_disk)
 
         if select_workflow is True:
@@ -148,5 +147,3 @@ async def execute_workflow(
             dynamodb_client=dynamodb_client,
         )
         await engine.run()
-    finally:
-        await dynamodb_resource.__aexit__(None, None, None)


### PR DESCRIPTION
## Summary
- Converted `create_dynamodb_client()` in `async_utils.py` from a plain async function to an `@asynccontextmanager`, so the underlying aioboto3/aiohttp session is properly closed on exit
- Updated all three callers (`alerting.py`, `workflow.py`, `workflow_loader.py`) to use `async with` instead of manual `__aenter__`/`__aexit__` calls
- Fixes "Unclosed client session" and "Unclosed connector" warnings when running the alerting command

## Test plan
- [x] `pytest -k "alerting or workflow"` — 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)