### PR TITLE
docs: add spec 023 for alert triage & synthesis agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ Examples:
 - N/A — purely in-memory component state (`strategy`, `signal`) (020-saxo-reporting)
 - Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (existing `api/` app), Python standard library `csv` module, existing `client/gsheet_client.py` (Google Sheets API via `googleapiclient`), Axios + React Router DOM v7+ (frontend, existing `frontend/src/services/api.ts`) (022-trade-republic-report)
 - N/A — per spec (FR-010), uploaded transactions are held only for the current browser session (React state); no database table or file store is introduced (022-trade-republic-report)
+- Python 3.12 (backend), TypeScript 5+ / React 19+ (frontend) + `anthropic` SDK (NEW, backend), FastAPI + Pydantic v2, Click, `aioboto3` (DynamoDB), `slack_sdk`, `cachetools` (TTLCache); React Router DOM v7+, Vite 7+, Axios (frontend) (023-alert-triage)
+- AWS DynamoDB — new `alert_digests` table (hash_key `run_date` String, range_key `created_at` Number, **no TTL**); existing `alerts` table unchanged (023-alert-triage)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/specs/023-alert-triage/checklists/requirements.md
+++ b/specs/023-alert-triage/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Alert Triage & Synthesis Agent
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately keeps implementation choices (dedicated Anthropic client, DynamoDB `alert_digests` table, specific model id, React view) OUT of the requirements per speckit convention — those belong in `plan.md`. The user has already agreed to those technical decisions in discussion; they will be captured at the `/speckit.plan` stage.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/023-alert-triage/contracts/alert-digests.openapi.yaml
+++ b/specs/023-alert-triage/contracts/alert-digests.openapi.yaml
@@ -1,0 +1,124 @@
+openapi: 3.1.0
+info:
+  title: Alert Digests API
+  version: 1.0.0
+  description: >
+    Read API for persisted daily alert-triage briefs (digests). Produced by the
+    daily alerting scan's triage step and retained indefinitely. Read-only:
+    digests are created by the scan, not via HTTP.
+servers:
+  - url: http://localhost:8000
+paths:
+  /api/alert-digests:
+    get:
+      summary: List alert digests, newest-first
+      operationId: listAlertDigests
+      tags: [alert-digests]
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 365
+          description: Maximum number of digests to return (default all; small table).
+      responses:
+        "200":
+          description: Digests ordered by created_at descending
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertDigestListResponse"
+        "403":
+          description: Not in an AWS context (DynamoDB unavailable)
+  /api/alert-digests/{run_date}:
+    get:
+      summary: Get the brief for a specific run date
+      operationId: getAlertDigest
+      tags: [alert-digests]
+      parameters:
+        - name: run_date
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: Run date in YYYY-MM-DD. Returns the latest run for that day.
+      responses:
+        "200":
+          description: The full ranked brief for the run date
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertDigestResponse"
+        "404":
+          description: No digest exists for that run date
+        "403":
+          description: Not in an AWS context (DynamoDB unavailable)
+components:
+  schemas:
+    Conviction:
+      type: string
+      enum: [high, watch, noise]
+    TriagedAssetResponse:
+      type: object
+      required: [asset_code, asset_description, exchange, conviction, patterns]
+      properties:
+        asset_code: { type: string, example: SAN }
+        asset_description: { type: string, example: Sanofi }
+        exchange: { type: string, example: saxo }
+        country_code:
+          type: [string, "null"]
+          example: xpar
+        conviction: { $ref: "#/components/schemas/Conviction" }
+        rank:
+          type: [integer, "null"]
+          minimum: 1
+          example: 1
+        rationale:
+          type: string
+          example: "double top + MA50 rejection, slope -2.3% (trend agrees)"
+        patterns:
+          type: array
+          items: { type: string }
+          example: [double_top, mm50_touch]
+        ma50_slope:
+          type: [number, "null"]
+          example: -2.3
+    AlertDigestResponse:
+      type: object
+      required: [run_date, created_at, summary, counts, triaged_assets, fallback_used, model]
+      properties:
+        run_date: { type: string, example: "2026-07-16" }
+        created_at: { type: integer, example: 1768579200 }
+        summary:
+          type: string
+          example: "28 signals across 22 stocks — 3 high, 5 watch."
+        counts:
+          type: object
+          additionalProperties: { type: integer }
+          example: { high: 3, watch: 5, noise: 20 }
+        triaged_assets:
+          type: array
+          items: { $ref: "#/components/schemas/TriagedAssetResponse" }
+        fallback_used: { type: boolean, example: false }
+        model: { type: string, example: "claude-sonnet-5" }
+    AlertDigestSummary:
+      type: object
+      required: [run_date, created_at, summary, counts, fallback_used]
+      properties:
+        run_date: { type: string }
+        created_at: { type: integer }
+        summary: { type: string }
+        counts:
+          type: object
+          additionalProperties: { type: integer }
+        fallback_used: { type: boolean }
+    AlertDigestListResponse:
+      type: object
+      required: [digests]
+      properties:
+        digests:
+          type: array
+          items: { $ref: "#/components/schemas/AlertDigestSummary" }

--- a/specs/023-alert-triage/contracts/alert-digests.openapi.yaml
+++ b/specs/023-alert-triage/contracts/alert-digests.openapi.yaml
@@ -11,9 +11,13 @@ servers:
 paths:
   /api/alert-digests:
     get:
-      summary: List alert digests, newest-first
+      summary: List recent alert digests (full), newest-first
       operationId: listAlertDigests
       tags: [alert-digests]
+      description: >
+        Returns full digests (including per-asset payloads) for the recent
+        window, newest-first, so the homepage carousel can page client-side
+        without per-day round-trips. The table holds ~1 item/day.
       parameters:
         - name: limit
           in: query
@@ -104,21 +108,11 @@ components:
           items: { $ref: "#/components/schemas/TriagedAssetResponse" }
         fallback_used: { type: boolean, example: false }
         model: { type: string, example: "claude-sonnet-5" }
-    AlertDigestSummary:
-      type: object
-      required: [run_date, created_at, summary, counts, fallback_used]
-      properties:
-        run_date: { type: string }
-        created_at: { type: integer }
-        summary: { type: string }
-        counts:
-          type: object
-          additionalProperties: { type: integer }
-        fallback_used: { type: boolean }
     AlertDigestListResponse:
       type: object
       required: [digests]
       properties:
         digests:
           type: array
-          items: { $ref: "#/components/schemas/AlertDigestSummary" }
+          description: Full digests for the recent window, newest-first.
+          items: { $ref: "#/components/schemas/AlertDigestResponse" }

--- a/specs/023-alert-triage/data-model.md
+++ b/specs/023-alert-triage/data-model.md
@@ -78,7 +78,7 @@ Field names mirror the domain models exactly so the frontend TS interfaces match
 
 - `TriagedAssetResponse`: `asset_code, asset_description, exchange, country_code, conviction, rank, rationale, patterns: List[str], ma50_slope`
 - `AlertDigestResponse`: `run_date, created_at, summary, counts, triaged_assets: List[TriagedAssetResponse], fallback_used, model`
