### PR TITLE
fix: auto-detect US market from exchange code in workflow engine

### DIFF
--- a/engines/workflow_engine.py
+++ b/engines/workflow_engine.py
@@ -174,10 +174,20 @@ class WorkflowEngine:
                         f"Failed to track order for {order[0].name}: {e}"
                     )
 
+    _US_EXCHANGES = (":xnys", ":xnas", ":xase")
+
+    def _get_market(self, workflow: Workflow):
+        if workflow.is_us:
+            return USMarket()
+        code = (workflow.cfd or "").lower()
+        if any(code.endswith(ex) for ex in self._US_EXCHANGES):
+            return USMarket()
+        return EUMarket()
+
     def _get_candles_from_indicator_ut(
         self, workflow: Workflow, indicator: Indicator
     ) -> List[Candle]:
-        market = EUMarket() if workflow.is_us is False else USMarket()
+        market = self._get_market(workflow)
 
         if indicator.ut == UnitTime.W:
             match indicator.name:
@@ -223,9 +233,7 @@ class WorkflowEngine:
             case IndicatorType.BBH | IndicatorType.BBB:
                 count = 21
             case (
-                IndicatorType.POL
-                | IndicatorType.ZONE
-                | IndicatorType.INCLINED
+                IndicatorType.POL | IndicatorType.ZONE | IndicatorType.INCLINED
             ):
                 count = 1
             case _:
@@ -262,7 +270,7 @@ class WorkflowEngine:
         self, workflow: Workflow, candles: List[Candle], run: AbstractWorkflow
     ) -> Optional[tuple[Candle, Order]]:
         run.init_workflow(workflow.conditions[0].indicator, candles)
-        market = EUMarket() if workflow.is_us is False else USMarket()
+        market = self._get_market(workflow)
 
         close_candles = self.candles_service.build_candles(
             code=workflow.cfd,
@@ -343,7 +351,7 @@ class WorkflowEngine:
         self.logger.debug(
             f"get trigger candle for {workflow.cfd} {workflow.trigger.ut}"
         )
-        market = EUMarket() if workflow.is_us is False else USMarket()
+        market = self._get_market(workflow)
         trigger_candles = self.candles_service.build_candles(
             code=workflow.cfd,
             ut=workflow.trigger.ut,


### PR DESCRIPTION
## Summary

- Workflows for US stocks (`NKE:xnys`, `AAPL:xnas`, `GOOG:xnas`) that were missing `is_us: true` in DynamoDB were silently using `EUMarket()` (7–15 UTC) instead of `USMarket()` (13:30–20 UTC)
- This caused `build_candles` to filter out all bars (none fall within EU hours for NYSE/NASDAQ stocks) and return an empty list, skipping the workflow
- Added `_get_market()` helper that auto-detects US market from the exchange suffix (`:xnys`, `:xnas`, `:xase`) as a fallback when `is_us` is not set

## Test plan

- [ ] Run `k-order workflow run --select-workflow y` with input `30` (buy zone lt nike) — workflow completes without "can't retrive close candle" error
- [ ] Verify no regression on EU stock workflows (e.g. CAC40 stocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)