### PR TITLE
fix: clamp age_hours to prevent negative values

### DIFF
--- a/api/services/alerting_service.py
+++ b/api/services/alerting_service.py
@@ -134,7 +134,7 @@ class AlertingService:
             country_code=alert.country_code,
             date=alert.date,
             data=alert.data,
-            age_hours=int(age.total_seconds() / 3600),
+            age_hours=max(0, int(age.total_seconds() / 3600)),
             tradingview_url=tradingview_url,
         )
 


### PR DESCRIPTION
## Summary
- Clamp `age_hours` to `max(0, ...)` in `alerting_service.py` to prevent negative values when an alert date is slightly in the future due to timezone mismatch
- Fixes 500 Internal Server Error on `/api/alerts` caused by Pydantic `ge=0` validation failing with `age_hours=-1`

## Test plan
- [x] `tests/api/services/test_alerting_service.py` — 9/9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)