-- `AlertDigestListResponse`: `digests: List[AlertDigestSummary]` where `AlertDigestSummary` = `run_date, created_at, summary, counts, fallback_used` (no per-asset payload, for the list view).
+- `AlertDigestListResponse`: `digests: List[AlertDigestResponse]` — the list endpoint returns **full** digests (with per-asset payloads) for the recent window so the homepage carousel pages client-side without extra calls. The table is ~1 item/day, so payload size is not a concern.
 
 ## State / lifecycle
 

--- a/specs/023-alert-triage/data-model.md
+++ b/specs/023-alert-triage/data-model.md
@@ -1,0 +1,85 @@
+# Phase 1 Data Model: Alert Triage & Synthesis Agent
+
+## Domain models (`model/`)
+
+### `Conviction` (enum, `model/enum.py`)
+
+`EnumWithGetValue`, mirroring existing enums (no hardcoded tier strings anywhere).
+
+| Member | Value |
+|--------|-------|
+| `HIGH`  | `"high"` |
+| `WATCH` | `"watch"` |
+| `NOISE` | `"noise"` |
+
+### `TriagedAsset` (dataclass, `model/__init__.py`)
+
+One asset's entry inside a brief.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `asset_code` | `str` | e.g. `"SAN"` |
+| `asset_description` | `str` | Human-readable name |
+| `exchange` | `str` | **Explicit** source exchange (`"saxo"` / `"binance"`) — never inferred from `country_code` (Constitution V) |
+| `country_code` | `Optional[str]` | May be absent for a Saxo asset |
+| `conviction` | `Conviction` | Tier |
+| `rank` | `Optional[int]` | 1-based within high+watch; `None` for noise |
+| `rationale` | `str` | One-line explanation (may be empty for noise) |
+| `patterns` | `List[AlertType]` | Distinct patterns that fired on this asset |
+| `ma50_slope` | `Optional[float]` | Trend context used in ranking (from `alert.data`) |
+
+### `AlertDigest` (dataclass, `model/__init__.py`)
+
+The synthesized output of one scan run.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `run_date` | `str` | `YYYY-MM-DD` — hash key |
+| `created_at` | `int` | epoch seconds — range key, orders same-day runs |
+| `summary` | `str` | Overall one/two-line brief headline |
+| `counts` | `Dict[str, int]` | `{"high": n, "watch": n, "noise": n}` |
+| `triaged_assets` | `List[TriagedAsset]` | Ordered; high+watch ranked, noise unranked |
+| `fallback_used` | `bool` | `True` when produced by deterministic fallback (FR-012) |
+| `model` | `str` | Reasoning model id used, or `"deterministic-fallback"` |
+
+**Validation / invariants**
+- Every alerting asset appears in exactly one tier (FR-002).
+- `rank` is unique and contiguous across high+watch, ordered by conviction then agent order (FR-003).
+- Assets not in the scan are never present; scan assets are never dropped (FR-018) — reconciled in the service.
+- `counts` values sum to `len(triaged_assets)`.
+
+## Persistence (`alert_digests` DynamoDB table)
+
+| Attribute | Type | Role |
+|-----------|------|------|
+| `run_date` | S | Hash key (`YYYY-MM-DD`) |
+| `created_at` | N | Range key (epoch seconds) |
+| `summary` | S | |
+| `counts` | M | |
+| `triaged_assets` | L(M) | Each map = one `TriagedAsset` (floats → Decimal on write) |
+| `fallback_used` | BOOL | |
+| `model` | S | |
+
+- `billing_mode=PAY_PER_REQUEST`, `stream_enabled=True`, `stream_view_type=NEW_AND_OLD_IMAGES`.
+- **No TTL attribute** — deliberate, history is permanent (FR-009, SC-006).
+- Writes go through `DynamoDBClient.store_alert_digest`; floats converted via existing `_convert_floats_to_decimal`.
+
+## `DynamoDBClient` methods (`client/aws_client.py`)
+
+Public methods (no `_` prefix — called from service/CLI layers; Constitution I):
+
+- `async store_alert_digest(digest: AlertDigest) -> Dict[str, Any]` — `put_item` on `alert_digests`.
+- `async get_alert_digests(limit: Optional[int] = None) -> List[Dict[str, Any]]` — scan, sorted by `created_at` desc (newest-first). Small table (≈1 item/day).
+- `async get_alert_digest(run_date: str) -> Optional[Dict[str, Any]]` — query by `run_date`, return latest `created_at` for that day.
+
+## API models (`api/models/alert_digest.py`, Pydantic v2)
+
+Field names mirror the domain models exactly so the frontend TS interfaces match 1:1 (Constitution API Contract Standards).
+
+- `TriagedAssetResponse`: `asset_code, asset_description, exchange, country_code, conviction, rank, rationale, patterns: List[str], ma50_slope`
+- `AlertDigestResponse`: `run_date, created_at, summary, counts, triaged_assets: List[TriagedAssetResponse], fallback_used, model`
+- `AlertDigestListResponse`: `digests: List[AlertDigestSummary]` where `AlertDigestSummary` = `run_date, created_at, summary, counts, fallback_used` (no per-asset payload, for the list view).
+
+## State / lifecycle
+
+`AlertDigest` is immutable once written — one record per run, never updated. History accrues append-only. No deletes in scope.

