### PR TITLE
perf: load workflow orders on demand instead of eagerly on list

### DIFF
--- a/frontend/src/components/WorkflowTable.tsx
+++ b/frontend/src/components/WorkflowTable.tsx
@@ -24,25 +24,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
     return new Date(dateString).toLocaleDateString();
   };
 
-  const formatRelativeTime = (timestamp: number | null | undefined) => {
-    if (!timestamp) return '-';
-
-    const now = Date.now();
-    const orderTime = timestamp * 1000; // Convert Unix timestamp to milliseconds
-    const diffMs = now - orderTime;
-    const diffMinutes = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMinutes < 1) return 'Just now';
-    if (diffMinutes < 60) return `${diffMinutes}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    // For older than 7 days, show the actual date
-    return new Date(orderTime).toLocaleDateString();
-  };
-
   const getSortIcon = (column: string) => {
     if (sortBy !== column) return null;
     return sortOrder === 'asc' ? ' ↑' : ' ↓';
@@ -83,12 +64,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
                 onClick={() => handleHeaderClick('end_date')}
               >
                 End Date{getSortIcon('end_date')}
-              </th>
-              <th
-                className={onSortChange ? 'sortable' : ''}
-                onClick={() => handleHeaderClick('last_order_timestamp')}
-              >
-                Last Order{getSortIcon('last_order_timestamp')}
               </th>
             </tr>
           </thead>
@@ -133,9 +108,6 @@ function WorkflowTable({ workflows, sortBy, sortOrder, onSortChange, onRowClick 
                     : '-'}
                 </td>
                 <td>{formatDate(workflow.end_date)}</td>
-                <td className="last-order-cell">
-                  {formatRelativeTime(workflow.last_order_timestamp)}
-                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -116,9 +116,6 @@ export interface WorkflowListItem {
   primary_unit_time: string | null;
   created_at: string;
   updated_at: string;
-  last_order_timestamp?: number | null;
-  last_order_direction?: string | null;
-  last_order_quantity?: number | null;
 }
 
 export interface WorkflowListResponse {

--- a/model/workflow_api.py
+++ b/model/workflow_api.py
@@ -27,15 +27,6 @@ class WorkflowListItem(BaseModel):
     )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    last_order_timestamp: Optional[int] = Field(
-        None, description="Unix timestamp of most recent order placement"
-    )
-    last_order_direction: Optional[str] = Field(
-        None, description="Direction of most recent order (BUY/SELL)"
-    )
-    last_order_quantity: Optional[float] = Field(
-        None, description="Quantity of most recent order"
-    )
 
 
 class IndicatorDetail(BaseModel):

--- a/services/workflow_service.py
+++ b/services/workflow_service.py
@@ -36,21 +36,6 @@ class WorkflowService:
             self._convert_to_list_item(w) for w in workflows_data
         ]
 
-        for workflow_item in workflow_items:
-            last_order = await self._get_last_order_for_workflow(
-                workflow_item.id
-            )
-            if last_order:
-                workflow_item.last_order_timestamp = int(
-                    last_order["placed_at"]
-                )
-                workflow_item.last_order_direction = last_order[
-                    "order_direction"
-                ]
-                workflow_item.last_order_quantity = float(
-                    last_order["order_quantity"]
-                )
-
         total = len(workflow_items)
 
         return WorkflowListResponse(
@@ -268,9 +253,6 @@ class WorkflowService:
             primary_unit_time=primary_unit_time,
             created_at=workflow_data["created_at"],
             updated_at=workflow_data["updated_at"],
-            last_order_timestamp=None,
-            last_order_direction=None,
-            last_order_quantity=None,
         )
 
     def _convert_to_detail(
@@ -416,17 +398,3 @@ class WorkflowService:
             ),
             order_direction=order_data["order_direction"],
         )
-
-    async def _get_last_order_for_workflow(
-        self, workflow_id: str
-    ) -> Dict[str, Any] | None:
-        try:
-            orders = await self.dynamodb_client.get_workflow_orders(
-                workflow_id=workflow_id, limit=1
-            )
-            return orders[0] if orders else None
-        except Exception as e:
-            self.logger.error(
-                f"Error fetching last order for workflow {workflow_id}: {e}"
-            )
-            return None

--- a/specs/010-workflow-execution-tracking/data-model.md
+++ b/specs/010-workflow-execution-tracking/data-model.md
@@ -276,25 +276,15 @@ class WorkflowOrderHistoryResponse(BaseModel):
 
 ---
 
-## 5. Updated WorkflowListItem (Existing Model Extension)
+## 5. WorkflowListItem
 
-**Purpose**: Add last order fields to existing workflow list response
+> **Note (PR #608)**: `last_order_timestamp`, `last_order_direction`, and `last_order_quantity` were removed from `WorkflowListItem` and the "Last Order" table column was dropped. Fetching one DynamoDB row per workflow on every list load caused N+1 queries and excessive debug logging. Order history is now loaded on demand inside the detail modal (`WorkflowDetailModal` calls `getWorkflowOrderHistory` when opened).
 
-**Location**: `model/workflow_api.py` (modify existing class)
+**Location**: `model/workflow_api.py`
 
-**New Fields**:
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `last_order_timestamp` | str \| None | No | ISO 8601 timestamp of most recent order |
-| `last_order_direction` | str \| None | No | BUY or SELL |
-| `last_order_quantity` | float \| None | No | Order quantity |
-
-**Modified Pydantic Model**:
+**Current Model**:
 
 ```python
