### PR TITLE
docs: backport spec for saxo order reporting feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ Examples:
 - N/A (no persistence changes) (018-candle-builder)
 - Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend — no changes required) + existing — `services/indicator_service.py` (`mobile_average`, `slope_percentage`), `saxo_order/commands/alerting.py` (`run_detection_for_asset`, `_build_candles`), `model.Alert`, `model.AlertType`, `client/aws_client.py` (`DynamoDBClient.store_alerts`), `slack_sdk.WebClient` (019-mm50-slope-alert)
 - AWS DynamoDB `alerts` table (existing, schema unchanged — `data` is a free-form `Dict[str, Any]`, alert_type is appended to the existing alerts list with same-type-same-date dedup) (019-mm50-slope-alert)
+- Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI, Click, `cachetools` (TTLCache), Pydantic v2, Axios, React Router DOM v7+, Vite 7+ (020-saxo-reporting)
+- Google Sheets (persisted trading journal); in-memory `TTLCache` for report fetches (5 min TTL); no database for this feature (020-saxo-reporting)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/specs/020-saxo-reporting/checklists/requirements.md
+++ b/specs/020-saxo-reporting/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Saxo Order Reporting
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Backport spec: feature is already implemented. Stories and requirements were reverse-engineered from `saxo_order/commands/get_report.py`, `api/services/report_service.py`, `api/routers/report.py`, `client/saxo_client.py`, `client/gsheet_client.py`, and `frontend/src/pages/Report.tsx`.
+- Cross-reference: `specs/471-binance-reporting/spec.md` documents the Binance variant that reuses the same UI/API surface; FR-014 makes the Saxo-vs-Binance routing explicit.
+- No `[NEEDS CLARIFICATION]` markers needed — all behavior could be confirmed against the implementation.

--- a/specs/020-saxo-reporting/contracts/report-api.md
+++ b/specs/020-saxo-reporting/contracts/report-api.md
@@ -1,0 +1,156 @@
+# HTTP Contract: `/api/report/*`
+
+**Status**: Retroactive — describes the existing FastAPI routes in `api/routers/report.py`.
+
+All endpoints are authenticated through the same session/cookie mechanism used by the rest of the API. Responses are JSON. Error payloads follow FastAPI's default `{"detail": "..."}` shape with the matching HTTP status code.
+
+Account routing: when the supplied `account_id` starts with `binance_`, the request is delegated to `BinanceReportService` (see `specs/471-binance-reporting`). Otherwise it is delegated to `ReportService` (the Saxo backend documented here).
+
+---
+
+## `GET /api/report/config`
+
+Returns the controlled vocabularies the UI needs to render dropdowns.
+
+**Response 200**
+```json
+{
+  "strategies": ["BREAKOUT", "PULLBACK", "MEAN_REVERSION", "..."],
+  "signals":    ["BULLISH_ENGULFING", "HAMMER", "..."]
+}
+```
+
+---
+
+## `GET /api/report/orders`
+
+Fetch the list of executed orders for an account over a period, with EUR conversion applied.
+
+**Query**
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `account_id` | string | yes | Saxo account key, or `binance_*` pseudo-id |
+| `from_date` | string (`YYYY/MM/DD` or `YYYY-MM-DD`) | yes | Inclusive start date |
+
+**Response 200**
+```json
+{
+  "orders": [
+    {
+      "code": "AIR:xpar",
+      "name": "Airbus SE",
+      "direction": "BUY",
+      "quantity": 10.0,
+      "price": 145.32,
+      "price_eur": 145.32,
+      "total": 1453.2,
+      "total_eur": 1453.2,
+      "currency": "EURO",
+      "date": "2025-04-15T09:32:11",
+      "asset_type": "STOCK",
+      "underlying_price": null
+    }
+  ],
+  "total_count": 1,
+  "from_date": "2025-04-01"
+}
+```
+
+**Errors**
+- `400` invalid date format
+- `404` account not found on the user's profile
+- `502` broker API failure
+
+Caching: results are cached server-side for 5 minutes keyed by `(account_id, from_date)`.
+
+---
+
+## `GET /api/report/summary`
+
+Aggregated statistics for the same period as `/orders`.
+
+**Query**: same as `/orders`.
+
+**Response 200**
+```json
+{
+  "total_orders": 12,
+  "total_volume_eur": 38421.55,
+  "total_fees_eur": 86.40,
+  "buy_count": 7,
+  "sell_count": 5,
+  "buy_volume_eur": 22890.10,
+  "sell_volume_eur": 15531.45
+}
+```
+
+---
+
+## `POST /api/report/gsheet/create`
+
+Create a new position row in the Google Sheets journal.
+
+**Body**
+```json
+{
+  "account_id": "12345678",
+  "order": { /* ReportOrder-shaped payload as returned by /orders */ },
+  "stop": 140.00,
+  "objective": 160.00,
+  "strategy": "BREAKOUT",
+  "signal": "BULLISH_ENGULFING",
+  "comment": "Daily breakout after 3w consolidation"
+}
+```
+
+**Response 200**
+```json
+{ "status": "ok", "message": "Order added to gsheet" }
+```
+
+**Errors**
+- `400` missing/invalid `strategy` or `signal`, or unknown enum value
+- `502` Google Sheets API failure
+- `409` not used — duplicate rows are allowed (the user is responsible for selecting which row to update)
+
+---
+
+## `POST /api/report/gsheet/update`
+
+Update an existing journal row — either to adjust risk fields while the position is open, or to record its closure.
+
+**Body**
+```json
+{
+  "account_id": "12345678",
+  "order": { /* ReportOrder payload */ },
+  "line_number": 42,
+  "close": true,
+  "stopped": false,
+  "be_stopped": true,
+  "stop": null,
+  "objective": null,
+  "strategy": null,
+  "signal": null,
+  "comment": null
+}
+```
+
+- When `close == false`: `stop` and/or `objective` may be supplied to adjust the open position. `stopped` / `be_stopped` must be `false`.
+- When `close == true`: at most one of `stopped` / `be_stopped` should be `true`. The closing price is taken from `order.price`; closing taxes are computed for stocks only.
+
+**Response 200**
+```json
+{ "status": "ok", "message": "Order updated in gsheet" }
+```
+
+**Errors**
+- `400` invalid combination (e.g. both `stopped` and `be_stopped` true, or close-flags set while `close == false`)
+- `404` `line_number` does not exist in the sheet
+- `502` Google Sheets API failure
+
+---
+
+## Account selection
+
+Account discovery is **not** part of this contract — the frontend obtains the account list (Saxo accounts + Binance pseudo-account) from `GET /api/fund/accounts` and passes the chosen `account_id` to the endpoints above.