--- a/specs/023-alert-triage/plan.md
+++ b/specs/023-alert-triage/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Alert Triage & Synthesis Agent
+
+**Branch**: `023-alert-triage` | **Date**: 2026-07-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/023-alert-triage/spec.md`
+
+## Summary
+
+After the daily French-stock alerting scan runs its deterministic pattern detectors and stores raw `Alert` objects, a new **triage agent** reasons over the day's collected alerts and produces a ranked **daily brief**: every alerting asset is assigned a conviction tier (high / watch / noise), the high/watch assets are ranked and given a one-line rationale, driven by pattern **confluence** (multiple patterns on one asset) and **`ma50_slope` trend alignment** (already attached to each alert's `data`). The brief is persisted to a new **no-TTL DynamoDB table `alert_digests`** for indefinite history, exposed via a new **API** (list newest-first, get by run date), and surfaced in a new **React "Daily Brief" page**. Slack is demoted from a per-indicator firehose to a short digest notification linking into the app.
+
+Technical approach: the Anthropic SDK is wrapped in a **new dedicated `client/anthropic_client.py`** (Client Layer) constructed from `Configuration`, owning retries/errors/logging and raising a new `AnthropicException`; a new `services/alert_triage_service.py` (Service Layer) depends on the client — never the SDK — builds the payload, parses the response, and falls back to a deterministic ranking on any failure so the scan never breaks. Model is config-driven (`claude-sonnet-5` default). Detection logic and the order/workflow path are untouched.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 (backend), TypeScript 5+ / React 19+ (frontend)
+**Primary Dependencies**: `anthropic` SDK (NEW, backend), FastAPI + Pydantic v2, Click, `aioboto3` (DynamoDB), `slack_sdk`, `cachetools` (TTLCache); React Router DOM v7+, Vite 7+, Axios (frontend)
+**Storage**: AWS DynamoDB — new `alert_digests` table (hash_key `run_date` String, range_key `created_at` Number, **no TTL**); existing `alerts` table unchanged
+**Testing**: pytest + `unittest.mock` (backend); frontend has no test framework configured (per constitution)
+**Target Platform**: AWS Lambda (scan/triage via `lambda_function.py` `alerting` command) + FastAPI API server; browser (React SPA)
+**Project Type**: Web (backend + API + frontend) with a Lambda-invoked CLI/service path
+**Performance Goals**: One Claude call per daily scan over a compact per-asset summary payload (no candle arrays); comfortably within the Lambda timeout. No per-asset model calls.
+**Constraints**: Triage/persistence failure MUST NOT break the scan, lose raw alerts, or affect the order/workflow path (FR-013). Model swappable via config with zero code change (FR-017).
+**Scale/Scope**: ~20–40 alerting assets per daily run; one brief per run; history retained indefinitely.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | How this plan complies |
+|-----------|--------|------------------------|
+| **I. Layered Architecture Discipline** | ✅ PASS | SDK lives ONLY in `client/anthropic_client.py`; `TriageAgent` service receives the client via constructor DI and never touches the SDK. New DynamoDB access goes through `DynamoDBClient` **methods** (`store_alert_digest`, `get_alert_digests`, `get_alert_digest`) — no `client.dynamodb.Table()` from services. API router is thin, delegates to `AlertDigestService`. Frontend calls go through `services/api.ts` only. Public methods have NO `_` prefix; internal helpers keep `_`. |
+| **II. Clean Code First** | ✅ PASS | No speculative abstraction — one client method (`complete_json`), one service. New `Conviction` enum instead of hardcoded tier strings. No explanatory inline comments. |
+| **III. Configuration-Driven Design** | ✅ PASS | `anthropic_api_key` in `secrets.yml` (gitignored); `anthropic_model` in `config.yml` defaulting to `claude-sonnet-5`; timeouts/retries in config. No hardcoded model id or endpoint. |
+| **IV. Safe Deployment Practices** | ✅ PASS | New table added via Pulumi (`pulumi/dynamodb.py` + `__main__.py`); no manual console changes. Conventional commits. |
+| **V. Domain Model Integrity** | ✅ PASS | New `AlertDigest`/`TriagedAsset` models carry an explicit `exchange` field per asset (never inferred from `country_code`). Candle ordering untouched (feature reads pre-computed `ma50_slope`, does not recompute). Models live in `model/` with no external deps. |
+
+**Planning Requirement**: This plan is presented for human validation before implementation (constitution Development Standards). No code written until approved.
+
+**Result**: PASS — no violations, Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-alert-triage/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── alert-digests.openapi.yaml
+├── checklists/
+│   └── requirements.md  # from /speckit.specify
+└── tasks.md             # /speckit.tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+model/
+├── __init__.py                  # ADD: AlertDigest, TriagedAsset dataclasses (+ exports)
+└── enum.py                      # ADD: Conviction (HIGH/WATCH/NOISE) enum
+
+client/
+└── anthropic_client.py          # NEW: AnthropicClient (wraps SDK, complete_json, retries/errors)
+
+services/
+└── alert_triage_service.py      # NEW: TriageAgent (payload build, parse, deterministic fallback)
+
+client/aws_client.py             # ADD methods: store_alert_digest, get_alert_digests, get_alert_digest
+
+saxo_order/commands/alerting.py  # EDIT: after scan, build+store digest, post concise Slack digest
+
+utils/
+├── configuration.py             # ADD: anthropic_api_key, anthropic_model properties
+└── exception.py                 # ADD: AnthropicException
+
+pulumi/
+├── dynamodb.py                  # ADD: alert_digests_table()
+└── __main__.py                  # EDIT: instantiate + grant + export new table
+
+api/
+├── main.py                      # EDIT: include_router(alert_digest.router)
+├── routers/alert_digest.py      # NEW: GET /api/alert-digests , GET /api/alert-digests/{run_date}
+├── services/alert_digest_service.py  # NEW: read/format digests (TTLCache like AlertingService)
+└── models/alert_digest.py       # NEW: Pydantic response models
+
+frontend/src/
+├── pages/DailyBrief.tsx + .css  # NEW: ranked brief view + run-date history selector
+├── services/api.ts              # EDIT: alertDigestService (list, getByRunDate)
+├── components/Sidebar.tsx       # EDIT: nav entry "Daily Brief"
+└── App.tsx                      # EDIT: <Route path="/daily-brief" ...>
+
+pyproject.toml                   # EDIT: add anthropic dependency
+
+tests/
+├── client/test_anthropic_client.py         # NEW (parse + error mapping; mock transport)
+├── services/test_alert_triage_service.py   # NEW (payload build, tiering, fallback path)
+├── client/test_aws_client_alert_digests.py # NEW (store/get round-trip, float→Decimal)
+└── api/test_alert_digest_service.py         # NEW (list newest-first, get by run_date)
+```
+
+**Structure Decision**: Web + Lambda layout matching the existing `workflow_orders` precedent end-to-end (new DynamoDB table → `DynamoDBClient` methods → API router/service/model → React page + sidebar route). The only new architectural element is the `AnthropicClient` in the Client Layer; everything else follows established patterns.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.
+
+## Phase Handoff
+
+- Phase 0 → `research.md`: resolves model/SDK, JSON-output strategy, table key design, fallback algorithm, config plumbing.
+- Phase 1 → `data-model.md`, `contracts/alert-digests.openapi.yaml`, `quickstart.md`, agent context update.
+- Phase 2 (`/speckit.tasks`) → `tasks.md` (NOT produced by this command).

--- a/specs/023-alert-triage/plan.md
+++ b/specs/023-alert-triage/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-After the daily French-stock alerting scan runs its deterministic pattern detectors and stores raw `Alert` objects, a new **triage agent** reasons over the day's collected alerts and produces a ranked **daily brief**: every alerting asset is assigned a conviction tier (high / watch / noise), the high/watch assets are ranked and given a one-line rationale, driven by pattern **confluence** (multiple patterns on one asset) and **`ma50_slope` trend alignment** (already attached to each alert's `data`). The brief is persisted to a new **no-TTL DynamoDB table `alert_digests`** for indefinite history, exposed via a new **API** (list newest-first, get by run date), and surfaced in a new **React "Daily Brief" page**. Slack is demoted from a per-indicator firehose to a short digest notification linking into the app.
+After the daily French-stock alerting scan runs its deterministic pattern detectors and stores raw `Alert` objects, a new **triage agent** reasons over the day's collected alerts and produces a ranked **daily brief**: every alerting asset is assigned a conviction tier (high / watch / noise), the high/watch assets are ranked and given a one-line rationale, driven by pattern **confluence** (multiple patterns on one asset) and **`ma50_slope` trend alignment** (already attached to each alert's `data`). The brief is persisted to a new **no-TTL DynamoDB table `alert_digests`** for indefinite history, exposed via a new **API** (list recent digests newest-first, get by run date), and surfaced as a **Daily Brief section on the existing homepage** with a **carousel** to page back through recent run dates. Slack is demoted from a per-indicator firehose to a short digest notification linking into the app.
 
 Technical approach: the Anthropic SDK is wrapped in a **new dedicated `client/anthropic_client.py`** (Client Layer) constructed from `Configuration`, owning retries/errors/logging and raising a new `AnthropicException`; a new `services/alert_triage_service.py` (Service Layer) depends on the client — never the SDK — builds the payload, parses the response, and falls back to a deterministic ranking on any failure so the scan never breaks. Model is config-driven (`claude-sonnet-5` default). Detection logic and the order/workflow path are untouched.
 