-# model/workflow_api.py (MODIFY existing class)
-
 class WorkflowListItem(BaseModel):
     """Workflow summary for list views."""
 
@@ -308,59 +298,8 @@ class WorkflowListItem(BaseModel):
     end_date: Optional[str] = None
     primary_indicator: Optional[str] = None
     primary_unit_time: Optional[str] = None
-    created_at: str
-    updated_at: str
-
-    # NEW FIELDS (Phase 1):
-    last_order_timestamp: Optional[str] = Field(
-        None,
-        description="ISO 8601 timestamp of most recent order placement"
-    )
-    last_order_direction: Optional[str] = Field(
-        None,
-        description="Direction of last order (BUY or SELL)"
-    )
-    last_order_quantity: Optional[float] = Field(
-        None,
-        gt=0,
-        description="Quantity of last order"
-    )
-```
-
-**Backend Service Logic**:
-
-```python
-# services/workflow_service.py (MODIFY existing method)
-
-def list_workflows(self) -> List[WorkflowListItem]:
-    """List all workflows with last order information."""
-    workflows = self._get_cached_workflows()
-    workflow_items = []
-
-    for wf in workflows:
-        # Get last order for this workflow
-        last_order = self._get_last_order_for_workflow(wf["id"])
-
-        workflow_items.append(
-            WorkflowListItem(
-                id=wf["id"],
-                name=wf["name"],
-                # ... existing fields ...
-                # NEW: Add last order fields
-                last_order_timestamp=last_order.get("placed_at") if last_order else None,
-                last_order_direction=last_order.get("order_direction") if last_order else None,
-                last_order_quantity=last_order.get("order_quantity") if last_order else None,
-            )
-        )
-
-    return workflow_items
-
-def _get_last_order_for_workflow(self, workflow_id: str) -> Optional[Dict[str, Any]]:
-    """Get most recent order for a workflow (cached)."""
-    orders = self.dynamodb_client.get_workflow_orders(workflow_id, limit=1)
-    if orders:
-        return orders[0]
-    return None
+    created_at: datetime
+    updated_at: datetime
 ```
 
 ---

--- a/specs/010-workflow-execution-tracking/quickstart.md
+++ b/specs/010-workflow-execution-tracking/quickstart.md
@@ -336,31 +336,7 @@ interface OrderHistoryResponse {
 
 ### 3.2 Update WorkflowTable Component
 
-**File**: `frontend/src/components/WorkflowTable.tsx`
-
-```typescript
-// Add "Last Order" column after "End Date"
-<th>Last Order</th>
-
-// In data row
-<td>{formatRelativeTime(workflow.last_order_timestamp)}</td>
-
-// Helper function
-const formatRelativeTime = (dateString: string | null) => {
-  if (!dateString) return '-';
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-
-  if (diffMins < 60) return `${diffMins}m ago`;
-  const diffHours = Math.floor(diffMins / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
-};
-```
+> **Note (PR #608)**: The "Last Order" column was removed from `WorkflowTable`. Order history is displayed in the detail modal instead (see §3.3).
 
 ### 3.3 Update WorkflowDetailModal Component
 
@@ -446,9 +422,8 @@ aws dynamodb put-item \
 **Step 2: Verify in UI**
 
 1. Navigate to http://localhost:5173/workflows
-2. Check "Last Order" column shows timestamp
-3. Click workflow row to open detail modal
-4. Verify "Order History" section displays order
+2. Click workflow row to open detail modal
+3. Verify "Order History" section displays order
 
 **Step 3: Test API Endpoints**
 


### PR DESCRIPTION
## Summary
- Removes the N+1 DynamoDB query pattern in `list_workflows` — one `get_workflow_orders` call was made per workflow to populate a "Last Order" column; now fetched on demand when the detail modal opens
- Drops `last_order_timestamp/direction/quantity` from `WorkflowListItem` (backend model + frontend interface)
- Removes the "Last Order" column from `WorkflowTable`
- Updates `specs/010-workflow-execution-tracking` data-model and quickstart to reflect current state

## Test plan
- [ ] Workflow list page loads without repeated `dynamodb.get_workflow_orders completed in Xms` debug logs
- [ ] Clicking a workflow row opens the modal and order history loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)