### PR TITLE
feat: auto-select default signal when picking a strategy in the report modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ Examples:
 - AWS DynamoDB `alerts` table (existing, schema unchanged — `data` is a free-form `Dict[str, Any]`, alert_type is appended to the existing alerts list with same-type-same-date dedup) (019-mm50-slope-alert)
 - Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI, Click, `cachetools` (TTLCache), Pydantic v2, Axios, React Router DOM v7+, Vite 7+ (020-saxo-reporting)
 - Google Sheets (persisted trading journal); in-memory `TTLCache` for report fetches (5 min TTL); no database for this feature (020-saxo-reporting)
+- TypeScript 5+ / React 19+ + React (`useState`), existing `reportConfigService` from `frontend/src/services/api.ts` (already loaded — no new dependency) (020-saxo-reporting)
+- N/A — purely in-memory component state (`strategy`, `signal`) (020-saxo-reporting)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -10,6 +10,12 @@ import {
 } from '../services/api';
 import './Report.css';
 
+const STRATEGY_DEFAULT_SIGNAL: Record<string, string> = {
+  B9H: 'BO5M',
+  INTRA: 'BOH1',
+  CONG: 'BHD',
+};
+
 const getTodayDate = () => {
   const today = new Date();
   const year = today.getFullYear();
@@ -378,6 +384,14 @@ function OrderModal({
     }
   };
 
+  const handleStrategyChange = (value: string) => {
+    setStrategy(value);
+    const defaultSignal = STRATEGY_DEFAULT_SIGNAL[value];
+    if (defaultSignal) {
+      setSignal(defaultSignal);
+    }
+  };
+
   const calculateRiskReward = () => {
     const stopNum = parseFloat(stop);
     const objectiveNum = parseFloat(objective);
@@ -575,7 +589,7 @@ function OrderModal({
                 <label>Strategy: <span className="required">*</span></label>
                 <select
                   value={strategy}
-                  onChange={(e) => setStrategy(e.target.value)}
+                  onChange={(e) => handleStrategyChange(e.target.value)}
                   required
                 >
                   {strategies.map((s) => (
@@ -673,7 +687,7 @@ function OrderModal({
                     <label>Strategy:</label>
                     <select
                       value={strategy}
-                      onChange={(e) => setStrategy(e.target.value)}
+                      onChange={(e) => handleStrategyChange(e.target.value)}
                     >
                       {strategies.map((s) => (
                         <option key={s.value} value={s.value}>

--- a/specs/020-saxo-reporting/data-model.md
+++ b/specs/020-saxo-reporting/data-model.md
@@ -141,3 +141,17 @@ A trade flows through these states from the journal's point of view:
 | `_account_cache` | `account_identifier` | `Account` | 300 s |
 
 The frontend has no knowledge of the cache — staleness is bounded by the TTL.
+
+---
+
+## US5 — Strategy → Signal default mapping (frontend constant)
+
+No persisted entity. The auto-suggest behaviour added by US5 is implemented as a module-level constant in `frontend/src/pages/Report.tsx`:
+
+| Strategy key (`Strategy.name`) | Strategy label (`Strategy.value`) | Default Signal key (`Signal.name`) | Default Signal label (`Signal.value`) |
+|---|---|---|---|
+| `B9H` | Bougie de 9h | `BO5M` | Breakout 5m |
+| `INTRA` | Intraday | `BOH1` | Breakout h1 |
+| `CONG` | Congestion | `BHD` | Breakout daily |
+
+The keys are the same `value` strings that the backend returns from `GET /report/config` (`api/routers/report.py:34-35`), so the constant lives entirely in the frontend without backend involvement. See `plan.md` §Phase 1 and `research.md` Decision 9 for rationale.

--- a/specs/020-saxo-reporting/plan.md
+++ b/specs/020-saxo-reporting/plan.md
@@ -1,57 +1,39 @@
-# Implementation Plan: Saxo Order Reporting
+# Implementation Plan: Auto-suggest signal from selected strategy (Saxo Reporting US5)
 
-**Branch**: `020-saxo-reporting` | **Date**: 2026-05-31 (retroactive documentation) | **Spec**: [spec.md](./spec.md)
-**Input**: Reverse-engineered from the existing CLI command, API router, service, client integrations, and React page
+**Branch**: `RNiveau/auto-select-signal` (against spec `020-saxo-reporting`) | **Date**: 2026-05-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/020-saxo-reporting/spec.md` (User Story 5, FR-017/018/019, SC-008)
 
 ## Summary
 
-Expose the trader's executed Saxo orders for a chosen period through two equivalent surfaces — an interactive Click CLI and a FastAPI + React web UI — and let the trader create or update positions in a Google Sheets trading journal with risk-management metadata (stop, objective, strategy, signal, comment, closure flags).
+When the user picks a strategy in the create-journal modal of the Report page, the signal field MUST be pre-filled with the canonical signal for three mapped strategies (Bougie de 9h → Breakout 5m; Intraday → Breakout h1; Congestion → Breakout daily). The auto-fill is a default only: a manual change wins, and selecting a strategy outside the mapping leaves the signal field untouched. This is a pure frontend change inside `frontend/src/pages/Report.tsx` — no backend, API, or persistence changes.
 
-The implementation introduces a single `ReportService` in the API layer that orchestrates `SaxoClient`, `GSheetClient`, and currency/tax helpers. The same service is reused by the API router for HTTP traffic and (later, in the Binance backport) became the template that `BinanceReportService` mirrored. The frontend is platform-agnostic and selects the backend via an `account_id` (Saxo account key, or the `binance_*` pseudo-account). The CLI command (`k-order get-report`) predates the API and remains as a power-user surface; it shares the underlying `SaxoClient.get_report` and `GSheetClient` integrations.
+**Technical approach**: extend the existing `onChange` handler of the strategy `<select>` (lines 578 and 676) to also call `setSignal(...)` when the chosen strategy is one of the three mapped enum keys. Mapping defined as a module-level `const STRATEGY_DEFAULT_SIGNAL: Record<string, string>` keyed by `Strategy` enum names (`B9H`, `INTRA`, `CONG`) and valued with `Signal` enum names (`BO5M`, `BOH1`, `BHD`) — the same `value` fields the backend already returns from `GET /report/config` (see `api/routers/report.py:34-35`).
 
 ## Technical Context
 
-**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend)
-**Primary Dependencies**: FastAPI, Click, `cachetools` (TTLCache), Pydantic v2, Axios, React Router DOM v7+, Vite 7+
-**Storage**: Google Sheets (persisted trading journal); in-memory `TTLCache` for report fetches (5 min TTL); no database for this feature
-**Testing**: `pytest` with `unittest.mock` for backend; no frontend test framework yet (per constitution §Testing Standards)
-**Target Platform**: Web app (React SPA + FastAPI behind uvicorn locally / Lambda in production) + CLI tool (`k-order`)
-**Project Type**: Full-stack web application + CLI (matches Option 2 from the template)
-**Performance Goals**: <3 s for a typical month of orders on first fetch; <500 ms on cache hits; aggregated summary recomputed inline from the order list
-**Constraints**: CLI must remain functional and produce equivalent results to the UI; Google Sheets writes are append/update only (no delete); regulatory taxes apply to stocks only; conversion rates come from configuration
-**Scale/Scope**: Single-trader use; up to ~hundreds of orders per period; one trading journal (single spreadsheet); two brokers covered by the shared report surface (Saxo here, Binance in spec 471)
+**Language/Version**: TypeScript 5+ / React 19+
+**Primary Dependencies**: React (`useState`), existing `reportConfigService` from `frontend/src/services/api.ts` (already loaded — no new dependency)
+**Storage**: N/A — purely in-memory component state (`strategy`, `signal`)
+**Testing**: Manual smoke test in `npm run dev` (no frontend test framework configured — see constitution §Testing Standards, "Frontend Testing: TBD")
+**Target Platform**: Web (Vite dev server on :5173, production build on Lambda-hosted dist)
+**Project Type**: Web application (existing FastAPI backend + React frontend) — only the frontend module changes
+**Performance Goals**: N/A — adds a constant-time lookup on a `<select>` change event
+**Constraints**: Must not break the existing US2/US3 create/update flow; manual override of the auto-filled signal MUST be preserved (FR-018)
+**Scale/Scope**: One file modified (`frontend/src/pages/Report.tsx`), two `<select onChange>` handlers updated, one module-level constant added. ~10 LOC.
 
 ## Constitution Check
 
-*GATE: Passes for both Phase 0 and post-Phase 1 design.*
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-✅ **I. Layered Architecture Discipline**:
-- CLI (`saxo_order/commands/get_report.py`) → orchestrates `SaxoClient` + `GSheetClient` + helpers; no business logic.
-- API router (`api/routers/report.py`) → thin orchestration of `ReportService`.
-- Service (`api/services/report_service.py`) → owns business logic (period fetch, EUR conversion, summary, journal writes); receives clients via constructor (DI).
-- Clients (`client/saxo_client.py`, `client/gsheet_client.py`) → external integrations only; return domain models (`ReportOrder`, `Order`).
-- Models (`model/__init__.py`, `model/enum.py`) → no external dependencies; `Strategy` / `Signal` / `Currency` / `Direction` / `AssetType` are enums.
-- Frontend: `Report.tsx` (page) → `reportService` in `frontend/src/services/api.ts` for all HTTP calls. `OrderModal` is a sub-component receiving data via props.
+| Principle | Applies? | Verdict |
+|-----------|----------|---------|
+| I. Layered Architecture Discipline | Yes (frontend layer) | PASS — change stays inside the Page component; no inline axios calls added; `reportConfigService` (services layer) continues to be the sole API surface. |
+| II. Clean Code First | Yes | PASS — one named `Record<string, string>` constant; no comments needed; uses the enum-key values already produced by the backend (no hardcoded strings duplicating the enum). |
+| III. Configuration-Driven Design | Partial | PASS — the mapping is product behaviour (three canonical strategy→signal defaults) defined by the spec, not deployment configuration; lives next to the component that consumes it. No new env vars, no `VITE_*` change. |
+| IV. Safe Deployment Practices | Yes | PASS — no infra change; ships as part of the frontend build; commit follows conventional commits (`feat:`). |
+| V. Domain Model Integrity | Yes | PASS — uses backend-provided `Strategy.name` / `Signal.name` values; does not introduce new domain models; does not bypass the existing enum boundary. |
 
-✅ **II. Clean Code First**:
-- Self-documenting Click options and Pydantic fields.
-- Enum-driven (`Strategy`, `Signal`, `Currency`, `Direction`, `AssetType`).
-- No inline `// what this does` comments in the affected files.
-
-✅ **III. Configuration-Driven Design**:
-- Currency conversion rates, Google Sheets credentials path, spreadsheet id, and Saxo credentials all come from `config.yml` / `secrets.yml` via `Configuration`.
-- Frontend uses `import.meta.env.VITE_API_URL` (no hardcoded API URL).
-
-✅ **IV. Safe Deployment Practices**:
-- Conventional commits (this feature is delivered as `docs:` because the code already shipped).
-- Backend deploys via the standard Lambda/ECR/Pulumi pipeline; no infra change required for this feature.
-
-✅ **V. Domain Model Integrity**:
-- `ReportOrder` extends `Order` with journaling fields; both live in `model/`.
-- `Account` is a dataclass in `model/__init__.py` (not a Pydantic model leak across the API boundary — the API exposes its own `AccountInfo`).
-- Account routing is prefix-based (`binance_*` → Binance, otherwise Saxo); does NOT infer broker from `country_code` (matches the constitution's explicit prohibition).
-
-✅ **No constitution violations identified.** "Complexity Tracking" therefore has nothing to justify.
+**Initial Constitution Check: PASS** — no violations, Complexity Tracking not required.
 
 ## Project Structure
 
@@ -59,88 +41,70 @@ The implementation introduces a single `ReportService` in the API layer that orc
 
 ```text
 specs/020-saxo-reporting/
-├── spec.md                      # User stories & requirements (already written)
-├── plan.md                      # This file
-├── research.md                  # Phase 0: architectural decisions (retroactive)
-├── data-model.md                # Phase 1: entities & relationships (retroactive)
-├── quickstart.md                # Phase 1: how to exercise the feature locally
-├── contracts/
-│   └── report-api.md            # Phase 1: HTTP endpoints & payload shapes
-└── checklists/
-    └── requirements.md          # Already written
+├── plan.md              # This file
+├── spec.md              # Updated with US5 / FR-017–019 / SC-008
+├── research.md          # Phase 0 — see ./research.md (US5 section appended)
+├── data-model.md        # Phase 1 — unchanged; no entities added (see note in file)
+├── quickstart.md        # Phase 1 — US5 section appended with manual verification steps
+├── contracts/           # Unchanged — no API contract change for US5
+└── tasks.md             # NOT created by /speckit.plan
 ```
 
-### Source Code (already implemented in the repo)
+### Source Code (repository root)
 
 ```text
-# Backend
-api/
-├── routers/report.py                       # FastAPI routes (5 endpoints)
-├── services/report_service.py              # ReportService — business logic
-├── models/report.py                        # Pydantic request/response models
-└── dependencies.py                         # get_saxo_client / get_binance_client / get_configuration
-
-client/
-├── saxo_client.py                          # get_report(account, from_date) -> List[ReportOrder]
-└── gsheet_client.py                        # create_order / update_order
-
-saxo_order/
-├── commands/get_report.py                  # Click CLI: k-order get-report
-└── service.py                              # calculate_currency / calculate_taxes (shared helpers)
-
-model/
-├── __init__.py                             # Order, ReportOrder, Account (dataclass), Taxes
-└── enum.py                                 # Strategy, Signal, Currency, Direction, AssetType
-
-# Frontend
-frontend/src/
-├── pages/Report.tsx                        # Report page + OrderModal sub-component
-├── services/api.ts                         # reportService + reportConfigService
-└── (styles colocated, e.g. Report.css)
-
-# Tests
-tests/
-└── client/test_gsheet_client.py            # GSheet client unit tests
-# Note: no dedicated tests for ReportService (Saxo side) — the Binance variant
-#       in spec 471 added 12 tests for BinanceReportService; an equivalent suite
-#       for ReportService is a follow-up.
+frontend/
+└── src/
+    └── pages/
+        └── Report.tsx          # ONLY file modified
+            - add module-level STRATEGY_DEFAULT_SIGNAL constant
+            - extend strategy <select> onChange at line 578 (create flow)
+            - extend strategy <select> onChange at line 676 (update flow)
 ```
 
-**Structure Decision**: Full-stack web application + CLI tool. The web stack mirrors the layered architecture mandated by the constitution; the CLI sits beside `api/` and shares clients and helpers but does NOT depend on FastAPI. The frontend is generic — it talks to `account_id` rather than to a "Saxo report" endpoint — which is what later allowed Binance to be added without frontend changes (see `specs/471-binance-reporting`).
+**Structure Decision**: Single-file frontend change. The existing `OrderModal` component (`Report.tsx:344`) already owns both the `strategy` and `signal` state and renders both `<select>` elements (create form at lines 575–599, update form at lines 673–697). The auto-fill behaviour belongs to the same component because (a) it operates on local component state, (b) both selects already share the same `strategies` / `signals` lists loaded from `reportConfigService`, and (c) factoring out a hook would be premature for ~10 LOC (Constitution §II: no over-engineering).
 
-## Phase 0 — Research (retroactive)
+## Phase 0 — Outline & Research
 
-The detailed decision log lives in [research.md](./research.md). Headline decisions:
+No NEEDS CLARIFICATION markers in the spec. Two micro-questions worth recording in `research.md`:
 
-1. **Single report endpoint with prefix-based account routing.** Saxo account keys go to `ReportService`; `binance_*` ids go to `BinanceReportService` (added later). One frontend, one URL space.
-2. **`ReportService` as the seam between CLI and API.** Business logic (period fetch, EUR conversion, summary, journal writes) lives in one class; the CLI uses the same client and helpers, the API delegates to the service.
-3. **5-minute TTL cache on report fetches** via `cachetools.TTLCache`, keyed by `(account_id, from_date)`. Trading-journal use does not need real-time freshness.
-4. **Conversion rates are configuration-driven, not live.** Acceptable because the journal records entry/exit prices, not mark-to-market.
-5. **Strategy/Signal are enums shipped via `/api/report/config`** so the UI picks from a controlled vocabulary instead of free-text input.
-6. **Google Sheets row targeting is manual.** The user supplies the row number; the system never auto-matches an order to an existing journal row.
+1. **Which form(s) should auto-fill apply to** — create only, or also update? Both forms share `strategy`/`signal` state and render the same `<select>`s, so resolving this is a behavioural decision, not an architectural one. **Decision recorded in research.md**: apply to both (the user expects consistency; the update form is also used to add stop/objective/strategy/signal to an existing row, per US3 acceptance scenario #1).
+2. **Should auto-fill overwrite a signal the user has already chosen** — or only fill when empty? Spec FR-019 says "the existing signal value (chosen or empty) is preserved" only for non-mapped strategies; for mapped strategies the spec is silent on a previously-set signal. **Decision recorded in research.md**: always overwrite on strategy-change for the three mapped strategies (this matches AC #6 "switching to another strategy that also has an auto-filled signal updates the field" and makes the behaviour predictable). The user remains free to manually change the signal afterwards (FR-018).
 
-## Phase 1 — Design Artefacts (retroactive)
+## Phase 1 — Design & Contracts
 
-- [data-model.md](./data-model.md) — entities: `ReportOrder`, `Order`, `Account`, `Taxes`, controlled vocabularies (`Strategy`, `Signal`, `Currency`, `Direction`, `AssetType`), and the Google Sheets journal row layout.
-- [contracts/report-api.md](./contracts/report-api.md) — HTTP contract for `/api/report/*`: `GET /config`, `GET /orders`, `GET /summary`, `POST /gsheet/create`, `POST /gsheet/update`.
-- [quickstart.md](./quickstart.md) — how to run the CLI and the UI flow end-to-end, plus the smoke-test checklist.
+### Data model
+
+No new entities or persisted fields. The mapping is a frontend constant. `data-model.md` does not need US5-specific changes; a one-line note will be added pointing back to this plan.
+
+**Mapping (frontend constant)**:
+
+```ts
+const STRATEGY_DEFAULT_SIGNAL: Record<string, string> = {
+  B9H: 'BO5M',     // Bougie de 9h → Breakout 5m
+  INTRA: 'BOH1',   // Intraday      → Breakout h1
+  CONG: 'BHD',     // Congestion    → Breakout daily
+};
+```
+
+Keys/values use the same `value` field already produced by `GET /report/config` (the Python `Enum.name`), so no transformation is required at the `<select>` boundary.
+
+### API contracts
+
+No change. The mapping is client-side; the backend already exposes `strategies` and `signals` through `GET /report/config` (`api/routers/report.py:30-36`). The `POST` create/update endpoints continue to receive and persist whatever signal value the user finally submits (auto-filled or manually changed), so server contracts and validation stay intact.
+
+### Quickstart additions
+
+Append a "Verify US5 auto-suggest signal" section to `quickstart.md` with the manual steps that match AC #1–6.
+
+### Agent context update
+
+Run `.specify/scripts/bash/update-agent-context.sh claude` to refresh `CLAUDE.md` with the spec 020 update. No new technologies — only the spec entry is renewed.
+
+## Post-Design Constitution Check
+
+Re-evaluated after producing the design above. Still PASS — the design adds zero new dependencies, no new files, no new API surfaces, and stays inside the Page component that already owns the relevant state. No items required for "Complexity Tracking".
 
 ## Complexity Tracking
 
-> No constitution violations — section intentionally empty.
-
-Noteworthy design choices that *avoided* complexity:
-
-| Decision | Rationale | Simpler Alternative Rejected Because |
-|----------|-----------|--------------------------------------|
-| Prefix-based account routing in the API | Single endpoint set covers all brokers | Per-broker URL space (`/api/saxo-report/*`) would force frontend changes for every new broker |
-| Manual row-number for journal updates | The user already knows which row maps to which trade; auto-match would need a second source of truth | Auto-detection of the journal row via heuristics would silently overwrite the wrong row when ambiguous |
-| In-memory `TTLCache` instead of a database for report results | Reports are derived data, not state; staleness is bounded by TTL | A persistent cache would add infra cost and migrations for no user-visible benefit |
-| `ReportOrder` as a subtype of `Order` rather than a new model | Journaling fields (`stopped`, `be_stopped`, `open_position`) are additive | A separate `JournalEntry` model would duplicate every order field and force conversions at every boundary |
-| Strategy/Signal as enums served by `/api/report/config` | Single source of truth for the UI dropdowns; values change in one place | Hardcoding the lists in the frontend would drift from the backend's validation |
-
-## Retroactive Verification Notes
-
-- **Behaviour parity CLI ↔ UI**: both call `SaxoClient.get_report` and write through `GSheetClient`; the CLI prompts interactively whereas the UI uses the `OrderModal` form. Same outputs for identical inputs.
-- **CORS**: `api/main.py` allows `localhost:3000` and `localhost:5173` per the constitution.
-- **Open follow-up**: no dedicated `tests/api/services/test_report_service.py` yet — the Binance variant added 12 tests in `tests/api/services/test_binance_report_service.py`; an equivalent suite for the Saxo service is a sensible next step but is out of scope for this retro-documentation effort.
+> Constitution Check passed without violations; this section intentionally empty.

--- a/specs/020-saxo-reporting/quickstart.md
+++ b/specs/020-saxo-reporting/quickstart.md
@@ -75,6 +75,20 @@ Run both surfaces against the same account and start date:
 
 Any divergence is a bug — both surfaces share `SaxoClient.get_report`, `calculate_currency`, `calculate_taxes`, and `GSheetClient`.
 
+## Verify US5 — strategy → signal auto-fill (frontend)
+
+Manual smoke test in `npm run dev` (port 5173):
+
+1. Open the Report page, fetch orders for an account, click an opening order to open the create modal.
+2. **Mapped strategies fire the default**:
+   - Select strategy "Bougie de 9h" → signal becomes "Breakout 5m".
+   - Select strategy "Intraday" → signal becomes "Breakout h1".
+   - Select strategy "Congestion" → signal becomes "Breakout daily".
+3. **Manual override is preserved**: after step 2 with any mapped strategy, change the signal to a different value (e.g. "Polarité"); submit the form; verify the journal row in Google Sheets carries the manually chosen signal, not the default.
+4. **Non-mapped strategy leaves signal alone**: pre-select a signal manually, then change the strategy to one *not* in the map (e.g. "Bougie impulsive"); verify the signal field keeps the previously chosen value.
+5. **Switching between mapped strategies updates the default**: select "Bougie de 9h" → signal = "Breakout 5m"; without touching the signal, switch to "Intraday" → signal becomes "Breakout h1".
+6. **Update flow has the same behaviour**: switch the modal to "update" mode, repeat step 2 on the update form's strategy `<select>`; same defaults fire.
+
 ## Troubleshooting
 
 - **"Account not found"**: the supplied `account_id` is not on the Saxo profile that the API is authenticated against. Re-run the OAuth flow.

--- a/specs/020-saxo-reporting/research.md
+++ b/specs/020-saxo-reporting/research.md
@@ -74,7 +74,21 @@ This file captures the design decisions that shaped the Saxo reporting feature. 
 
 ---
 
+## Decision 9 — Strategy→Signal auto-fill is a frontend constant in `Report.tsx` (US5)
+
+- **Decision**: Define `STRATEGY_DEFAULT_SIGNAL: Record<string, string>` at module scope in `frontend/src/pages/Report.tsx`, keyed by `Strategy.name` (`B9H`, `INTRA`, `CONG`) and valued with `Signal.name` (`BO5M`, `BOH1`, `BHD`). On the strategy `<select>`'s `onChange`, if the new value is a key of the map, also call `setSignal(map[value])`. Otherwise leave the signal state alone.
+- **Rationale**:
+  - The mapping is product behaviour (canonical entry timeframe for the strategy), not deployment configuration — constitution §III is satisfied by colocating it with the only component that uses it.
+  - The dropdown values are already the Python enum *names* (`api/routers/report.py:34-35`), so the map uses those keys directly — no string duplication of the human-readable French labels (constitution §II, enum-driven).
+  - Component-local: avoids spreading the rule across a hook + a service when the OrderModal already owns the relevant state.
+- **Alternatives considered**:
+  - *Return the mapping from `GET /report/config`.* Rejected for now — the mapping is small, static, and only consumed by one UI control; round-tripping it through the API adds a backend change for zero current benefit. Easy to lift if a second consumer appears.
+  - *Encode the rule as a `selectedStrategy.defaultSignal` field on the enum payload.* Rejected — would change the existing TS `EnumOption` shape and the backend serializer for one feature.
+  - *Auto-fill only when signal is empty (preserve a manually-chosen signal).* Rejected — conflicts with AC #6 ("switching to another mapped strategy updates the signal"); also makes the behaviour less predictable. Manual override still wins because the user can change the signal *after* the strategy change (FR-018).
+  - *Apply only to the create form, not the update form.* Rejected — the update form shares the same `<select>` controls and is also used to add a missing strategy/signal to an existing row (US3 AC #1). Applying to both keeps behaviour consistent.
+
 ## Open Items (follow-ups, not blocking)
 
 - No `tests/api/services/test_report_service.py` exists yet. The Binance variant added 12 unit tests as a template; an equivalent Saxo suite is the obvious next step.
 - The CLI's interactive update flow and the UI's `OrderModal` have diverged in micro-details (prompt wording, default values). Reconciling them would tighten parity but is cosmetic.
+- The CLI does not implement the strategy→signal auto-fill (it prompts independently for both). Adding it CLI-side is out of scope for US5 (which is explicitly a UI affordance); if the trader requests parity later, the mapping can be lifted to a shared backend module.

--- a/specs/020-saxo-reporting/spec.md
+++ b/specs/020-saxo-reporting/spec.md
@@ -2,8 +2,9 @@
 
 **Feature Branch**: `020-saxo-reporting`
 **Created**: 2026-05-31 (retroactive documentation)
-**Status**: Implemented
-**Input**: User description: "we need a retro spec about the saxo reporting feature, (backend + UI)"
+**Updated**: 2026-05-31 (added US5 — auto-suggest signal from selected strategy)
+**Status**: Implemented (US1–US4, US6); US5 pending
+**Input**: User description: "we need a retro spec about the saxo reporting feature, (backend + UI)"; update: "auto-select the canonical signal when the user picks a strategy in the create-journal form (Bougie de 9h → Breakout 5m, Intraday → Breakout h1, Congestion → Breakout daily)"
 
 ## Overview
 
@@ -78,7 +79,26 @@ As a trader, while reviewing the report I want to see aggregated statistics for 
 
 ---
 
-### User Story 5 - CLI parity for power users (Priority: P3)
+### User Story 5 - Auto-suggest the default signal for a chosen strategy (Priority: P2)
+
+As a trader filling in the "create journal entry" form, when I pick a strategy that has a canonical entry signal, I want the signal field to be pre-filled with that canonical signal so I don't have to re-select it every time, while still being free to override it if my actual entry differed.
+
+**Why this priority**: Several strategies in the trader's playbook have a one-to-one canonical signal (e.g. the 9h-candle strategy is by definition entered on a 5-minute breakout). Auto-filling the matching signal removes a redundant manual step on the most common case, reduces mis-clicks on the long signal list, and keeps the journal more consistent across entries; it is a quality-of-life improvement on top of the already-working create flow (US2), not a correctness requirement.
+
+**Independent Test**: Open the create-journal form, pick each of the three strategies below, and verify the signal dropdown is pre-selected to the mapped value; pick any other strategy and verify the signal field stays at its current value (or empty). For each auto-filled case, change the signal manually and confirm the form keeps the manual choice and submits it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the create-journal form is open with no signal yet chosen, **When** the trader selects strategy "Bougie de 9h", **Then** the signal field is automatically set to "Breakout 5m".
+2. **Given** the create-journal form is open with no signal yet chosen, **When** the trader selects strategy "Intraday", **Then** the signal field is automatically set to "Breakout h1".
+3. **Given** the create-journal form is open with no signal yet chosen, **When** the trader selects strategy "Congestion", **Then** the signal field is automatically set to "Breakout daily".
+4. **Given** a strategy with an auto-filled signal has been selected, **When** the trader manually changes the signal to a different value, **Then** the manual choice is preserved and submitted as the journal entry's signal.
+5. **Given** the trader selects a strategy that has no canonical signal mapping (any strategy other than the three above), **When** the strategy changes, **Then** the signal field is not modified by the system.
+6. **Given** a strategy with an auto-filled signal has been selected, **When** the trader switches to another strategy that also has an auto-filled signal, **Then** the signal field is updated to the new strategy's canonical signal.
+
+---
+
+### User Story 6 - CLI parity for power users (Priority: P3)
 
 As a power user / script author, I want the same reporting and journaling capabilities available from a CLI command so I can run the workflow from a terminal and keep my pre-existing scripts working.
 
@@ -126,6 +146,9 @@ As a power user / script author, I want the same reporting and journaling capabi
 - **FR-014**: System MUST route reporting requests to the Saxo backend for Saxo account identifiers and to the Binance backend for Binance account identifiers (shared report surface, see `specs/471-binance-reporting/spec.md`).
 - **FR-015**: System MUST clearly surface failures from the broker API or Google Sheets to the user without corrupting the journal or the in-memory report.
 - **FR-016**: System MUST require the user to confirm the journal row number to update; it MUST NOT try to auto-detect which journal row corresponds to which order.
+- **FR-017**: System MUST, in the web UI create-journal form, pre-fill the signal field when the user selects a strategy that has a canonical entry signal, using the following mappings: "Bougie de 9h" → "Breakout 5m"; "Intraday" → "Breakout h1"; "Congestion" → "Breakout daily".
+- **FR-018**: System MUST treat the auto-filled signal as a default only: the user MUST be able to override it manually before submitting, and the manually chosen value MUST be the one persisted to the journal.
+- **FR-019**: System MUST NOT modify the signal field when the user selects a strategy that is not in the canonical mapping; the existing signal value (chosen or empty) is preserved.
 
 ### Key Entities
 
@@ -147,6 +170,7 @@ As a power user / script author, I want the same reporting and journaling capabi
 - **SC-005**: The aggregated summary (counts, EUR volumes, fees) is consistent with the per-row data within ±0.01 EUR.
 - **SC-006**: The CLI and the UI produce equivalent results for the same input (same account, same start date) — same orders, same EUR conversions, same journal rows.
 - **SC-007**: An empty result set and a broker/Sheets failure are each surfaced with a clear, distinct user-facing message (no silent failures).
+- **SC-008**: For each of the three strategies "Bougie de 9h", "Intraday", and "Congestion", selecting the strategy in the create-journal form pre-fills the signal with its canonical value ("Breakout 5m", "Breakout h1", "Breakout daily" respectively) in 100% of attempts, and the manually overridden signal is the one persisted when the user changes it before submitting.
 
 ## Assumptions
 


### PR DESCRIPTION
## Summary

- Add a canonical strategy → signal mapping in the Report create/update modal so the trader doesn't have to re-pick the signal for the three common cases:
  - **Bougie de 9h** → **Breakout 5m**
  - **Intraday** → **Breakout h1**
  - **Congestion** → **Breakout daily**
- The auto-fill is a default only — manually changing the signal afterwards still wins, and strategies outside the mapping leave the signal field untouched (FR-018 / FR-019).
- Pure frontend change in `frontend/src/pages/Report.tsx` (one module-level constant + one helper + two `onChange` rewires). Spec 020 updated with US5 / FR-017–019 / SC-008 and supporting design notes in `plan.md`, `research.md` (Decision 9), `data-model.md`, and `quickstart.md`.

## Test plan

- [ ] Open the Report page, fetch orders for a Saxo account, click an opening order, switch to the create flow.
- [ ] Select strategy **Bougie de 9h** → verify signal becomes **Breakout 5m**.
- [ ] Select strategy **Intraday** → verify signal becomes **Breakout h1**.
- [ ] Select strategy **Congestion** → verify signal becomes **Breakout daily**.
- [ ] With a mapped strategy selected and signal auto-filled, manually change the signal to another value, submit, and verify the journal row in Google Sheets carries the **manually chosen** signal (not the default).
- [ ] Pre-select a signal manually, then change the strategy to a non-mapped one (e.g. *Bougie impulsive*) → verify the signal field is unchanged.
- [ ] Switch from one mapped strategy to another (e.g. *Bougie de 9h* → *Intraday*) → verify the signal updates to the new default (*Breakout h1*).
- [ ] Repeat the three mapped-strategy checks on the **update** form (same modal, "update existing position" mode, keep open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)