@@ -81,15 +81,15 @@ pulumi/
 
 api/
 ├── main.py                      # EDIT: include_router(alert_digest.router)
-├── routers/alert_digest.py      # NEW: GET /api/alert-digests , GET /api/alert-digests/{run_date}
+├── routers/alert_digest.py      # NEW: GET /api/alert-digests (full recent digests) , GET /api/alert-digests/{run_date}
 ├── services/alert_digest_service.py  # NEW: read/format digests (TTLCache like AlertingService)
 └── models/alert_digest.py       # NEW: Pydantic response models
 
 frontend/src/
-├── pages/DailyBrief.tsx + .css  # NEW: ranked brief view + run-date history selector
-├── services/api.ts              # EDIT: alertDigestService (list, getByRunDate)
-├── components/Sidebar.tsx       # EDIT: nav entry "Daily Brief"
-└── App.tsx                      # EDIT: <Route path="/daily-brief" ...>
+├── components/DailyBrief.tsx + .css          # NEW: brief section embedded in Home
+├── components/DailyBriefCarousel.tsx + .css  # NEW: reverse-chronological day pager
+├── components/Home.tsx          # EDIT: render DailyBrief section above homepage grid
+└── services/api.ts              # EDIT: alertDigestService (listRecent, getByRunDate)
 
 pyproject.toml                   # EDIT: add anthropic dependency
 
@@ -100,7 +100,7 @@ tests/
 └── api/test_alert_digest_service.py         # NEW (list newest-first, get by run_date)
 ```
 
-**Structure Decision**: Web + Lambda layout matching the existing `workflow_orders` precedent end-to-end (new DynamoDB table → `DynamoDBClient` methods → API router/service/model → React page + sidebar route). The only new architectural element is the `AnthropicClient` in the Client Layer; everything else follows established patterns.
+**Structure Decision**: Web + Lambda layout matching the existing `workflow_orders` precedent for the backend (new DynamoDB table → `DynamoDBClient` methods → API router/service/model). The front end diverges from that precedent deliberately: instead of a standalone page + route + sidebar entry, the brief is a **section embedded in the existing `Home` component** with a carousel to page recent run dates — zero-click access to the day's top signals and history navigation for free. The list endpoint returns full recent digests so the carousel pages client-side without per-day round-trips. The only new architectural element is the `AnthropicClient` in the Client Layer; everything else follows established patterns.
 
 ## Complexity Tracking
 

--- a/specs/023-alert-triage/quickstart.md
+++ b/specs/023-alert-triage/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: Alert Triage & Synthesis Agent
+
+## Prerequisites
+
+- `poetry install` (adds the new `anthropic` dependency)
+- `secrets.yml` contains `anthropic_api_key: <key>`
+- `config.yml` may contain `anthropic_model: claude-sonnet-5` (this is the default if omitted)
+- AWS credentials configured (DynamoDB `alert_digests` table deployed via Pulumi)
+
+## Deploy the new table
+
+```bash
+cd pulumi && pulumi up      # creates the alert_digests table + IAM grants
+```
+
+## Run the daily scan locally (produces + stores a brief)
+
+```bash
+# Single asset (fast smoke test)
+poetry run k-order alerting --code SAN --country-code xpar
+
+# Full French-stock scan (as the Lambda 'alerting' command does)
+poetry run python -c "import asyncio; from saxo_order.commands.alerting import run_alerting; asyncio.run(run_alerting('config.yml'))"
+```
+
+Expected: scan runs detection as before, then a single **Daily Brief** is written to `alert_digests` and a concise digest is posted to Slack `#stock` with a link to `/daily-brief`.
+
+## Verify the fallback path
+
+Temporarily set an invalid `anthropic_api_key` (or disconnect network) and re-run: the scan still completes, a brief is still stored with `fallback_used: true` and `model: "deterministic-fallback"`, raw alerts are still saved, and no order/workflow behavior changes.
+
+## Read via API
+
+```bash
+poetry run python run_api.py          # http://localhost:8000
+
+curl http://localhost:8000/api/alert-digests            # list newest-first
+curl http://localhost:8000/api/alert-digests/2026-07-16 # single brief by run date
+```
+
+## Frontend
+
+```bash
+cd frontend && npm run dev            # http://localhost:5173/daily-brief
+```
+
+The Daily Brief page shows the latest brief with conviction badges (🔴 high / 🟡 watch) and a run-date selector to page back through history.
+
+## Test
+
+```bash
+poetry run pytest tests/services/test_alert_triage_service.py \
+                  tests/client/test_anthropic_client.py \
+                  tests/client/test_aws_client_alert_digests.py \
+                  tests/api/test_alert_digest_service.py
+poetry run black . && poetry run isort . && poetry run mypy . && poetry run flake8
+```
+
+## Acceptance smoke checklist
+
+- [ ] Multi-pattern asset ranks above single-pattern asset (US1 / SC-007)
+- [ ] Reasoning failure → fallback brief, scan intact, raw alerts stored (US2 / SC-003, SC-004)
+- [ ] `GET /api/alert-digests` newest-first; `GET /{run_date}` returns full brief (US3)
+- [ ] Slack gets one concise digest + link, not the raw firehose (US4 / SC-001)
+- [ ] No-alerts run still records a brief and Slack says "no signals" (FR-019)

--- a/specs/023-alert-triage/quickstart.md
+++ b/specs/023-alert-triage/quickstart.md
@@ -23,7 +23,7 @@ poetry run k-order alerting --code SAN --country-code xpar
 poetry run python -c "import asyncio; from saxo_order.commands.alerting import run_alerting; asyncio.run(run_alerting('config.yml'))"
 ```
 
-Expected: scan runs detection as before, then a single **Daily Brief** is written to `alert_digests` and a concise digest is posted to Slack `#stock` with a link to `/daily-brief`.
+Expected: scan runs detection as before, then a single **Daily Brief** is written to `alert_digests` and a concise digest is posted to Slack `#stock` with a link to the homepage `/`.
 
 ## Verify the fallback path
 
@@ -41,10 +41,10 @@ curl http://localhost:8000/api/alert-digests/2026-07-16 # single brief by run da
 ## Frontend
 
 ```bash
-cd frontend && npm run dev            # http://localhost:5173/daily-brief
+cd frontend && npm run dev            # http://localhost:5173/
 ```
 
-The Daily Brief page shows the latest brief with conviction badges (🔴 high / 🟡 watch) and a run-date selector to page back through history.
+The homepage shows a Daily Brief section with the latest brief — conviction badges (🔴 high / 🟡 watch), noise as a count — and a carousel to page back through recent run dates.
 
 ## Test
 
@@ -60,6 +60,6 @@ poetry run black . && poetry run isort . && poetry run mypy . && poetry run flak
 
 - [ ] Multi-pattern asset ranks above single-pattern asset (US1 / SC-007)
 - [ ] Reasoning failure → fallback brief, scan intact, raw alerts stored (US2 / SC-003, SC-004)
