### PR TITLE
perf: load workflow orders on demand instead of eagerly on list

### DIFF
--- a/frontend/src/components/WorkflowTable.tsx
+++ b/frontend/src/components/WorkflowTable.tsx
@@ -24,25 +24,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
     return new Date(dateString).toLocaleDateString();
   };
 
-  const formatRelativeTime = (timestamp: number | null | undefined) => {
-    if (!timestamp) return '-';
-
-    const now = Date.now();
-    const orderTime = timestamp * 1000; // Convert Unix timestamp to milliseconds
-    const diffMs = now - orderTime;
-    const diffMinutes = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMinutes < 1) return 'Just now';
-    if (diffMinutes < 60) return `${diffMinutes}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    // For older than 7 days, show the actual date
-    return new Date(orderTime).toLocaleDateString();
-  };
-
   const getSortIcon = (column: string) => {
     if (sortBy !== column) return null;
     return sortOrder === 'asc' ? ' ↑' : ' ↓';
@@ -83,12 +64,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
                 onClick={() => handleHeaderClick('end_date')}
               >
                 End Date{getSortIcon('end_date')}
-              </th>
-              <th
-                className={onSortChange ? 'sortable' : ''}
-                onClick={() => handleHeaderClick('last_order_timestamp')}
-              >
-                Last Order{getSortIcon('last_order_timestamp')}
               </th>
             </tr>
           </thead>
@@ -133,9 +108,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
                     : '-'}
                 </td>
                 <td>{formatDate(workflow.end_date)}</td>
-                <td className="last-order-cell">
-                  {formatRelativeTime(workflow.last_order_timestamp)}
-                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -116,9 +116,6 @@ export interface WorkflowListItem {
   primary_unit_time: string | null;
   created_at: string;
   updated_at: string;
-  last_order_timestamp?: number | null;
-  last_order_direction?: string | null;
-  last_order_quantity?: number | null;
 }
 
 export interface WorkflowListResponse {

--- a/model/workflow_api.py
+++ b/model/workflow_api.py
@@ -27,15 +27,6 @@ class WorkflowListItem(BaseModel):
     )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    last_order_timestamp: Optional[int] = Field(
-        None, description="Unix timestamp of most recent order placement"
-    )
-    last_order_direction: Optional[str] = Field(
-        None, description="Direction of most recent order (BUY/SELL)"
-    )
-    last_order_quantity: Optional[float] = Field(
-        None, description="Quantity of most recent order"
-    )
 
 
 class IndicatorDetail(BaseModel):

--- a/services/workflow_service.py
+++ b/services/workflow_service.py
@@ -36,21 +36,6 @@ class WorkflowService:
             self._convert_to_list_item(w) for w in workflows_data
         ]
 
-        for workflow_item in workflow_items:
-            last_order = await self._get_last_order_for_workflow(
-                workflow_item.id
-            )
-            if last_order:
-                workflow_item.last_order_timestamp = int(
-                    last_order["placed_at"]
-                )
-                workflow_item.last_order_direction = last_order[
-                    "order_direction"
-                ]
-                workflow_item.last_order_quantity = float(
-                    last_order["order_quantity"]
-                )
-
         total = len(workflow_items)
 
         return WorkflowListResponse(
@@ -268,9 +253,6 @@ class WorkflowService:
             primary_unit_time=primary_unit_time,
             created_at=workflow_data["created_at"],
             updated_at=workflow_data["updated_at"],
-            last_order_timestamp=None,
-            last_order_direction=None,
-            last_order_quantity=None,
         )
 
     def _convert_to_detail(
@@ -416,17 +398,3 @@ class WorkflowService:
             ),
             order_direction=order_data["order_direction"],
         )
-
-    async def _get_last_order_for_workflow(
-        self, workflow_id: str
-    ) -> Dict[str, Any] | None:
-        try:
-            orders = await self.dynamodb_client.get_workflow_orders(
-                workflow_id=workflow_id, limit=1
-            )
-            return orders[0] if orders else None
-        except Exception as e:
-            self.logger.error(
-                f"Error fetching last order for workflow {workflow_id}: {e}"
-            )
-            return None


### PR DESCRIPTION
## Summary
- Removes the N+1 DynamoDB query pattern in `list_workflows`: previously one `get_workflow_orders` call was made per workflow to populate a "Last Order" column in the table
- Drops `last_order_timestamp/direction/quantity` from `WorkflowListItem` (backend model + frontend interface)
- Removes the "Last Order" column from `WorkflowTable`
- Order history is already loaded on demand in `WorkflowDetailModal` when you click a row

## Test plan
- [ ] Workflow list page loads without the repeated `dynamodb.get_workflow_orders completed in Xms` debug logs
- [ ] Clicking a workflow row opens the modal and order history loads correctly
- [ ] No TypeScript type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)