### PR TITLE
docs: note docker rebuild requirement after lockfile changes

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,6 +47,14 @@ docker-compose up
 docker-compose up --build
 ```
 
+After changing `package.json` or `package-lock.json`, rebuild the image so the container's `node_modules` matches the lockfile:
+
+```bash
+docker-compose build --no-cache frontend
+```
+
+A stale image will surface as an esbuild host/binary version mismatch (e.g. `Host version "0.25.10" does not match binary version "0.27.7"`) because the platform-specific `@esbuild/*` packages are reinstalled at runtime while the cached top-level `esbuild` lib is not.
+
 The services will be available at:
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:8000


### PR DESCRIPTION
## Summary
- Document that the frontend docker image must be rebuilt with `--no-cache` after `package.json` / `package-lock.json` changes, and explain the esbuild host/binary version mismatch symptom that surfaces when it isn't.

## Test plan
- [ ] Render the updated `frontend/README.md` and confirm the new section reads correctly under "Docker Setup".

🤖 Generated with [Claude Code](https://claude.com/claude-code)