-- [ ] `GET /api/alert-digests` newest-first; `GET /{run_date}` returns full brief (US3)
+- [ ] `GET /api/alert-digests` returns full recent digests newest-first; homepage carousel pages back through them (US3)
 - [ ] Slack gets one concise digest + link, not the raw firehose (US4 / SC-001)
 - [ ] No-alerts run still records a brief and Slack says "no signals" (FR-019)

--- a/specs/023-alert-triage/research.md
+++ b/specs/023-alert-triage/research.md
@@ -1,0 +1,57 @@
+# Phase 0 Research: Alert Triage & Synthesis Agent
+
+All Technical Context items were resolvable from the existing codebase and prior design discussion; there are no open `NEEDS CLARIFICATION` markers. This document records the decisions and the alternatives weighed.
+
+## R1. Reasoning model
+
+- **Decision**: `claude-sonnet-5`, set in `config.yml` as `anthropic_model`, overridable without code change.
+- **Rationale**: The task runs once per day over a small structured payload (~20–40 assets, no candle arrays), so cost and latency are negligible for any model. The value of the feature is judgment quality — confluence weighting, trend alignment, and separating signal from noise in a rationale a trader will trust. At once-daily cadence a higher-capability model is effectively free, and a weak brief is worse than none because trust erodes.
+- **Alternatives considered**: `claude-haiku-4-5` — right choice only if this were high-volume or latency-critical (it is neither); kept reachable via config for A/B comparison and downgrade.
+
+## R2. Anthropic access as a dedicated Client Layer member
+
+- **Decision**: New `client/anthropic_client.py` exposing `AnthropicClient(configuration)` with a single public method `complete_json(system, user_payload) -> dict`. The `anthropic` SDK is imported **only** here. Failures raise a new `AnthropicException` (in `utils/exception.py`, mirroring `SaxoException`).
+- **Rationale**: Constitution Principle I requires external integrations to live in the Client Layer and services to depend on client **methods**, not SDK internals. This mirrors `SaxoClient`/`GSheetClient`: constructed from `Configuration`, owns retries/backoff/logging, returns parsed domain data. Keeps the triage service testable by mocking one method rather than the SDK.
+- **Alternatives considered**: Instantiating the SDK inside `TriageAgent` — rejected, violates layering and couples the service to the vendor SDK.
+
+## R3. Structured JSON output from the model
+
+- **Decision**: `complete_json` sends a system prompt describing the ranking rules and a user payload of per-asset facts, instructs a strict JSON schema, extracts the JSON from the response, and `json.loads` it. Invalid/ò unparseable output raises `AnthropicException`; the service treats that as a fallback trigger.
+- **Rationale**: Deterministic downstream formatting requires structured output. Parsing/validation belongs in the boundary (client returns a `dict`; service validates shape into `TriagedAsset`s). Any parse failure is funneled into the same fallback path as a transport failure — one recovery path (FR-011).
+- **Alternatives considered**: Free-form text posted directly to Slack — rejected, not parseable, not storable as structured history, not reconcilable against detected alerts (FR-018).
+
+## R4. Persistence — `alert_digests` table
+
+- **Decision**: New DynamoDB table `alert_digests`, `hash_key="run_date"` (String, `YYYY-MM-DD`), `range_key="created_at"` (Number, epoch seconds), `PAY_PER_REQUEST`, streams on, **no TTL**. Defined in `pulumi/dynamodb.py` and registered in `pulumi/__main__.py` (instantiate + IAM grant + export), mirroring `workflow_orders_table()`.
+- **Rationale**: Run date is the natural key; the range key retains multiple same-day runs distinctly and orders by run time (FR-010). No TTL is deliberate — history must outlive the 7-day raw-alert expiry so "was the agent right?" review is possible (FR-009, SC-006). `Query` by `run_date` fetches a single day; `Scan` (small table, one item/day) lists history.
+- **Alternatives considered**: (a) Annotating each existing `alert.data` with triage info — rejected: dies with the alerts' 7-day TTL, no cross-run digest, no single-brief entity. (b) A TTL on digests — rejected: contradicts the history requirement.
+
+## R5. Deterministic fallback ranking
+
+- **Decision**: When reasoning fails, rank assets by a pure function of the raw signals: primary key = number of distinct patterns fired on the asset (confluence), secondary key = `abs(ma50_slope)` (trend strength). Tier mapping: assets with ≥2 patterns → high; exactly 1 pattern with meaningful |slope| → watch; the remainder → noise. Rationale strings are templated (e.g. "3 patterns, slope -2.3%"). The brief is flagged `fallback_used=true` (FR-012).
+- **Rationale**: Must be side-effect-free, fast, and dependency-free so it always succeeds inside the scan's time budget (FR-011, FR-013). Uses only data already on the `Alert` objects. Thresholds live in config, not hardcoded.
+- **Alternatives considered**: No fallback (skip the brief on failure) — rejected: violates guaranteed-delivery (SC-003) and the "never break the scan" requirement.
+
+## R6. Wiring into the scan without touching detection or orders
+
+- **Decision**: In `run_alerting` (`saxo_order/commands/alerting.py`), collect the `Alert` objects already produced per asset into a run-level list, then after the existing per-asset storage loop call `TriageAgent.synthesize(all_alerts)` → `DynamoDBClient.store_alert_digest(digest)` → post the concise Slack digest. The raw-alert `store_alerts` calls and the entire order/workflow path are unchanged. The whole triage+notify block is wrapped so any exception is logged and swallowed (raw alerts already persisted).
+- **Rationale**: Detection is the deterministic source of truth (FR-006); triage is a pure read-and-summarize layer appended at the end (FR-007, FR-008, FR-013). Mirrors the existing fallback philosophy already in `run_alerting` (stocks.json fallback).
+- **Alternatives considered**: A separate Lambda command reading alerts back from DynamoDB — more moving parts and a second schedule; rejected for the MVP since the alerts are already in memory at end of scan.
+
+## R7. Slack demotion
+
+- **Decision**: Replace the per-indicator `slack_messages` dump to `#stock` with a single concise message: headline tier counts + top high-conviction names + a link to the app's Daily Brief page. The `#errors` operational channel and the workflow channels are unchanged. "No signals" message preserved (FR-019).
+- **Rationale**: FR-016 / SC-001 — app becomes source of truth, Slack becomes a pointer. Link target is the frontend `/daily-brief` route (base URL from config).
+- **Alternatives considered**: Keep both raw and digest — rejected: reintroduces the firehose the feature exists to remove.
+
+## R8. API + Frontend surface
+
+- **Decision**: New router `GET /api/alert-digests` (list, newest-first, optional `limit`) and `GET /api/alert-digests/{run_date}` (latest brief for that date), backed by `AlertDigestService` (with a short `TTLCache` like `AlertingService`) and Pydantic models in `api/models/alert_digest.py`. New React page `DailyBrief.tsx` at route `/daily-brief`, fetching via a new `alertDigestService` in `services/api.ts`, with conviction badges and a run-date selector; sidebar entry added.
+- **Rationale**: Directly mirrors the alerting/workflow-orders API+UI precedent. TypeScript interfaces mirror the Pydantic models exactly (constitution API Contract Standards).
+- **Alternatives considered**: Reusing the existing `/alerts` page — rejected: the brief is a distinct, ranked, cross-asset artifact with its own history navigation.
+
+## R9. Configuration & dependency
+
+- **Decision**: Add `anthropic` to `pyproject.toml`. Add `Configuration.anthropic_api_key` (from `self.secrets["anthropic_api_key"]`) and `Configuration.anthropic_model` (from `self.config.get("anthropic_model", "claude-sonnet-5")`), matching the `slack_token` / property pattern. Document the new keys in `secrets.yml`/`config.yml` examples.
+- **Rationale**: Principle III — secrets gitignored, non-sensitive model id in `config.yml`, sensible default.
+- **Alternatives considered**: Env-var-only — rejected as inconsistent with the established YAML config pattern (though env override remains available per the config design).