--- a/specs/020-saxo-reporting/data-model.md
+++ b/specs/020-saxo-reporting/data-model.md
@@ -1,0 +1,143 @@
+# Phase 1 Data Model: Saxo Order Reporting
+
+**Status**: Retroactive — entities reflect what is already in `model/`, `api/models/report.py`, and the Google Sheets layout.
+
+This feature reads orders from Saxo, derives an EUR view, summarises the period, and writes selected entries to Google Sheets. There is **no new persistent storage** introduced by this feature; the entities below describe the in-memory and Sheet-resident shapes.
+
+---
+
+## Domain entities (`model/`)
+
+### `Order` (`model/__init__.py`)
+
+The base order shape used across the codebase.
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | `str` | Asset code / symbol |
+| `name` | `str` | Human-readable asset name |
+| `direction` | `Direction` enum | `BUY` / `SELL` |
+| `quantity` | `float` | Order size |
+| `price` | `float` | Execution price (original currency) |
+| `currency` | `Currency` enum | `EURO`, `USD`, `JPY`, ... |
+| `asset_type` | `AssetType` enum | `STOCK`, `CFD`, `WARRANT`, `CRYPTO`, ... |
+| `stop` | `Optional[float]` | Stop-loss; populated when journaling |
+| `objective` | `Optional[float]` | Target price; populated when journaling |
+| `strategy` | `Optional[Strategy]` | Required at journal-creation |
+| `signal` | `Optional[Signal]` | Required at journal-creation |
+| `comment` | `Optional[str]` | Free-text note |
+| `underlying` | `Optional[UnderlyingOrder]` | For derivatives — underlying price/asset |
+| `taxes` | `Optional[Taxes]` | Computed at journal time for stocks |
+
+### `ReportOrder(Order)` (`model/__init__.py`)
+
+Adds lifecycle fields needed for journaling.
+
+| Field | Type | Notes |
+|---|---|---|
+| `date` | `datetime` | Execution date returned by Saxo |
+| `open_position` | `bool` | `True` when the order opens a new position |
+| `stopped` | `bool` | Position closed by stop-loss |
+| `be_stopped` | `bool` | Position closed at break-even |
+
+### `Account` (`model/__init__.py`, dataclass)
+
+| Field | Type | Notes |
+|---|---|---|
+| `key` | `str` | Saxo account key (or `binance_main` for Binance) |
+| `name` | `str` | Display name |
+| `fund` | `float` | Total balance |
+| `available_fund` | `float` | Free balance |
+| `client_key` | `str` | Saxo client key (empty for pseudo-accounts) |
+
+> The API exposes its own `AccountInfo` Pydantic model — clients never see the dataclass directly.
+
+### `Taxes` (`model/__init__.py`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `cost` | `float` | Broker commission (`max(2, total * 0.0008)` for stocks) |
+| `taxes` | `float` | Regulatory tax (`0.004 * total` for stocks; `0` for non-stocks) |
+
+### `UnderlyingOrder` (`model/__init__.py`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | `str` | Underlying asset code |
+| `price` | `float` | Underlying price at execution (EUR) |
+
+---
+
+## Controlled vocabularies (`model/enum.py`)
+
+| Enum | Purpose | Representative values |
+|---|---|---|
+| `Strategy` | Why the trader entered the trade | breakout, pullback, mean-reversion, ... (~37 members) |
+| `Signal` | Signal type that triggered the trade | bullish engulfing, hammer, ... (~19 members) |
+| `Currency` | Order currency | `EURO`, `USD`, `JPY` |
+| `Direction` | Order direction | `BUY`, `SELL` |
+| `AssetType` | Class of instrument | `STOCK`, `CFD`, `WARRANT`, `CRYPTO`, ... |
+
+`Strategy` and `Signal` are surfaced to the UI via `GET /api/report/config` so dropdowns stay in sync with backend validation.
+
+---
+
+## API surface models (`api/models/report.py`)
+
+These are Pydantic v2 models — the serialisation contract between FastAPI and the React client.
+
+| Model | Role |
+|---|---|
+| `ReportOrderResponse` | Single order projected for the UI: `code`, `name`, `direction`, `quantity`, `price`, `price_eur`, `total`, `total_eur`, `currency`, `date`, `asset_type`, optional `underlying_price` |
+| `ReportListResponse` | `{ orders: List[ReportOrderResponse], total_count: int, from_date: str }` |
+| `ReportSummaryResponse` | Aggregates — `total_orders`, `total_volume_eur`, `total_fees_eur`, `buy_count`, `sell_count`, `buy_volume_eur`, `sell_volume_eur` |
+| `CreateGSheetOrderRequest` | Create-journal payload: `account_id`, `order` (raw), `stop`, `objective`, `strategy`, `signal`, optional `comment` |
+| `UpdateGSheetOrderRequest` | Update-journal payload: `account_id`, `order`, `line_number`, `close: bool`, `stopped: bool`, `be_stopped: bool`, optional `stop`/`objective`/`strategy`/`signal`/`comment` |
+
+`Strategy` and `Signal` values arrive as strings on the wire and are parsed back into the enums by the request models, with explicit validation errors on unknown values.
+
+---
+
+## External entity — Google Sheets journal row
+
+Each persisted position is one row in the trader's spreadsheet. The exact column ranges live in `client/gsheet_client.py`; the logical layout is:
+
+| Group | Fields | Filled by |
+|---|---|---|
+| Identity | Asset code, asset name, type (CASH / CFD / WARRANT / CRYPTO), direction (BUY/SELL) | Create |
+| Entry | Date, quantity, entry price (original), entry price (EUR) | Create |
+| Risk | Strategy, signal, comment, stop, objective | Create |
+| Cost | Broker cost, regulatory taxes (stocks only) | Create / Update on close |
+| Closure | Stopped flag, BE-stopped flag, close date, close price | Update on close |
+| Computed | Risk/reward, P&L formulas | Sheet formulas |
+
+The feature appends (create) and batch-updates (update) cells; it never deletes rows.
+
+---
+
+## State transitions
+
+A trade flows through these states from the journal's point of view:
+
+```
+(no entry)  ──create──▶  Open
+   Open     ──adjust──▶  Open       (stop / objective / strategy / signal updates)
+   Open     ──close───▶  Closed     (writes closing price + stopped/BE-stopped flags)
+```
+
+- `create` requires `strategy` and `signal`.
+- `adjust` modifies a subset of risk fields without affecting closure state.
+- `close` is one-way; reopening a closed position would require a new row.
+
+---
+
+## Caching shape (in-memory)
+
+`ReportService` keeps two caches via `cachetools.TTLCache`:
+
+| Cache | Key | Value | TTL |
+|---|---|---|---|
+| `_report_cache` | `(account_id, from_date)` | `List[ReportOrder]` | 300 s |
+| `_account_cache` | `account_identifier` | `Account` | 300 s |
+
+The frontend has no knowledge of the cache — staleness is bounded by the TTL.

