### PR TITLE
feat: add TradingView and asset detail links to workflow detail view

### DIFF
--- a/frontend/src/components/WorkflowDetailModal.css
+++ b/frontend/src/components/WorkflowDetailModal.css
@@ -225,6 +225,34 @@
   gap: 1rem;
 }
 
+.workflow-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.workflow-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.35);
+  color: #58a6ff;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.workflow-link:hover {
+  background: rgba(88, 166, 255, 0.2);
+  border-color: #58a6ff;
+}
+
 .detail-item {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/WorkflowDetailModal.tsx
+++ b/frontend/src/components/WorkflowDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { WorkflowDetail, OrderHistoryItem } from '../services/api';
 import { workflowService } from '../services/api';
 import { WorkflowCreateModal } from './WorkflowCreateModal';
@@ -11,6 +12,7 @@ interface WorkflowDetailModalProps {
 }
 
 export function WorkflowDetailModal({ workflowId, onClose, onDelete }: WorkflowDetailModalProps) {
+  const navigate = useNavigate();
   const [workflow, setWorkflow] = useState<WorkflowDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,6 +78,15 @@ export function WorkflowDetailModal({ workflowId, onClose, onDelete }: WorkflowD
     if (e.target === e.currentTarget) {
       onClose();
     }
+  };
+
+  const handleAssetDetailClick = () => {
+    if (!workflow) return;
+    navigate(
+      `/asset/${encodeURIComponent(workflow.index)}?exchange=saxo`,
+      { state: { description: workflow.name } }
+    );
+    onClose();
   };
 
   return (
@@ -151,6 +162,27 @@ export function WorkflowDetailModal({ workflowId, onClose, onDelete }: WorkflowD
           <div className="modal-body">
             <section className="detail-section">
               <h3>Basic Information</h3>
+              <div className="workflow-links">
+                {workflow.tradingview_url && (
+                  <a
+                    href={workflow.tradingview_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="workflow-link"
+                    title="View on TradingView"
+                  >
+                    📊 TradingView
+                  </a>
+                )}
+                <button
+                  type="button"
+                  className="workflow-link"
+                  onClick={handleAssetDetailClick}
+                  title="Open asset detail page"
+                >
+                  📈 Asset Details
+                </button>
+              </div>
               <div className="detail-grid">
                 <div className="detail-item">
                   <span className="detail-label">Name:</span>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -170,6 +170,7 @@ export interface WorkflowDetail {
   end_date: string | null;
   conditions: ConditionDetail[];
   trigger: TriggerDetail;
+  tradingview_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/model/workflow_api.py
+++ b/model/workflow_api.py
@@ -116,6 +116,13 @@ class WorkflowDetail(BaseModel):
     trigger: TriggerDetail = Field(
         ..., description="Order generation parameters"
     )
+    tradingview_url: Optional[str] = Field(
+        None,
+        description=(
+            "Resolved TradingView chart URL: custom URL from asset_details "
+            "if set, otherwise a default URL built from the index symbol."
+        ),
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 

--- a/services/workflow_service.py
+++ b/services/workflow_service.py
@@ -19,6 +19,7 @@ from model.workflow_api import (
     WorkflowOrderListItem,
 )
 from utils.logger import Logger
+from utils.tradingview import build_tradingview_url_from_symbol
 
 
 class WorkflowService:
@@ -70,7 +71,11 @@ class WorkflowService:
             workflow_dict
         )
         await self.dynamodb_client.put_workflow(converted)
-        return self._convert_to_detail(workflow_dict)
+        detail = self._convert_to_detail(workflow_dict)
+        detail.tradingview_url = await self._resolve_tradingview_url(
+            detail.index
+        )
+        return detail
 
     def _validate_request(self, data: WorkflowCreateRequest) -> None:
         if data.end_date is not None:
@@ -183,7 +188,11 @@ class WorkflowService:
             workflow_dict
         )
         await self.dynamodb_client.put_workflow(converted)
-        return self._convert_to_detail(workflow_dict)
+        detail = self._convert_to_detail(workflow_dict)
+        detail.tradingview_url = await self._resolve_tradingview_url(
+            detail.index
+        )
+        return detail
 
     async def delete_workflow(self, workflow_id: str) -> None:
         existing = await self.dynamodb_client.get_workflow_by_id(workflow_id)
@@ -199,7 +208,24 @@ class WorkflowService:
         )
         if not workflow_data:
             return None
-        return self._convert_to_detail(workflow_data)
+        detail = self._convert_to_detail(workflow_data)
+        detail.tradingview_url = await self._resolve_tradingview_url(
+            detail.index
+        )
+        return detail
+
+    async def _resolve_tradingview_url(self, index: str) -> str:
+        code = index.split(":", 1)[0] if ":" in index else index
+        try:
+            custom_url = await self.dynamodb_client.get_tradingview_link(code)
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to fetch TradingView link for {code}: {e}"
+            )
+            custom_url = None
+        if custom_url:
+            return custom_url
+        return build_tradingview_url_from_symbol(index)
 
     async def get_workflows_by_asset(
         self, code: str, country_code: str = "xpar"
@@ -310,6 +336,7 @@ class WorkflowService:
             end_date=workflow_data.get("end_date"),
             conditions=conditions,
             trigger=trigger,
+            tradingview_url=None,
             created_at=workflow_data["created_at"],
             updated_at=workflow_data["updated_at"],
         )

--- a/tests/services/test_workflow_service.py
+++ b/tests/services/test_workflow_service.py
@@ -81,3 +81,95 @@ async def test_get_all_orders_applies_limit_after_dedup():
 
     assert len(result) == 2
     assert [item.workflow_id for item in result] == ["wf-4", "wf-3"]
+
+
+def _make_workflow_data(workflow_id: str, index: str) -> dict:
+    return {
+        "id": workflow_id,
+        "name": "Test Workflow",
+        "index": index,
+        "cfd": index,
+        "enable": True,
+        "dry_run": False,
+        "is_us": False,
+        "end_date": None,
+        "conditions": [
+            {
+                "indicator": {
+                    "name": "ma7",
+                    "ut": "daily",
+                    "value": None,
+                    "zone_value": None,
+                },
+                "close": {
+                    "direction": "above",
+                    "ut": "daily",
+                    "spread": 0.5,
+                },
+                "element": None,
+            }
+        ],
+        "trigger": {
+            "ut": "daily",
+            "signal": "breakout",
+            "location": "higher",
+            "order_direction": "buy",
+            "quantity": 1.0,
+        },
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_by_id_uses_custom_tradingview_url_from_db():
+    dynamodb_client = AsyncMock()
+    dynamodb_client.get_workflow_by_id.return_value = _make_workflow_data(
+        "wf-1", "NKE:xnys"
+    )
+    dynamodb_client.get_tradingview_link.return_value = (
+        "https://www.tradingview.com/chart/custom"
+    )
+
+    service = WorkflowService(dynamodb_client=dynamodb_client)
+    result = await service.get_workflow_by_id("wf-1")
+
+    assert result is not None
+    assert result.tradingview_url == "https://www.tradingview.com/chart/custom"
+    dynamodb_client.get_tradingview_link.assert_awaited_once_with("NKE")
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_by_id_builds_default_tradingview_url():
+    dynamodb_client = AsyncMock()
+    dynamodb_client.get_workflow_by_id.return_value = _make_workflow_data(
+        "wf-2", "NKE:xnys"
+    )
+    dynamodb_client.get_tradingview_link.return_value = None
+
+    service = WorkflowService(dynamodb_client=dynamodb_client)
+    result = await service.get_workflow_by_id("wf-2")
+
+    assert result is not None
+    assert (
+        result.tradingview_url
+        == "https://www.tradingview.com/chart/?symbol=NYSE:NKE"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_by_id_handles_dynamodb_failure():
+    dynamodb_client = AsyncMock()
+    dynamodb_client.get_workflow_by_id.return_value = _make_workflow_data(
+        "wf-3", "MC:xpar"
+    )
+    dynamodb_client.get_tradingview_link.side_effect = RuntimeError("boom")
+
+    service = WorkflowService(dynamodb_client=dynamodb_client)
+    result = await service.get_workflow_by_id("wf-3")
+
+    assert result is not None
+    assert (
+        result.tradingview_url
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:MC"
+    )

--- a/tests/utils/test_tradingview.py
+++ b/tests/utils/test_tradingview.py
@@ -1,0 +1,51 @@
+from utils.tradingview import (
+    build_tradingview_url,
+    build_tradingview_url_from_symbol,
+)
+
+
+def test_build_tradingview_url_maps_known_country_codes():
+    assert (
+        build_tradingview_url("nke", "xnys")
+        == "https://www.tradingview.com/chart/?symbol=NYSE:NKE"
+    )
+    assert (
+        build_tradingview_url("aapl", "xnas")
+        == "https://www.tradingview.com/chart/?symbol=NASDAQ:AAPL"
+    )
+    assert (
+        build_tradingview_url("mc", "xpar")
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:MC"
+    )
+
+
+def test_build_tradingview_url_falls_back_to_euronext_for_unknown_country():
+    assert (
+        build_tradingview_url("foo", "xzzz")
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:FOO"
+    )
+
+
+def test_build_tradingview_url_handles_missing_country_code():
+    assert (
+        build_tradingview_url("foo", None)
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:FOO"
+    )
+    assert (
+        build_tradingview_url("foo", "")
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:FOO"
+    )
+
+
+def test_build_tradingview_url_from_symbol_parses_colon_format():
+    assert (
+        build_tradingview_url_from_symbol("NKE:xnys")
+        == "https://www.tradingview.com/chart/?symbol=NYSE:NKE"
+    )
+
+
+def test_build_tradingview_url_from_symbol_handles_no_colon():
+    assert (
+        build_tradingview_url_from_symbol("FRA40")
+        == "https://www.tradingview.com/chart/?symbol=EURONEXT:FRA40"
+    )

--- a/utils/tradingview.py
+++ b/utils/tradingview.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+EXCHANGE_MAP = {
+    "xpar": "EURONEXT",
+    "xnas": "NASDAQ",
+    "xnys": "NYSE",
+    "xlon": "LSE",
+    "xfra": "FWB",
+    "xetr": "XETR",
+}
+
+_DEFAULT_EXCHANGE = "EURONEXT"
+
+
+def build_tradingview_url(code: str, country_code: Optional[str]) -> str:
+    exchange = EXCHANGE_MAP.get(
+        (country_code or "").lower(), _DEFAULT_EXCHANGE
+    )
+    return (
+        f"https://www.tradingview.com/chart/?symbol={exchange}:{code.upper()}"
+    )
+
+
+def build_tradingview_url_from_symbol(symbol: str) -> str:
+    if ":" in symbol:
+        code, country_code = symbol.split(":", 1)
+    else:
+        code, country_code = symbol, None
+    return build_tradingview_url(code, country_code)


### PR DESCRIPTION
## Summary
- The workflow detail modal now exposes two quick-access links under **Basic Information**: a 📊 TradingView chart link and a 📈 Asset Details link that navigates to the asset page.
- The TradingView URL is resolved server-side — preferring the custom URL stored in `asset_details` and falling back to a default URL built from the index symbol (`xnys→NYSE`, `xnas→NASDAQ`, `xpar→EURONEXT`, `xlon→LSE`, `xfra→FWB`, `xetr→XETR`).
- New `utils/tradingview.py` helper, `WorkflowDetail.tradingview_url` field, and unit tests cover custom URL, default URL, and DynamoDB-failure fallback paths.

## Test plan
- [x] `poetry run pytest tests/utils/test_tradingview.py tests/services/test_workflow_service.py`
- [x] `poetry run mypy utils/tradingview.py services/workflow_service.py model/workflow_api.py`
- [x] `npx tsc --noEmit` in `frontend/`
- [ ] Manual: open a workflow with a custom TradingView URL → 📊 link uses it
- [ ] Manual: open a workflow without a custom URL → 📊 link points to the correct exchange/symbol
- [ ] Manual: click 📈 Asset Details → modal closes and asset page opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)