--- a/specs/023-alert-triage/research.md
+++ b/specs/023-alert-triage/research.md
@@ -41,14 +41,15 @@ All Technical Context items were resolvable from the existing codebase and prior
 ## R7. Slack demotion
 
 - **Decision**: Replace the per-indicator `slack_messages` dump to `#stock` with a single concise message: headline tier counts + top high-conviction names + a link to the app's Daily Brief page. The `#errors` operational channel and the workflow channels are unchanged. "No signals" message preserved (FR-019).
-- **Rationale**: FR-016 / SC-001 — app becomes source of truth, Slack becomes a pointer. Link target is the frontend `/daily-brief` route (base URL from config).
+- **Rationale**: FR-016 / SC-001 — app becomes source of truth, Slack becomes a pointer. Link target is the frontend homepage `/` (base URL from config), where the brief section renders.
 - **Alternatives considered**: Keep both raw and digest — rejected: reintroduces the firehose the feature exists to remove.
 
 ## R8. API + Frontend surface
 
-- **Decision**: New router `GET /api/alert-digests` (list, newest-first, optional `limit`) and `GET /api/alert-digests/{run_date}` (latest brief for that date), backed by `AlertDigestService` (with a short `TTLCache` like `AlertingService`) and Pydantic models in `api/models/alert_digest.py`. New React page `DailyBrief.tsx` at route `/daily-brief`, fetching via a new `alertDigestService` in `services/api.ts`, with conviction badges and a run-date selector; sidebar entry added.
-- **Rationale**: Directly mirrors the alerting/workflow-orders API+UI precedent. TypeScript interfaces mirror the Pydantic models exactly (constitution API Contract Standards).
-- **Alternatives considered**: Reusing the existing `/alerts` page — rejected: the brief is a distinct, ranked, cross-asset artifact with its own history navigation.
+- **Decision**: New router `GET /api/alert-digests` (returns **full** recent digests, newest-first, optional `limit`) and `GET /api/alert-digests/{run_date}` (latest brief for that date), backed by `AlertDigestService` (with a short `TTLCache` like `AlertingService`) and Pydantic models in `api/models/alert_digest.py`. The brief is rendered as a **`DailyBrief` section embedded in the existing `Home` component** (above the current homepage grid), with a **`DailyBriefCarousel`** that pages recent run dates in reverse-chronological order; conviction badges for high/watch, noise as a count. Fetching via a new `alertDigestService` in `services/api.ts`. No new route or sidebar entry.
+- **Rationale**: The brief is the trader's primary "what to look at today" artifact — homepage placement gives zero-click access, and the carousel satisfies the run-history requirement (FR-015/US3) without a separate selector or page. The list endpoint returns full digests (not just summaries) because the table is tiny (~1 item/day) and it lets the carousel page client-side with no per-day round-trip. TypeScript interfaces mirror the Pydantic models exactly (constitution API Contract Standards).
+- **Scope note**: The carousel covers recent run dates only (bounded by `limit`); arbitrary jump-to-date deep-history lookup is deferred to a future iteration.
+- **Alternatives considered**: (a) Standalone `/daily-brief` page + sidebar entry — rejected: adds a click to the most important artifact and duplicates history navigation the carousel already provides. (b) List endpoint returning summaries only + per-day `GET /{run_date}` on each carousel move — rejected: unnecessary round-trips for a one-item-per-day table.
 
 ## R9. Configuration & dependency
 

