### PR TITLE
fix: repair broken tests and mypy duplicate module error

### DIFF
--- a/tests/api/routers/test_order.py
+++ b/tests/api/routers/test_order.py
@@ -1,8 +1,30 @@
+from unittest.mock import MagicMock
+
+import pytest
 from fastapi.testclient import TestClient
 
+from api.dependencies import (
+    get_configuration,
+    get_gsheet_client,
+    get_saxo_client,
+)
 from api.main import app
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_dependencies():
+    """Mock order endpoint dependencies."""
+    mock_saxo = MagicMock()
+    mock_config = MagicMock()
+    mock_gsheet = MagicMock()
+
+    app.dependency_overrides[get_saxo_client] = lambda: mock_saxo
+    app.dependency_overrides[get_configuration] = lambda: mock_config
+    app.dependency_overrides[get_gsheet_client] = lambda: mock_gsheet
+    yield
+    app.dependency_overrides.clear()
 
 
 class TestOrderEndpoint:

--- a/tests/api/routers/test_search.py
+++ b/tests/api/routers/test_search.py
@@ -13,7 +13,7 @@ from utils.exception import SaxoException
 client = TestClient(app)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_saxo_client():
     """Mock SaxoClient for testing."""
     mock_client = MagicMock()
@@ -26,7 +26,7 @@ def mock_saxo_client():
     app.dependency_overrides.clear()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_binance_client():
     """Mock BinanceClient for testing."""
     mock_client = MagicMock()
@@ -37,7 +37,6 @@ def mock_binance_client():
 
     app.dependency_overrides[get_binance_client] = override_get_binance_client
     yield mock_client
-    app.dependency_overrides.clear()
 
 
 class TestSearchEndpoint:


### PR DESCRIPTION
## Summary
- Rename `client/__init_.py` to `client/__init__.py` (missing underscore caused mypy "Source file found twice under different module names" error)
- Add `autouse=True` fixtures in `test_order.py` and `test_search.py` so tests that don't explicitly use mock fixtures still get mocked dependencies (prevents `KeyError: 'binance_api_key'` and `FileNotFoundError: gsheet-creds.json`)

## Test plan
- [x] All 271 tests pass (0 failures, was 12 failures)
- [x] mypy no longer reports duplicate module error
- [x] All pre-commit hooks pass (isort, black, pytest, flake8, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)