### PR TITLE
fix: handle Saxo Time values without fractional seconds

### DIFF
--- a/client/saxo_client.py
+++ b/client/saxo_client.py
@@ -528,9 +528,14 @@ class SaxoClient:
             self._check_response(response)
             tmp_data = response.json()["Data"]
             for d in tmp_data:
-                d["Time"] = datetime.strptime(
-                    d["Time"], "%Y-%m-%dT%H:%M:%S.%fZ"
-                )
+                try:
+                    d["Time"] = datetime.strptime(
+                        d["Time"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                    )
+                except ValueError:
+                    d["Time"] = datetime.strptime(
+                        d["Time"], "%Y-%m-%dT%H:%M:%SZ"
+                    )
             data += sorted(tmp_data, key=lambda x: x["Time"], reverse=True)
             offset += real_count
             real_count = (


### PR DESCRIPTION
## Summary
- The Saxo historical chart API occasionally returns `Time` values without fractional seconds (e.g. `2026-04-16T12:30:00Z`), which broke the hardcoded `%Y-%m-%dT%H:%M:%S.%fZ` parse in `client/saxo_client.py` and caused command snapshots to fail with `time data '2026-04-16T12:30:00Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'`.
- Fall back to the no-fraction format on `ValueError` so both shapes parse cleanly.

## Test plan
- [ ] Re-run the failing command snapshot to confirm the error no longer occurs
- [ ] `poetry run pytest` (pre-commit pytest hook ran clean locally)