--- a/specs/023-alert-triage/spec.md
+++ b/specs/023-alert-triage/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Alert Triage & Synthesis Agent
+
+**Feature Branch**: `023-alert-triage`
+**Created**: 2026-07-16
+**Status**: Draft
+**Input**: User description: "Alert triage & synthesis agent (spec 023). After the daily French-stock alerting scan runs its deterministic pattern detectors and produces Alert objects, a new triage agent reasons over the day's collected alerts and produces a ranked 'daily brief': each asset assigned a conviction tier (high / watch / noise), a rank, and a one-line rationale, based on pattern confluence and ma50_slope trend alignment. The digest is persisted to a new no-TTL store so history is retained for later 'was the agent right?' review. Detection logic and the order/workflow path are untouched. On any reasoning failure the agent falls back to a deterministic ranking so the daily scan never breaks. The persisted digest is surfaced in the app and Slack is demoted to a short digest notification that links into the app."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Receive a ranked daily brief instead of a raw firehose (Priority: P1)
+
+Today, after the daily French-stock scan, the trader receives a raw, per-indicator dump of every pattern that fired — dozens of lines across all scanned stocks — and must eyeball it to find what matters. With this feature, once the scan completes the trader instead receives a synthesized daily brief: the day's signals are grouped by conviction (high / watch / noise), each high- and watch-tier asset is ranked and accompanied by a one-line rationale explaining *why* it stands out (which patterns co-fired on the same asset and whether the medium-term trend agrees), and the low-value noise is summarized as a count rather than listed in full.
+
+**Why this priority**: This is the core value of the feature — turning an unreadable firehose into a decision-ready brief. Everything else (persistence, history, UI) exists to support or extend this. A brief the trader trusts and can act on in seconds is the minimum viable product.
+
+**Independent Test**: Run the daily scan against a set of assets that produce a known mix of alerts; verify a brief is produced that ranks assets with multiple co-firing patterns and trend agreement above isolated single-pattern hits, that each ranked asset carries a plain-language rationale, and that low-conviction hits are collapsed into a summary count.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daily scan produced alerts across several stocks, some with multiple patterns firing on the same asset and some with a single pattern, **When** the triage step runs, **Then** assets with multiple co-firing patterns are ranked above assets with a single isolated pattern.
+2. **Given** an asset has a bearish pattern and its medium-term trend is falling, **When** the brief is produced, **Then** that asset is rated higher conviction than an equivalent bearish pattern whose trend is rising.
+3. **Given** the scan produced a large number of low-significance hits, **When** the brief is produced, **Then** those hits are represented as a summary count in a "noise" grouping rather than enumerated individually.
+4. **Given** the brief is produced, **When** the trader reads any high- or watch-tier entry, **Then** it includes a one-line rationale referencing the specific patterns and trend context behind the ranking.
+
+---
+
+### User Story 2 - Never lose a scan to a reasoning failure (Priority: P1)
+
+The daily scan is a critical, unattended background job. The trader must be able to rely on receiving *a* brief every day, even if the reasoning step is unavailable or misbehaves. When the synthesis step cannot produce a valid result, the system falls back to a deterministic ranking derived from the raw signals themselves (how many patterns fired on the asset and how strongly the trend is inclined), and clearly marks the brief as having used the fallback so the trader knows the reasoning quality is degraded.
+
+**Why this priority**: A brief that occasionally silently disappears — or worse, breaks the whole scan and suppresses the raw alerts too — would destroy trust and remove a tool the trader depends on. Guaranteed delivery with graceful degradation is as important as the synthesis itself.
+
+**Independent Test**: Force the reasoning step to fail (unavailable service or malformed output) and confirm the scan still completes, a brief is still produced from a deterministic ranking, the brief is flagged as fallback, and no raw alert data is lost.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reasoning service is unavailable, **When** the triage step runs, **Then** the scan still completes and a brief is produced using the deterministic fallback ranking.
+2. **Given** the reasoning step returns an unparseable or invalid result, **When** the triage step processes it, **Then** the system discards it and uses the deterministic fallback instead of failing.
+3. **Given** a fallback brief was produced, **When** the trader views it, **Then** it is clearly marked as having used the fallback ranking.
+4. **Given** any failure in the triage step, **When** the scan runs, **Then** the raw per-asset alerts are still stored exactly as they are today and the order/workflow path is unaffected.
+
+---
+
+### User Story 3 - Review the history of past briefs (Priority: P2)
+
+Because each daily brief is persisted without expiry, the trader can look back at previous days' briefs to review what the agent flagged and judge, in hindsight, whether the high-conviction calls played out. The trader can open the most recent brief and step back through prior runs by date.
+
+**Why this priority**: History is the payoff of persisting the digest and the basis for building trust in (or calibrating) the agent's judgment over time. It is highly valuable but not required for the first usable version — the brief delivers value on day one; history compounds it.
+
+**Independent Test**: Produce briefs on multiple distinct run dates, then confirm they can be listed newest-first and any individual past brief can be retrieved and viewed by its run date.
+
+**Acceptance Scenarios**:
+
+1. **Given** briefs exist for several past run dates, **When** the trader opens the brief history, **Then** the briefs are listed newest-first.
+2. **Given** the trader selects a past run date, **When** the brief is opened, **Then** the full ranked brief for that date is displayed.
+3. **Given** briefs have accumulated over many days, **When** old alerts have expired from the raw alert store, **Then** the corresponding briefs remain available in history.
+
+---
+
+### User Story 4 - A concise notification that links to the full brief (Priority: P2)
+
+Instead of blasting the raw per-indicator lists into the notification channel, the system posts a short, human-readable summary of the day's brief (headline counts and the top high-conviction names) with a link into the application where the full ranked brief lives. The application becomes the source of truth; the notification is a pointer.
+
+**Why this priority**: This closes the loop on replacing the firehose and drives the trader to the richer, persisted view. It depends on the brief and its persisted, viewable form existing first, so it follows P1.
+
+**Independent Test**: After a scan, confirm the notification channel receives a single concise message containing the headline counts and top names plus a link to the brief, and does not receive the old per-indicator raw dump.
+
+**Acceptance Scenarios**:
+
+1. **Given** a brief was produced, **When** the notification is sent, **Then** it contains a short summary (counts and top high-conviction names) and a link to the full brief in the app.
+2. **Given** a brief was produced, **When** the notification is sent, **Then** the old raw per-indicator firehose is not sent to the primary channel.
+3. **Given** no alerts were detected in the scan, **When** the notification is sent, **Then** it states that there were no signals for the day.
+
+---
+
+### Edge Cases
+
+- **No alerts detected**: the scan finds nothing. A brief is still recorded (empty/zero-count) and the notification states there were no signals for the day.
+- **Single alert / very small scan**: the brief still produces a valid ranking without over-editorializing; behavior degrades gracefully to essentially passing through the one signal.
+- **Missing trend context**: an asset's trend-slope value is unavailable (insufficient history). The asset is still ranked using the available signals rather than being dropped.
+- **Reasoning service slow or timing out**: treated as a failure and handled by the deterministic fallback within the scan's time budget.
+- **Reasoning output references an asset not in the scan, or omits assets that were in the scan**: the system reconciles against the actual detected alerts; unknown assets are ignored and detected assets are never silently dropped.
+- **Two runs on the same calendar date**: history retains each run distinctly (ordered by run time) rather than overwriting.
+- **Duplicate/late notification**: a triage failure must never cause the raw alerts, their storage, or the order/workflow path to be skipped.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: After the daily alerting scan completes its deterministic pattern detection, the system MUST collect the day's detected alerts and produce a single synthesized daily brief.
+- **FR-002**: The brief MUST assign every asset that produced at least one alert to exactly one conviction tier: high, watch, or noise.
+- **FR-003**: The brief MUST assign a rank ordering to the high- and watch-tier assets.
+- **FR-004**: The brief MUST include a concise one-line rationale for each high- and watch-tier asset.
+- **FR-005**: Ranking and tiering MUST take into account pattern confluence (multiple distinct patterns firing on the same asset) and alignment between the signal's direction and the asset's medium-term trend slope.
+- **FR-006**: The system MUST NOT modify the existing pattern-detection logic; detection remains the deterministic source of truth.
+- **FR-007**: The system MUST continue to store the raw per-asset alerts exactly as it does today, independently of the brief.
+- **FR-008**: The system MUST NOT alter the order-placement / workflow execution path in any way.
+- **FR-009**: The system MUST persist each produced brief durably and WITHOUT automatic expiry, so that historical briefs remain available indefinitely for later review.
+- **FR-010**: Each persisted brief MUST be identifiable and retrievable by its run date, and multiple runs on the same date MUST be retained distinctly by run time.
+- **FR-011**: On any failure of the reasoning step (service unavailable, timeout, or invalid/unparseable output), the system MUST fall back to a deterministic ranking derived from pattern count and trend-slope magnitude, and MUST still produce and persist a brief.
+- **FR-012**: A brief produced via the fallback path MUST be flagged as such so consumers can distinguish reasoning-based from fallback briefs.
+- **FR-013**: A failure in the triage or persistence step MUST NOT prevent the scan from completing, MUST NOT lose raw alert data, and MUST NOT affect the order/workflow path.
+- **FR-014**: The system MUST expose the persisted briefs for consumption by the application, supporting (a) listing briefs newest-first and (b) retrieving a single brief by its run date.
+- **FR-015**: The application MUST provide a view that displays a brief's ranked assets with their conviction tier indicated visually, and MUST allow the user to select and view briefs from prior run dates.
+- **FR-016**: After a scan, the notification channel MUST receive a concise summary (headline counts and top high-conviction names) with a link into the application, and MUST NOT receive the previous raw per-indicator dump.
+- **FR-017**: The reasoning model MUST be configurable and swappable without code changes, defaulting to a specified high-capability model.
+- **FR-018**: The reasoning step MUST reconcile its output against the actually detected alerts: assets not present in the scan are ignored, and assets present in the scan are never silently dropped from the brief.
+- **FR-019**: When no alerts are detected, the system MUST still record a brief for the run and the notification MUST communicate that there were no signals.
+
+### Key Entities *(include if feature involves data)*
+
+- **Daily Brief (Digest)**: The synthesized output of one scan run. Attributes: run date, run timestamp, overall summary text, tier counts (high/watch/noise), the ordered list of triaged assets, an indicator of whether the reasoning-based or fallback path produced it, and a record of which reasoning model was used. Retained indefinitely.
+- **Triaged Asset**: One asset's entry within a brief. Attributes: asset identifier and human-readable name, conviction tier, rank, one-line rationale, the set of patterns that fired on it, and the trend-slope context used in ranking.
+- **Alert** (existing, unchanged): A single detected pattern for an asset produced by the deterministic detectors; the raw input to triage. Continues to be stored as-is with its existing expiry behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The primary notification for a daily scan is reduced from the full per-indicator listing to a single concise message, regardless of how many raw alerts fired.
+- **SC-002**: The trader can identify the day's top opportunities from the brief in under 30 seconds, without scrolling through per-indicator raw lists.
+- **SC-003**: 100% of scan runs produce and persist a brief — including runs where the reasoning step fails (via fallback) and runs where no alerts are detected.
+- **SC-004**: In 100% of reasoning-failure cases, the scan still completes, the raw alerts are still stored, and the order/workflow path is unaffected.
+- **SC-005**: Every high- and watch-tier entry in a brief carries a rank and a one-line rationale.
+- **SC-006**: Briefs remain retrievable in history beyond the point at which their underlying raw alerts have expired (i.e., history outlives the raw-alert retention window).
+- **SC-007**: An asset with multiple co-firing patterns and trend agreement is ranked above an otherwise-comparable asset with a single pattern in 100% of cases where that comparison applies.
+
+## Assumptions
+
+- The medium-term trend-slope value used for ranking is already computed and attached to each alert by the existing scan and does not need to be recomputed by this feature.
+- "Daily brief" corresponds to one scan run; the run date is the natural key and multiple same-day runs are rare but retained distinctly.
+- Conviction tiers are exactly three (high / watch / noise); "noise" is summarized rather than enumerated in notifications.
+- The concise notification targets the same primary channel used today for stock alerts; error/operational channels are unchanged.
+- Historical briefs are retained indefinitely (no automatic expiry); any future pruning is out of scope for this feature.
+- The application already surfaces raw alerts, so the daily-brief view is an addition alongside the existing alerts experience rather than a replacement of it.
+- Access control for the new view follows the same model as the rest of the application (no new authentication requirements introduced by this feature).
+
+## Out of Scope
+
+- Any change to how patterns are detected or which patterns exist.
+- Any automated order placement or change to the workflow/execution path.
+- Backfilling briefs for historical scans that ran before this feature existed.
+- Trader feedback/labeling of whether a call was "right" (the history view enables manual review; capturing structured outcomes is a potential future feature).
+- Multi-channel or per-user notification routing beyond the single existing primary channel.

