### PR TITLE
feat: triage domain models for spec 023 (phase 2)

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from model.enum import (  # noqa: F401
     AlertType,
     AssetType,
+    Conviction,
     Currency,
     Direction,
     OrderType,
@@ -51,6 +52,30 @@ class Alert:
             return f"{self.asset_code}_{self.country_code}"
         else:
             return self.asset_code
+
+
+@dataclass
+class TriagedAsset:
+    asset_code: str
+    asset_description: str
+    exchange: str
+    conviction: Conviction
+    rationale: str
+    patterns: List[AlertType]
+    ma50_slope: Optional[float] = None
+    rank: Optional[int] = None
+    country_code: Optional[str] = None
+
+
+@dataclass
+class AlertDigest:
+    run_date: str
+    created_at: int
+    summary: str
+    counts: Dict[str, int]
+    triaged_assets: List[TriagedAsset]
+    model: str
+    fallback_used: bool = False
 
 
 @dataclass

--- a/model/enum.py
+++ b/model/enum.py
@@ -119,3 +119,9 @@ class AlertType(EnumWithGetValue):
 class Exchange(EnumWithGetValue):
     SAXO = "saxo"
     BINANCE = "binance"
+
+
+class Conviction(EnumWithGetValue):
+    HIGH = "high"
+    WATCH = "watch"
+    NOISE = "noise"

--- a/specs/023-alert-triage/tasks.md
+++ b/specs/023-alert-triage/tasks.md
@@ -41,8 +41,8 @@ Web + Lambda layout (per plan.md): backend at repo root (`model/`, `client/`, `s
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T004 [P] Add `Conviction` enum (`HIGH`/`WATCH`/`NOISE`) to `model/enum.py` using `EnumWithGetValue`
-- [ ] T005 Add `TriagedAsset` and `AlertDigest` dataclasses to `model/__init__.py` (with explicit `exchange` field per asset; export both) (depends on T004)
+- [x] T004 [P] Add `Conviction` enum (`HIGH`/`WATCH`/`NOISE`) to `model/enum.py` using `EnumWithGetValue`
+- [x] T005 Add `TriagedAsset` and `AlertDigest` dataclasses to `model/__init__.py` (with explicit `exchange` field per asset; export both) (depends on T004)
 
 **Checkpoint**: Domain models ready — user stories can begin
 


### PR DESCRIPTION
## Summary

Phase 2 (Foundational) for spec **023 — Alert Triage & Synthesis Agent** (tasks T004–T005). Adds the domain models the triage agent produces and the API/persistence layers will consume. No triage logic yet — that's Phase 3 (US1 MVP).

## Changes

| Task | Change |
|------|--------|
| **T004** | Add `Conviction` enum (`HIGH`/`WATCH`/`NOISE`) to `model/enum.py` via `EnumWithGetValue` |
| **T005** | Add `TriagedAsset` and `AlertDigest` dataclasses to `model/__init__.py`; export `Conviction` |

## Design fidelity

- `TriagedAsset` carries an **explicit `exchange` field** — per Constitution V, exchange is never inferred from `country_code`.
- `patterns` is typed `List[AlertType]` (existing enum), not strings — per the enum-driven rule.
- `AlertDigest` matches `data-model.md` exactly: `run_date`, `created_at`, `summary`, `counts`, `triaged_assets`, `model`, `fallback_used`; defaulted fields ordered last for a valid dataclass.

## Verification

- Both models instantiate; `Conviction` values resolve.
- `black` / `isort` / `flake8` clean; `mypy` **Success: no issues found**.
- Existing model/alert tests: **29 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_