### PR TITLE
fix: correct is_day_open midnight UTC query and Decimal y-values in inclined workflow

### DIFF
--- a/client/saxo_client.py
+++ b/client/saxo_client.py
@@ -564,7 +564,10 @@ class SaxoClient:
     def is_day_open(
         self, saxo_uic: str, asset_type: str, date: datetime
     ) -> bool:
-        data = self.get_historical_data(saxo_uic, asset_type, 1, 1, date)
+        end_of_day = date.replace(hour=23, minute=59, second=0, microsecond=0)
+        data = self.get_historical_data(
+            saxo_uic, asset_type, 1440, 1, end_of_day
+        )
         if len(data) == 0:
             return False
         return data[0]["Time"].day == date.day

--- a/engines/workflow_loader.py
+++ b/engines/workflow_loader.py
@@ -130,13 +130,13 @@ async def load_workflows(force_from_disk: bool = False) -> List[Workflow]:
                     x=datetime.datetime.strptime(
                         indicator_data["x1"]["x"], "%Y-%m-%d"
                     ).replace(tzinfo=datetime.UTC),
-                    y=indicator_data["x1"]["y"],
+                    y=float(indicator_data["x1"]["y"]),
                 )
                 x2 = Point(
                     x=datetime.datetime.strptime(
                         indicator_data["x2"]["x"], "%Y-%m-%d"
                     ).replace(tzinfo=datetime.UTC),
-                    y=indicator_data["x2"]["y"],
+                    y=float(indicator_data["x2"]["y"]),
                 )
                 indicator: Indicator = IndicatorInclined(
                     indicator_data["name"],


### PR DESCRIPTION
## Summary

- **`is_day_open` always returned `False`**: The function queried the Saxo API with `Mode=UpTo` at midnight UTC (`horizon=1`). European markets close at ~16:30 UTC, so the most recent candle at midnight is always from the *previous* day — making every day appear closed. Fixed by querying at 23:59 UTC with `horizon=1440` (daily candles, which are also cached).
- **`number_of_day_between_dates` returned 0**: As a direct consequence of the above, this function counted 0 trading days for any date range, causing `apply_linear_function(0, y0, 0, y1, x)` to call `find_linear_function(0, y0, 0, y1)` which divided by zero (`decimal.DivisionByZero`).
- **DynamoDB `Decimal` type mismatch**: Point `y` values loaded from DynamoDB are `Decimal` objects, not `float`. This caused a `TypeError: unsupported operand type(s) for -: 'decimal.Decimal' and 'float'` in the workflow spread comparisons. Fixed by converting to `float` at the DynamoDB boundary in the loader.

## Test plan

- [x] `poetry run pytest tests/client/test_saxo_client.py tests/services/test_indicator_service.py tests/engines/test_inclined_workflow.py` — all 73 tests pass
- [x] `echo "6" | poetry run k-order workflow run --select-workflow y` — runs BUY INCLINED DAILY FRVIA cleanly with exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)