--- a/specs/023-alert-triage/spec.md
+++ b/specs/023-alert-triage/spec.md
@@ -43,7 +43,7 @@ The daily scan is a critical, unattended background job. The trader must be able
 
 ### User Story 3 - Review the history of past briefs (Priority: P2)
 
-Because each daily brief is persisted without expiry, the trader can look back at previous days' briefs to review what the agent flagged and judge, in hindsight, whether the high-conviction calls played out. The trader can open the most recent brief and step back through prior runs by date.
+Because each daily brief is persisted without expiry, the trader can look back at previous days' briefs to review what the agent flagged and judge, in hindsight, whether the high-conviction calls played out. From the homepage the trader sees the latest brief and can page back through recent runs via a carousel.
 
 **Why this priority**: History is the payoff of persisting the digest and the basis for building trust in (or calibrating) the agent's judgment over time. It is highly valuable but not required for the first usable version — the brief delivers value on day one; history compounds it.
 
@@ -51,8 +51,8 @@ Because each daily brief is persisted without expiry, the trader can look back a
 
 **Acceptance Scenarios**:
 
-1. **Given** briefs exist for several past run dates, **When** the trader opens the brief history, **Then** the briefs are listed newest-first.
-2. **Given** the trader selects a past run date, **When** the brief is opened, **Then** the full ranked brief for that date is displayed.
+1. **Given** briefs exist for several past run dates, **When** the trader opens the homepage, **Then** the most recent brief is shown first and the carousel pages backward through prior runs in reverse-chronological order.
+2. **Given** the trader pages the carousel to a past run date, **When** that slide is shown, **Then** the ranked brief for that date is displayed.
 3. **Given** briefs have accumulated over many days, **When** old alerts have expired from the raw alert store, **Then** the corresponding briefs remain available in history.
 
 ---
@@ -101,7 +101,7 @@ Instead of blasting the raw per-indicator lists into the notification channel, t
 - **FR-012**: A brief produced via the fallback path MUST be flagged as such so consumers can distinguish reasoning-based from fallback briefs.
 - **FR-013**: A failure in the triage or persistence step MUST NOT prevent the scan from completing, MUST NOT lose raw alert data, and MUST NOT affect the order/workflow path.
 - **FR-014**: The system MUST expose the persisted briefs for consumption by the application, supporting (a) listing briefs newest-first and (b) retrieving a single brief by its run date.
-- **FR-015**: The application MUST provide a view that displays a brief's ranked assets with their conviction tier indicated visually, and MUST allow the user to select and view briefs from prior run dates.
+- **FR-015**: The application MUST surface the latest brief on the homepage, displaying the ranked high- and watch-tier assets with their conviction tier indicated visually (noise summarized as a count), and MUST let the user page back through recent run dates via a carousel.
 - **FR-016**: After a scan, the notification channel MUST receive a concise summary (headline counts and top high-conviction names) with a link into the application, and MUST NOT receive the previous raw per-indicator dump.
 - **FR-017**: The reasoning model MUST be configurable and swappable without code changes, defaulting to a specified high-capability model.
 - **FR-018**: The reasoning step MUST reconcile its output against the actually detected alerts: assets not present in the scan are ignored, and assets present in the scan are never silently dropped from the brief.
@@ -132,7 +132,8 @@ Instead of blasting the raw per-indicator lists into the notification channel, t
 - Conviction tiers are exactly three (high / watch / noise); "noise" is summarized rather than enumerated in notifications.
 - The concise notification targets the same primary channel used today for stock alerts; error/operational channels are unchanged.
 - Historical briefs are retained indefinitely (no automatic expiry); any future pruning is out of scope for this feature.
-- The application already surfaces raw alerts, so the daily-brief view is an addition alongside the existing alerts experience rather than a replacement of it.
+- The daily brief is surfaced as a section on the existing homepage (above the current homepage cards) rather than as a separate page; the existing raw-alerts experience is unchanged.
+- The carousel covers recent run dates only; arbitrary deep-history lookup (jump-to-date) is deferred to a future iteration.
 - Access control for the new view follows the same model as the rest of the application (no new authentication requirements introduced by this feature).
 
 ## Out of Scope


### PR DESCRIPTION
Specify the alert triage & synthesis agent: after the daily French-stock
scan produces raw alerts, a triage agent ranks them into a conviction-tiered
daily brief (high/watch/noise) with per-asset rationale, persisted without
expiry for historical review and surfaced in the app. Includes user stories,
functional requirements, success criteria, and the requirements quality
checklist. No implementation yet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC