### PR TITLE
fix: make inclined indicator Point.x tz-aware UTC

### DIFF
--- a/engines/workflow_loader.py
+++ b/engines/workflow_loader.py
@@ -129,13 +129,13 @@ async def load_workflows(force_from_disk: bool = False) -> List[Workflow]:
                 x1 = Point(
                     x=datetime.datetime.strptime(
                         indicator_data["x1"]["x"], "%Y-%m-%d"
-                    ),
+                    ).replace(tzinfo=datetime.UTC),
                     y=indicator_data["x1"]["y"],
                 )
                 x2 = Point(
                     x=datetime.datetime.strptime(
                         indicator_data["x2"]["x"], "%Y-%m-%d"
-                    ),
+                    ).replace(tzinfo=datetime.UTC),
                     y=indicator_data["x2"]["y"],
                 )
                 indicator: Indicator = IndicatorInclined(


### PR DESCRIPTION
## Summary
- `engines/workflow_loader.py` was building `Point.x` for `inclined` indicators with a **naive** datetime (`datetime.strptime`), while `utils.helper.get_date_utc0()` returns a **UTC-aware** datetime.
- Both flowed into `services/indicator_service.py::number_of_day_between_dates`, whose `date1 > date2` comparison crashed the `workflows` command with `can't compare offset-naive and offset-aware datetimes`.
- Attach `tzinfo=datetime.UTC` to `Point.x` at parse time so the comparison stays consistent.

## Test plan
- [x] `poetry run pytest tests/engines/test_inclined_workflow.py` — 12 passed (existing tests use naive datetimes directly and mock `get_date_utc0`, so they're unaffected).
- [ ] Run the `workflows` command against a real config with an inclined-indicator workflow and confirm it no longer raises.