--- a/specs/020-saxo-reporting/plan.md
+++ b/specs/020-saxo-reporting/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Saxo Order Reporting
+
+**Branch**: `020-saxo-reporting` | **Date**: 2026-05-31 (retroactive documentation) | **Spec**: [spec.md](./spec.md)
+**Input**: Reverse-engineered from the existing CLI command, API router, service, client integrations, and React page
+
+## Summary
+
+Expose the trader's executed Saxo orders for a chosen period through two equivalent surfaces — an interactive Click CLI and a FastAPI + React web UI — and let the trader create or update positions in a Google Sheets trading journal with risk-management metadata (stop, objective, strategy, signal, comment, closure flags).
+
+The implementation introduces a single `ReportService` in the API layer that orchestrates `SaxoClient`, `GSheetClient`, and currency/tax helpers. The same service is reused by the API router for HTTP traffic and (later, in the Binance backport) became the template that `BinanceReportService` mirrored. The frontend is platform-agnostic and selects the backend via an `account_id` (Saxo account key, or the `binance_*` pseudo-account). The CLI command (`k-order get-report`) predates the API and remains as a power-user surface; it shares the underlying `SaxoClient.get_report` and `GSheetClient` integrations.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend)
+**Primary Dependencies**: FastAPI, Click, `cachetools` (TTLCache), Pydantic v2, Axios, React Router DOM v7+, Vite 7+
+**Storage**: Google Sheets (persisted trading journal); in-memory `TTLCache` for report fetches (5 min TTL); no database for this feature
+**Testing**: `pytest` with `unittest.mock` for backend; no frontend test framework yet (per constitution §Testing Standards)
+**Target Platform**: Web app (React SPA + FastAPI behind uvicorn locally / Lambda in production) + CLI tool (`k-order`)
+**Project Type**: Full-stack web application + CLI (matches Option 2 from the template)
+**Performance Goals**: <3 s for a typical month of orders on first fetch; <500 ms on cache hits; aggregated summary recomputed inline from the order list
+**Constraints**: CLI must remain functional and produce equivalent results to the UI; Google Sheets writes are append/update only (no delete); regulatory taxes apply to stocks only; conversion rates come from configuration
+**Scale/Scope**: Single-trader use; up to ~hundreds of orders per period; one trading journal (single spreadsheet); two brokers covered by the shared report surface (Saxo here, Binance in spec 471)
+
+## Constitution Check
+
+*GATE: Passes for both Phase 0 and post-Phase 1 design.*
+
+✅ **I. Layered Architecture Discipline**:
+- CLI (`saxo_order/commands/get_report.py`) → orchestrates `SaxoClient` + `GSheetClient` + helpers; no business logic.
+- API router (`api/routers/report.py`) → thin orchestration of `ReportService`.
+- Service (`api/services/report_service.py`) → owns business logic (period fetch, EUR conversion, summary, journal writes); receives clients via constructor (DI).
+- Clients (`client/saxo_client.py`, `client/gsheet_client.py`) → external integrations only; return domain models (`ReportOrder`, `Order`).
+- Models (`model/__init__.py`, `model/enum.py`) → no external dependencies; `Strategy` / `Signal` / `Currency` / `Direction` / `AssetType` are enums.
+- Frontend: `Report.tsx` (page) → `reportService` in `frontend/src/services/api.ts` for all HTTP calls. `OrderModal` is a sub-component receiving data via props.
+
+✅ **II. Clean Code First**:
+- Self-documenting Click options and Pydantic fields.
+- Enum-driven (`Strategy`, `Signal`, `Currency`, `Direction`, `AssetType`).
+- No inline `// what this does` comments in the affected files.
+
+✅ **III. Configuration-Driven Design**:
+- Currency conversion rates, Google Sheets credentials path, spreadsheet id, and Saxo credentials all come from `config.yml` / `secrets.yml` via `Configuration`.
+- Frontend uses `import.meta.env.VITE_API_URL` (no hardcoded API URL).
+
+✅ **IV. Safe Deployment Practices**:
+- Conventional commits (this feature is delivered as `docs:` because the code already shipped).
+- Backend deploys via the standard Lambda/ECR/Pulumi pipeline; no infra change required for this feature.
+
+✅ **V. Domain Model Integrity**:
+- `ReportOrder` extends `Order` with journaling fields; both live in `model/`.
+- `Account` is a dataclass in `model/__init__.py` (not a Pydantic model leak across the API boundary — the API exposes its own `AccountInfo`).
+- Account routing is prefix-based (`binance_*` → Binance, otherwise Saxo); does NOT infer broker from `country_code` (matches the constitution's explicit prohibition).
+
+✅ **No constitution violations identified.** "Complexity Tracking" therefore has nothing to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-saxo-reporting/
+├── spec.md                      # User stories & requirements (already written)
+├── plan.md                      # This file
+├── research.md                  # Phase 0: architectural decisions (retroactive)
+├── data-model.md                # Phase 1: entities & relationships (retroactive)
+├── quickstart.md                # Phase 1: how to exercise the feature locally
+├── contracts/
+│   └── report-api.md            # Phase 1: HTTP endpoints & payload shapes
+└── checklists/
+    └── requirements.md          # Already written
+```
+
+### Source Code (already implemented in the repo)
+
+```text
+# Backend
+api/
+├── routers/report.py                       # FastAPI routes (5 endpoints)
+├── services/report_service.py              # ReportService — business logic
+├── models/report.py                        # Pydantic request/response models
+└── dependencies.py                         # get_saxo_client / get_binance_client / get_configuration
+
+client/
+├── saxo_client.py                          # get_report(account, from_date) -> List[ReportOrder]
+└── gsheet_client.py                        # create_order / update_order
+
+saxo_order/
+├── commands/get_report.py                  # Click CLI: k-order get-report
+└── service.py                              # calculate_currency / calculate_taxes (shared helpers)
+
+model/
+├── __init__.py                             # Order, ReportOrder, Account (dataclass), Taxes
+└── enum.py                                 # Strategy, Signal, Currency, Direction, AssetType
+
+# Frontend
+frontend/src/
+├── pages/Report.tsx                        # Report page + OrderModal sub-component
+├── services/api.ts                         # reportService + reportConfigService
+└── (styles colocated, e.g. Report.css)
+
+# Tests
+tests/
+└── client/test_gsheet_client.py            # GSheet client unit tests
+# Note: no dedicated tests for ReportService (Saxo side) — the Binance variant
+#       in spec 471 added 12 tests for BinanceReportService; an equivalent suite
+#       for ReportService is a follow-up.
+```
+
+**Structure Decision**: Full-stack web application + CLI tool. The web stack mirrors the layered architecture mandated by the constitution; the CLI sits beside `api/` and shares clients and helpers but does NOT depend on FastAPI. The frontend is generic — it talks to `account_id` rather than to a "Saxo report" endpoint — which is what later allowed Binance to be added without frontend changes (see `specs/471-binance-reporting`).
+
+## Phase 0 — Research (retroactive)
+
+The detailed decision log lives in [research.md](./research.md). Headline decisions:
+
+1. **Single report endpoint with prefix-based account routing.** Saxo account keys go to `ReportService`; `binance_*` ids go to `BinanceReportService` (added later). One frontend, one URL space.
+2. **`ReportService` as the seam between CLI and API.** Business logic (period fetch, EUR conversion, summary, journal writes) lives in one class; the CLI uses the same client and helpers, the API delegates to the service.
+3. **5-minute TTL cache on report fetches** via `cachetools.TTLCache`, keyed by `(account_id, from_date)`. Trading-journal use does not need real-time freshness.
+4. **Conversion rates are configuration-driven, not live.** Acceptable because the journal records entry/exit prices, not mark-to-market.
+5. **Strategy/Signal are enums shipped via `/api/report/config`** so the UI picks from a controlled vocabulary instead of free-text input.
+6. **Google Sheets row targeting is manual.** The user supplies the row number; the system never auto-matches an order to an existing journal row.
+
+## Phase 1 — Design Artefacts (retroactive)
+
+- [data-model.md](./data-model.md) — entities: `ReportOrder`, `Order`, `Account`, `Taxes`, controlled vocabularies (`Strategy`, `Signal`, `Currency`, `Direction`, `AssetType`), and the Google Sheets journal row layout.
+- [contracts/report-api.md](./contracts/report-api.md) — HTTP contract for `/api/report/*`: `GET /config`, `GET /orders`, `GET /summary`, `POST /gsheet/create`, `POST /gsheet/update`.
+- [quickstart.md](./quickstart.md) — how to run the CLI and the UI flow end-to-end, plus the smoke-test checklist.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.
+
+Noteworthy design choices that *avoided* complexity:
+
+| Decision | Rationale | Simpler Alternative Rejected Because |
+|----------|-----------|--------------------------------------|
+| Prefix-based account routing in the API | Single endpoint set covers all brokers | Per-broker URL space (`/api/saxo-report/*`) would force frontend changes for every new broker |
+| Manual row-number for journal updates | The user already knows which row maps to which trade; auto-match would need a second source of truth | Auto-detection of the journal row via heuristics would silently overwrite the wrong row when ambiguous |
+| In-memory `TTLCache` instead of a database for report results | Reports are derived data, not state; staleness is bounded by TTL | A persistent cache would add infra cost and migrations for no user-visible benefit |
+| `ReportOrder` as a subtype of `Order` rather than a new model | Journaling fields (`stopped`, `be_stopped`, `open_position`) are additive | A separate `JournalEntry` model would duplicate every order field and force conversions at every boundary |
+| Strategy/Signal as enums served by `/api/report/config` | Single source of truth for the UI dropdowns; values change in one place | Hardcoding the lists in the frontend would drift from the backend's validation |
+
+## Retroactive Verification Notes
+
+- **Behaviour parity CLI ↔ UI**: both call `SaxoClient.get_report` and write through `GSheetClient`; the CLI prompts interactively whereas the UI uses the `OrderModal` form. Same outputs for identical inputs.
+- **CORS**: `api/main.py` allows `localhost:3000` and `localhost:5173` per the constitution.
+- **Open follow-up**: no dedicated `tests/api/services/test_report_service.py` yet — the Binance variant added 12 tests in `tests/api/services/test_binance_report_service.py`; an equivalent suite for the Saxo service is a sensible next step but is out of scope for this retro-documentation effort.

--- a/specs/020-saxo-reporting/quickstart.md
+++ b/specs/020-saxo-reporting/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart: Saxo Order Reporting
+
+How to exercise the existing Saxo reporting feature end-to-end, from both the CLI and the web UI. Useful as a smoke-test checklist after touching `ReportService`, `SaxoClient.get_report`, `GSheetClient`, or the React `Report.tsx` page.
+
+## Prerequisites
+
+- Working `config.yml` with Saxo credentials, Google Sheets credentials path, spreadsheet id, and `currencies_rate`.
+- A Saxo account with at least one executed order in the chosen window.
+- Access to the target Google Sheets journal.
+
+```bash
+poetry install                  # backend deps
+cd frontend && npm install      # frontend deps
+```
+
+## CLI flow
+
+Run the report from a terminal:
+
+```bash
+poetry run k-order get-report --from-date 2025/04/01 --update-gsheet true
+```
+
+You should see:
+
+1. An account selection prompt (skipped when a single Saxo account exists).
+2. A numbered list of executed orders since the start date, with prices shown in original currency and EUR for non-EUR orders.
+3. Per-row interactive prompts to either **create** a new journal row (asks for stop / objective / strategy / signal / comment) or **update** an existing row (asks for the row number and whether the position is being closed, stopped, or BE-stopped).
+
+Smoke-test sequence:
+
+- [ ] Run with an empty period → "No order to report" then exits cleanly.
+- [ ] Create one row in Google Sheets → row appears at the bottom of the sheet with all mandatory fields populated.
+- [ ] Update the row's stop/objective → only that row changes.
+- [ ] Update the row as closed with `stopped=true` → closure cells populated, taxes computed (if the asset is a stock).
+
+## Web UI flow
+
+Start the backend and frontend in two terminals:
+
+```bash
+poetry run python run_api.py    # http://localhost:8000
+cd frontend && npm run dev      # http://localhost:5173
+```
+
+Then in the browser:
+
+1. Open the **Report** page from the sidebar.
+2. Select the Saxo account in the dropdown (Binance is also listed but routes to the Binance service — out of scope here).
+3. Enter the start date and load.
+4. Confirm the summary cards (`total_orders`, `total_volume_eur`, `total_fees_eur`, buy/sell breakdown) match the per-row data.
+5. Click **Manage** on an order to open the `OrderModal`:
+   - **Open position**: fill stop / objective / strategy / signal, optionally a comment, save. A new row appears in Google Sheets.
+   - **Update / Close**: enter the existing row number, either adjust the stop/objective or tick `stopped` / `be_stopped` to close.
+6. Reload the page → results come back instantly (cache hit), and remain consistent for ~5 minutes.
+
+Smoke-test checklist:
+
+- [ ] Account selector lists all Saxo accounts from the user's profile.
+- [ ] EUR conversion matches `config.yml` rates within ±0.01 EUR.
+- [ ] Summary totals reconcile with the table rows.
+- [ ] Create / update / close flows each succeed against Google Sheets.
+- [ ] Reloading within 5 minutes returns results in <500 ms (cache hit).
+
+## CLI ↔ UI parity check
+
+Run both surfaces against the same account and start date:
+
+| Check | Expected |
+|---|---|
+| Same number of orders listed | Identical |
+| Same per-order EUR prices | Identical |
+| Same summary totals | Identical |
+| Same row layout after create | Identical |
+
+Any divergence is a bug — both surfaces share `SaxoClient.get_report`, `calculate_currency`, `calculate_taxes`, and `GSheetClient`.
+
+## Troubleshooting
+
+- **"Account not found"**: the supplied `account_id` is not on the Saxo profile that the API is authenticated against. Re-run the OAuth flow.
+- **Empty orders list with non-empty period**: check the date format (`YYYY/MM/DD` for the CLI; the API also accepts `YYYY-MM-DD`).
+- **EUR conversion off / missing**: confirm `currencies_rate` exists for the order's currency in `config.yml`.
+- **Google Sheets write failure**: check `gsheet_creds_path` and that the sheet is shared with the service account.
+- **Stale results in the UI**: TTL cache is 5 minutes; reload after waiting, or restart the API for an immediate refresh.

--- a/specs/020-saxo-reporting/research.md
+++ b/specs/020-saxo-reporting/research.md
@@ -1,0 +1,80 @@
+# Phase 0 Research: Saxo Order Reporting
+
+**Status**: Retroactive — decisions documented from the existing implementation.
+
+This file captures the design decisions that shaped the Saxo reporting feature. There were no open `[NEEDS CLARIFICATION]` markers in the spec, so the research below is a reverse-engineered decision log rather than a forward investigation.
+
+---
+
+## Decision 1 — Where business logic lives: a dedicated `ReportService`
+
+- **Decision**: Put period fetch, EUR conversion, summary aggregation, and Google Sheets journal writes in a single `ReportService` in `api/services/report_service.py`. The API router stays thin; the CLI calls the same underlying client + helper functions.
+- **Rationale**: The constitution forbids business logic in the CLI and the router layers. Centralising the orchestration in a service keeps the CLI and API equivalent and makes the later Binance backport straightforward (`BinanceReportService` mirrors the same shape).
+- **Alternatives considered**:
+  - *Logic in the router.* Rejected — violates §I Layered Architecture Discipline.
+  - *Logic in the CLI, called by the router.* Rejected — pulls the API into a Click-shaped surface and makes testing awkward.
+  - *Logic in `client/saxo_client.py`.* Rejected — clients must not contain business logic per the constitution.
+
+## Decision 2 — Single report endpoint with prefix-based account routing
+
+- **Decision**: One set of endpoints (`/api/report/*`) handles all brokers. The router inspects `account_id`: if it starts with `binance_`, delegate to `BinanceReportService`; otherwise delegate to `ReportService` (Saxo).
+- **Rationale**: The frontend's `OrderModal` and orders table are platform-agnostic — they only need `account_id` + `from_date`. Per-broker URL spaces would force frontend changes every time a new broker is added.
+- **Alternatives considered**:
+  - *Separate `/api/saxo-report/*` and `/api/binance-report/*` routers.* Rejected — duplicate code, frontend churn.
+  - *Detect broker from asset metadata (e.g. `country_code`).* Rejected — explicitly forbidden by §V (a Saxo asset can lack `country_code`).
+
+## Decision 3 — 5-minute TTL cache on report fetches
+
+- **Decision**: `ReportService` wraps `get_orders_report` and `_find_account` with `cachetools.TTLCache(maxsize=128, ttl=300)` via `@cachedmethod`.
+- **Rationale**: A trader reviewing their journal does not need second-by-second freshness; Saxo's audit endpoint is slow and rate-limited. Five minutes balances responsiveness with cost.
+- **Alternatives considered**:
+  - *No cache.* Rejected — every UI re-render would hit the broker API.
+  - *Longer TTL (e.g. 1 h).* Rejected — surprises the user when an order they just executed isn't visible.
+  - *Persistent cache (DynamoDB).* Rejected — adds infra for no user-visible benefit; reports are derived data.
+
+## Decision 4 — Configuration-driven currency conversion
+
+- **Decision**: USD→EUR and JPY→EUR rates live in `config.yml` under `currencies_rate` and are applied by `calculate_currency(order, currencies_rate)` in `saxo_order/service.py`.
+- **Rationale**: The journal records prices at the time of trade; live FX would distort the record. Configuration centralises the rate so it can be refreshed out-of-band by the trader.
+- **Alternatives considered**:
+  - *Live FX from a provider.* Rejected — adds a dependency and changes journal semantics from "trade-time price" to "mark-to-market".
+  - *Per-order rate from the broker.* Rejected — Saxo does not consistently return a conversion rate per order.
+
+## Decision 5 — `Strategy` / `Signal` are enums delivered to the UI via `/api/report/config`
+
+- **Decision**: The backend ships the list of valid strategies and signals through `GET /api/report/config`. The frontend renders them as dropdowns.
+- **Rationale**: Trade journaling discipline depends on a controlled vocabulary. Letting the user type free-text would let typos accumulate in the journal and break post-trade analysis grouped by strategy.
+- **Alternatives considered**:
+  - *Hardcode in the frontend.* Rejected — drifts from backend validation; the backend rejects unknown values.
+  - *Open free-text field.* Rejected — defeats the purpose of journaling.
+
+## Decision 6 — Manual journal row targeting on updates
+
+- **Decision**: When updating a row in Google Sheets, the user supplies the row number. The service never tries to find the row for an order.
+- **Rationale**: There is no stable order↔row mapping (the trader may journal an order more than once, or skip orders). Auto-matching would risk silently overwriting the wrong row.
+- **Alternatives considered**:
+  - *Auto-match by asset + date.* Rejected — ambiguous when the trader has multiple positions on the same asset.
+  - *Maintain a side map of order→row.* Rejected — duplicates Google Sheets as the source of truth.
+
+## Decision 7 — Regulatory taxes only for stocks
+
+- **Decision**: `calculate_taxes(order)` returns `Taxes(cost, taxes)` for stocks (cost = `max(2, total * 0.0008)`, taxes = `0.004 * total`); for other asset types, the journal row has no tax line.
+- **Rationale**: Matches the trader's actual tax exposure (French regulatory tax on stock trades). Derivatives and crypto are treated under a different regime not in scope here.
+- **Alternatives considered**:
+  - *Tax all asset types uniformly.* Rejected — would falsify the journal.
+  - *Per-instrument tax rules via config.* Deferred — useful if the trader's regime changes; not needed for current scope.
+
+## Decision 8 — CLI predates the API and stays
+
+- **Decision**: Keep the Click command (`k-order get-report`) functional. It shares `SaxoClient` and `GSheetClient` with the API; the UI flow does not replace it.
+- **Rationale**: Existing trader workflows depend on the CLI; deprecating it would break personal scripts. Keeping it also serves as a backstop when the UI is unavailable.
+- **Alternatives considered**:
+  - *Remove the CLI.* Rejected — breaks existing workflows.
+  - *Re-implement the CLI on top of HTTP.* Rejected — adds a network hop for no benefit on the trader's workstation.
+
+---
+
+## Open Items (follow-ups, not blocking)
+
+- No `tests/api/services/test_report_service.py` exists yet. The Binance variant added 12 unit tests as a template; an equivalent Saxo suite is the obvious next step.
+- The CLI's interactive update flow and the UI's `OrderModal` have diverged in micro-details (prompt wording, default values). Reconciling them would tighten parity but is cosmetic.

--- a/specs/020-saxo-reporting/spec.md
+++ b/specs/020-saxo-reporting/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Saxo Order Reporting
+
+**Feature Branch**: `020-saxo-reporting`
+**Created**: 2026-05-31 (retroactive documentation)
+**Status**: Implemented
+**Input**: User description: "we need a retro spec about the saxo reporting feature, (backend + UI)"
+
+## Overview
+
+The Saxo reporting feature lets a trader review the orders that were executed on a Saxo Bank account over a chosen period and selectively persist the resulting positions to a Google Sheets trading journal with risk-management metadata (stop loss, objective, strategy, signal). It is exposed both as an interactive CLI (`k-order get-report`) and as a web UI backed by an HTTP API, and is the original implementation later generalized to support Binance (see `specs/471-binance-reporting/spec.md`).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Review executed Saxo orders for a period (Priority: P1)
+
+As a trader, I want to list every order that was filled on one of my Saxo accounts since a chosen start date so I can audit my recent trading activity in a single view, with prices expressed in both the original currency and EUR.
+
+**Why this priority**: Without this list, the trader has no consolidated view of what was filled on Saxo and cannot reconcile the broker's activity with the trading journal. Every downstream action (journaling, P&L analysis, position management) depends on it.
+
+**Independent Test**: Pick a Saxo account, enter a start date, and verify that all orders filled since that date are listed with date, asset, direction, quantity, price, and EUR conversion. Aggregated counters (total orders, buy/sell volume, fees) match the row-level data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Saxo account with executed orders since 2025-01-01, **When** the trader requests the report from 2025-01-01, **Then** every executed order is listed in chronological order with date, name, direction, quantity, and execution price.
+2. **Given** an order executed in a non-EUR currency (e.g. USD, JPY), **When** the report is displayed, **Then** the price and total are shown both in original currency and converted to EUR using the configured exchange rate.
+3. **Given** a warrant/turbo order with an underlying asset, **When** the report is displayed, **Then** the underlying asset's price at execution is also shown.
+4. **Given** an account with no executed orders in the period, **When** the trader requests the report, **Then** an explicit "no orders" message is shown instead of an empty table.
+5. **Given** multiple Saxo accounts on the user's profile, **When** the trader opens the report, **Then** they can choose which account to report on before fetching the orders.
+
+---
+
+### User Story 2 - Journal a new position to Google Sheets (Priority: P1)
+
+As a trader, after reviewing an opening order in the report, I want to save it as a new position in my Google Sheets trading journal with my stop loss, objective, strategy, and signal so my journal stays in sync with what I actually traded and my risk management is captured at the moment of entry.
+
+**Why this priority**: Capturing entries with stop and objective is the core of the trader's journaling discipline. Without it the report is read-only and the journal must be updated by hand, which is error-prone and skipped under pressure.
+
+**Independent Test**: From a populated report, pick an opening order, enter stop / objective / strategy / signal (and optional comment), confirm; verify a new row appears in the configured Google Sheets with the order data and the risk-management fields populated, prices shown in both original currency and EUR, and computed risk/reward.
+
+**Acceptance Scenarios**:
+
+1. **Given** an opening order in the report, **When** the trader opens the "create" flow and enters stop, objective, strategy, and signal, **Then** a new row is appended to the Google Sheets journal with the order's date, asset, direction, quantity, prices (original + EUR), strategy, signal, stop, objective, and the computed risk/reward.
+2. **Given** the create flow, **When** the trader omits strategy or signal, **Then** the journal entry is rejected with a validation error and no row is written.
+3. **Given** an order in a currency other than EUR, **When** the journal entry is created, **Then** both the original currency price and the EUR-converted price are persisted on the row.
+4. **Given** the order belongs to a stock (not a derivative/crypto), **When** the journal entry is created, **Then** the row includes the regulatory taxes computed from the order's total amount.
+
+---
+
+### User Story 3 - Update an existing journaled position (Priority: P2)
+
+As a trader, I want to update a position that is already in my Google Sheets journal — either to adjust the stop/objective while the position is still open, or to mark it as closed (and indicate whether it was stopped or break-even-stopped) — so the journal reflects the lifecycle of each trade without manual sheet editing.
+
+**Why this priority**: Tracking lifecycle events is essential for accurate P&L and post-trade analysis, but it is less critical than the initial journaling: a missed update degrades historical analytics, while a missed entry loses the trade entirely.
+
+**Independent Test**: From the report, select an order corresponding to an already-journaled position, point at the row in the sheet, choose "adjust" or "close"; verify the targeted row is updated with the new stop/objective or with the closure flags and computed taxes, and that no other row is affected.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open position already in the journal, **When** the trader adjusts the stop and/or objective for a given row, **Then** only that row's stop, objective, and dependent computed fields (e.g. risk/reward) are updated.
+2. **Given** a closing order in the report, **When** the trader marks the corresponding journal row as closed, **Then** the row is updated with the closing price, closing date, the "stopped" / "BE-stopped" flags, and the computed taxes.
+3. **Given** a closing update on a stock, **When** it is persisted, **Then** the regulatory taxes for the closing leg are computed and written to the journal.
+4. **Given** the trader targets a wrong row number, **When** the update is submitted, **Then** the system updates only the targeted row (no implicit row search) — selecting the correct row remains the trader's responsibility.
+
+---
+
+### User Story 4 - Aggregated summary of the period (Priority: P3)
+
+As a trader, while reviewing the report I want to see aggregated statistics for the period (total number of orders, buy vs sell breakdown, total volume in EUR, total fees) so I can get a quick sense of activity without scanning every row.
+
+**Why this priority**: The summary is decision-support: useful but not blocking. The detailed list already covers the audit need.
+
+**Independent Test**: Load a report with a known mix of buys and sells in mixed currencies; verify the summary shows the correct counts, the buy/sell volume split, and a total EUR amount consistent with the per-row EUR conversions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a non-empty report, **When** it is displayed in the UI, **Then** summary cards show total orders, total volume in EUR, total fees, and a buy/sell breakdown.
+2. **Given** orders in multiple currencies, **When** the summary is computed, **Then** all monetary aggregates are expressed in EUR using the configured conversion rates.
+
+---
+
+### User Story 5 - CLI parity for power users (Priority: P3)
+
+As a power user / script author, I want the same reporting and journaling capabilities available from a CLI command so I can run the workflow from a terminal and keep my pre-existing scripts working.
+
+**Why this priority**: The CLI predates the UI and remains the source of truth for the underlying behavior; preserving it keeps existing workflows intact, but day-to-day use is shifting to the UI.
+
+**Independent Test**: Run the CLI command with a start date, select an account interactively, view the printed orders, optionally answer the interactive prompts to create or update Google Sheets rows; verify the resulting sheet matches what the UI would produce.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI command is invoked with a start date, **When** the user selects a Saxo account, **Then** the executed orders since that date are printed with the same fields and EUR conversion as the UI.
+2. **Given** the CLI is run with the gsheet-update flag, **When** the user picks an order row and chooses "create", **Then** a new journal row is appended exactly as it would be from the UI flow.
+3. **Given** the CLI is run with the gsheet-update flag, **When** the user picks an order row and chooses "update", **Then** they can either adjust the stop/objective or mark the position closed (with stopped / BE-stopped flags), with the same outcome as the UI.
+
+---
+
+### Edge Cases
+
+- **Empty period**: No order matches the date range → the system shows an explicit empty-state message instead of an empty table or an error.
+- **Missing currency rate**: An order is in a currency for which no conversion rate is configured → the report still displays the order, falling back to a default rate or omitting the EUR column for that row rather than failing the whole report.
+- **Underlying-less derivative**: A derivative order has no underlying price returned → the row is still shown; the underlying line is omitted.
+- **Single-account user**: A user with a single Saxo account is not forced through an extra selection step.
+- **Google Sheets write failure**: A network or permission error during create/update surfaces a clear error to the user; no partial row is left in the sheet, and the in-memory report is not corrupted.
+- **Wrong row update**: The user targets a non-existent or wrong row → the update is rejected with a clear message; existing rows are not silently overwritten.
+- **Non-stock asset taxation**: Regulatory taxes are only computed for stocks; derivatives and crypto journal entries do not include a tax line.
+- **Stale conversion rates**: Conversion rates come from configuration and are not real-time → the report reflects journaling-time accuracy, not mark-to-market, and this is acceptable for journal use.
+- **Date format mismatch**: The user enters a start date in an unexpected format → the system rejects it with an explicit error rather than silently returning no orders.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow the user to fetch the list of executed orders on a chosen Saxo account from a chosen start date up to today.
+- **FR-002**: System MUST let the user select the target Saxo account when several accounts exist on their profile.
+- **FR-003**: System MUST display, for each order, at minimum: execution date, asset name/code, direction (buy/sell), quantity, execution price, and total amount.
+- **FR-004**: System MUST display prices and totals in EUR using configured conversion rates whenever the order's currency is not EUR, in addition to the original-currency values.
+- **FR-005**: System MUST display the underlying asset's price for derivative orders (e.g. warrants/turbos) when the broker provides one.
+- **FR-006**: System MUST provide an aggregated summary of the period including total order count, buy/sell breakdown, total EUR volume, and total fees.
+- **FR-007**: System MUST allow the user to create a new journal entry in Google Sheets from any executed order in the report, capturing at least: order data, stop loss, objective, strategy, signal, and an optional free-text comment.
+- **FR-008**: System MUST reject creation of a journal entry that does not specify both a strategy and a signal.
+- **FR-009**: System MUST allow the user to update an existing journal row in Google Sheets, either by adjusting the stop/objective (position still open) or by marking the position as closed.
+- **FR-010**: System MUST capture closure flags "stopped" and "break-even-stopped" on a closing update so post-trade analysis can distinguish those outcomes.
+- **FR-011**: System MUST compute regulatory taxes for stock orders when persisting to Google Sheets, and MUST NOT add a tax line for non-stock assets (derivatives, crypto).
+- **FR-012**: System MUST expose the reporting and journaling capabilities via two surfaces with equivalent behavior: an interactive CLI command and a web UI backed by an HTTP API.
+- **FR-013**: System MUST provide the list of valid strategies and signals to the UI so the user picks them from controlled vocabularies rather than typing free text.
+- **FR-014**: System MUST route reporting requests to the Saxo backend for Saxo account identifiers and to the Binance backend for Binance account identifiers (shared report surface, see `specs/471-binance-reporting/spec.md`).
+- **FR-015**: System MUST clearly surface failures from the broker API or Google Sheets to the user without corrupting the journal or the in-memory report.
+- **FR-016**: System MUST require the user to confirm the journal row number to update; it MUST NOT try to auto-detect which journal row corresponds to which order.
+
+### Key Entities
+
+- **ReportOrder**: An order that was actually executed on a broker account. Carries asset identity (code, name), direction, quantity, execution price, currency, execution date, asset type (stock / derivative / crypto), and, for derivatives, an optional underlying price. Extended with journaling metadata when persisted: stop, objective, strategy, signal, comment, and lifecycle flags (`open_position`, `stopped`, `be_stopped`).
+- **Account**: A trading account on a broker. Identified by an account id whose prefix determines which backend serves the report (Saxo vs Binance).
+- **Strategy / Signal**: Controlled vocabularies (enums) describing the trader's reason for entering the trade. Required at journal creation time.
+- **Taxes**: Per-order fee/tax structure (broker cost + regulatory tax) computed for stocks only and persisted to the journal alongside the order.
+- **Journal Row (Google Sheets)**: The persisted representation of a position in the trader's external journal. Holds order data (in original currency and EUR), risk-management fields (stop, objective, strategy, signal, comment), computed taxes, and lifecycle status (open / closed / stopped / BE-stopped).
+- **Period Summary**: Aggregate over the reported orders — total count, buy/sell breakdown, EUR volume, total fees — recomputed from the displayed orders.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A trader can list all executed orders for a chosen Saxo account and date in under 3 seconds for a typical month of activity.
+- **SC-002**: Currency conversions match the configured rates within ±0.01 EUR for every displayed row.
+- **SC-003**: Creating a journal entry from the report writes exactly one new row to the Google Sheet, with all mandatory fields (order data, stop, objective, strategy, signal) populated, in 100% of successful runs.
+- **SC-004**: Updating a journal entry modifies only the targeted row; no other rows are altered, in 100% of runs.
+- **SC-005**: The aggregated summary (counts, EUR volumes, fees) is consistent with the per-row data within ±0.01 EUR.
+- **SC-006**: The CLI and the UI produce equivalent results for the same input (same account, same start date) — same orders, same EUR conversions, same journal rows.
+- **SC-007**: An empty result set and a broker/Sheets failure are each surfaced with a clear, distinct user-facing message (no silent failures).
+
+## Assumptions
+
+- The trader's Google Sheets journal already exists and has the expected column layout; the feature writes into it, it does not create it.
+- Currency conversion rates are maintained in configuration and refreshed out-of-band; the feature does not fetch live FX rates.
+- The CLI is run by a single user on a trusted workstation with valid Saxo and Google credentials; multi-tenant authentication is out of scope for the CLI.
+- Account selection in the UI uses the same authenticated user profile as the rest of the app; no separate login flow is part of this feature.
+- The trader is responsible for selecting the correct journal row when updating; the feature does not auto-match orders to existing journal rows.
+- Regulatory taxes only apply to stocks under the current French-resident assumption baked into the tax formula; other tax regimes are out of scope.
+
+## Out of Scope
+
+- Real-time / streaming order updates — the report is a pull on demand for a chosen period.
+- Live FX rates — conversions use configured rates.
+- Automated reconciliation between Saxo orders and existing journal rows.
+- P&L computation, performance analytics, or charting based on journaled positions (the journal is the data source for those, but they are separate features).
+- Multi-user / role-based access to the journal — single-trader use is assumed.
+- Mobile-specific UI — the web UI is the only graphical surface.
+
+## Dependencies
+
+- **Saxo Bank API**: source of executed order activity for a Saxo account over a period.
+- **Google Sheets API**: target of journal create/update operations.
+- **Application configuration**: currency conversion rates, Google Sheets spreadsheet id and credentials, list of valid strategies and signals.
+- **Binance reporting feature** (`specs/471-binance-reporting`): shares the same report UI/API surface; this Saxo feature is the original implementation that the Binance one generalized.


### PR DESCRIPTION
## Summary

- Retroactive spec (`specs/020-saxo-reporting/spec.md`) for the existing Saxo order reporting feature, covering CLI (`k-order get-report`), HTTP API (`/api/report/*`), and the React `Report.tsx` page.
- 5 prioritized user stories: list executed orders (P1), journal a new position to Google Sheets (P1), update/close an existing journal row (P2), period summary (P3), CLI parity (P3). 16 functional requirements, edge cases, success criteria, assumptions, and out-of-scope.
- Cross-references `specs/471-binance-reporting/spec.md` (the Binance variant that reuses the same report surface); FR-014 makes the Saxo/Binance routing explicit.
- Quality checklist at `specs/020-saxo-reporting/checklists/requirements.md` — all items pass, no `[NEEDS CLARIFICATION]` markers.

## Test plan

- [ ] Review user stories and acceptance scenarios against current CLI and UI behavior
- [ ] Confirm FR-001..FR-016 match the implemented features
- [ ] Confirm cross-reference to `471-binance-reporting` is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)