### PR TITLE
fix: size candle fetch by calendar days to handle off-session runs

### DIFF
--- a/services/candles_service.py
+++ b/services/candles_service.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import math
 from typing import List, Optional, Union
 
 from client.client_helper import map_data_to_candle, map_data_to_candles
@@ -248,18 +249,23 @@ class CandlesService:
         self.logger.info(f"Build candles for {code}, ut: {ut}, date: {date}")
         if market.open_minutes not in [0, 30]:
             raise SaxoException(
-                f"Wrong parameter {market.open_minutes}, we handle only 0 and 30"
+                f"Wrong parameter {market.open_minutes}, "
+                "we handle only 0 and 30"
             )
-        nbr_30m = count * 2 * 3
+        num_h1_per_day = (
+            market.close_hour
+            - market.open_hour
+            + (1 if market.open_minutes == 0 else 0)
+        )
         if ut == UnitTime.H4:
-            nbr_30m = count * 8 * 3
+            candles_per_day = len(market.h4_blocks)
         elif ut == UnitTime.D:
-            num_h1 = (
-                market.close_hour
-                - market.open_hour
-                + (1 if market.open_minutes == 0 else 0)
-            )
-            nbr_30m = count * num_h1 * 2 * 3
+            candles_per_day = 1
+        else:
+            candles_per_day = num_h1_per_day
+        trading_days = math.ceil(count / candles_per_day)
+        calendar_days = math.ceil(trading_days * 7 / 5) + 4
+        nbr_30m = calendar_days * 48
         asset = self.saxo_client.get_asset(code)
         data = self.saxo_client.get_historical_data(
             saxo_uic=asset["Identifier"],
@@ -269,9 +275,7 @@ class CandlesService:
             date=date,
         )
         if len(data) == 0:
-            raise SaxoException(
-                f"No data returned for {code}"
-            )
+            raise SaxoException(f"No data returned for {code}")
         if data[0]["Time"].minute == market.open_minutes:
             data = data[1:]
         candles = self._build_h1_from_30m(data, market, ut)


### PR DESCRIPTION
## Problem

Running `k-order workflow run` with a `combo h1` workflow (e.g. `combo h1 cac40`, input 52) silently skipped the workflow:

```
ERROR - can't retrive close candle for FRA40.I combo h1 cac40
WARNING - Skipping workflow combo h1 cac40: Can't retrive candle
```

The exit code stayed `0` because the `SaxoException` is caught and logged as a warning, so the failure was invisible unless run with `LOG_LEVEL=DEBUG`.

## Root cause

`CandlesService.build_candles` builds H1 candles from 30-minute bars, keeping only in-session bars (hours 7–15 UTC for the EU market). The over-fetch was sized as a fixed `count * 2 * 3` — just **6 bars** for `count=1`.

But the Saxo API returns the most recent *calendar* bars first, and `FRA40.I` is an index CFD that trades ~24h. When the command runs **outside the cash session** (evenings, before open, over weekends), those few most-recent bars are all off-session and get filtered out, leaving `build_candles` empty. During the session it happened to work — hence the intermittent failure.

## Fix

Size the fetch by **full calendar days** (48 thirty-min bars/day) instead of in-session bars, with a weekend/holiday buffer, so in-session bars are always reachable regardless of when the command runs:

```python
trading_days  = ceil(count / candles_per_day)
calendar_days = ceil(trading_days * 7 / 5) + 4
nbr_30m       = calendar_days * 48
```

`candles_per_day` is derived per target UT (`len(h4_blocks)` for H4, `1` for D, `num_h1_per_day` for H1).

## Verification

- Simulated evening (19:56 UTC) and pre-open/post-weekend runs — both now return the correct last in-session H1 candle (previously returned 0).
- `k-order workflow run --select-workflow y` with input 52 → exit 0, no errors/warnings.
- All 86 candle/workflow tests pass; `black` / `isort` / `flake8` / `mypy` clean.