### PR TITLE
fix: cut triage call cost and avoid truncation failures (spec 023)

### DIFF
--- a/client/anthropic_client.py
+++ b/client/anthropic_client.py
@@ -23,18 +23,23 @@ class AnthropicClient:
         return self._model
 
     def complete_json(
-        self, system: str, user_payload: str, max_tokens: int = 16000
+        self, system: str, user_payload: str, max_tokens: int = 4096
     ) -> Dict[str, Any]:
         try:
             response = self._client.messages.create(
                 model=self._model,
                 max_tokens=max_tokens,
+                thinking={"type": "disabled"},
                 system=system,
                 messages=[{"role": "user", "content": user_payload}],
             )
         except (anthropic.APIError, anthropic.APIConnectionError) as e:
             raise AnthropicException(f"Anthropic API call failed: {e}")
 
+        if response.stop_reason == "max_tokens":
+            raise AnthropicException(
+                "Anthropic response truncated (max_tokens)"
+            )
         return self._parse_json(self._extract_text(response))
 
     def _extract_text(self, response: Any) -> str:

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -12,7 +12,6 @@ technical alerts on French stocks.
 
 You receive a JSON object with an "assets" array. Each asset has:
 - id: opaque identifier you MUST echo back unchanged
-- code, name, exchange
 - patterns: the chart patterns that fired today on this asset
 - ma50_slope: percent slope of the 50-period moving average (medium-term \
 trend); positive = uptrend, negative = downtrend, null = unknown
@@ -24,22 +23,23 @@ stronger than one with a single isolated pattern.
 negative (trend agrees); a bullish setup is higher conviction when ma50_slope \
 is positive. A signal fighting the trend is weaker.
 
-Assign every asset exactly one conviction tier:
+Conviction tiers:
 - "high": a genuine, actionable setup worth looking at now.
 - "watch": a plausible setup to keep an eye on.
 - "noise": low-signal, isolated, or trend-conflicting hits.
 
-Rank the high and watch assets together with a 1-based "rank" (1 = best). \
-Give each high/watch asset a one-line "rationale" naming the patterns and the \
-trend context. Noise assets need no rank or rationale.
+RETURN ONLY the "high" and "watch" assets - the ones worth surfacing. Any \
+asset you omit is treated as "noise", so never list noise assets. Rank the \
+returned assets with a 1-based "rank" (1 = best) and give each a one-line \
+"rationale" naming the patterns and the trend context.
 
-Be selective: most days only a few assets are "high". Do not inflate tiers.
+Be selective: most days only a few assets are high or watch. Do not inflate \
+tiers.
 
 Respond with ONLY a JSON object, no prose, no code fences:
 {"summary": "<one or two sentence headline of the day>",
- "assets": [{"id": "<echoed id>", "conviction": "high|watch|noise", \
-"rank": <int or null>, "rationale": "<one line or empty>"}]}
-Include every asset from the input in your "assets" array."""
+ "assets": [{"id": "<echoed id>", "conviction": "high|watch", \
+"rank": <int>, "rationale": "<one line>"}]}"""
 
 
 class TriageAgent:
@@ -115,9 +115,6 @@ class TriageAgent:
         assets = [
             {
                 "id": asset_id,
-                "code": entry["asset_code"],
-                "name": entry["asset_description"],
-                "exchange": entry["exchange"],
                 "patterns": [p.value for p in entry["patterns"]],
                 "ma50_slope": entry["ma50_slope"],
             }


### PR DESCRIPTION
## Summary

Follow-up fix to the alert triage agent (spec 023, merged in #629). The first real production run cost **~20ct and failed**: Sonnet 5 runs adaptive thinking by default, which — together with an output JSON that echoed every scanned asset — overran `max_tokens`, truncated the JSON, and raised a parse error *after* billing the wasted output/thinking tokens.

## Root cause

- Adaptive thinking is **on by default** on Sonnet 5 → thousands of thinking tokens billed as output.
- The prompt asked the model to return **every** scanned asset (~200) → large output on top of thinking.
- Combined, they hit `stop_reason: "max_tokens"` → truncated JSON → `AnthropicException` → the guarded triage step logged a failure. Tokens were billed for output that was discarded.

## The fix

| Change | Effect |
|--------|--------|
| Disable thinking on the triage call (`thinking: {"type": "disabled"}`) | Removes the dominant cost/truncation driver; the ranking is a single-pass application of explicit rules (confluence + slope) |
| Return only **high/watch** assets | Omitted assets already reconcile to noise, so output drops from O(all assets) to O(a few) |
| Trim the payload to `id` + `patterns` + `ma50_slope` | ~halves the 22K input (name/code/exchange aren't needed to rank) |
| Cap `max_tokens` at 4096 + fail fast on `stop_reason == "max_tokens"` | Hard cost ceiling; truncation now raises cleanly (→ deterministic fallback in Phase 4) instead of silently billing |

**Expected new cost:** ~2–3ct/run instead of 20ct, with no truncation failure.

## Tradeoff

Disabling extended thinking trades away some deep reasoning. For this task — structured facts, explicit ranking rules — a single pass is well within Sonnet's ability, so it's the right default. The middle ground, if more judgment is wanted later, is adaptive thinking at `low` effort.

## Verification

- `black` / `isort` / `flake8` clean; `mypy` **Success: no issues found** (CI flags).
- Triage tests: **6 passed** (they already covered the "omitted → noise" path, so they validate the new prompt semantics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_