### PR TITLE
fix: make market session hours DST-aware via central helper

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -196,19 +196,28 @@ class Market:
     open_minutes: int
     close_hour: int
     h4_blocks: List[int] = None  # type: ignore[assignment]
+    timezone: str = "UTC"
 
 
 class USMarket(Market):
     def __init__(self) -> None:
         super().__init__(
-            open_hour=13, close_hour=19, open_minutes=30, h4_blocks=[4, 3]
+            open_hour=9,
+            close_hour=15,
+            open_minutes=30,
+            h4_blocks=[4, 3],
+            timezone="America/New_York",
         )
 
 
 class EUMarket(Market):
     def __init__(self) -> None:
         super().__init__(
-            open_hour=7, close_hour=15, open_minutes=0, h4_blocks=[3, 4, 2]
+            open_hour=9,
+            close_hour=17,
+            open_minutes=0,
+            h4_blocks=[3, 4, 2],
+            timezone="Europe/Paris",
         )
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4027,6 +4027,18 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+files = [
+    {file = "tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931"},
+    {file = "tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415"},
+]
+
+[[package]]
 name = "uritemplate"
 version = "4.2.0"
 description = "Implementation of RFC 6570 URI Templates"
@@ -4626,4 +4638,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "19e4d75054beb628143b62ec4bac45339e6f8c8728a5ce789d6e16f9b044e5c3"
+content-hash = "0dadcf78c4125a69a169d796223547c879096b0f4c76c5fd5b6f9719f19e8ccd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pydantic = "^2.12.4"
 cachetools = "^6.2.1"
 python-multipart = "^0.0.32"
 anthropic = "^0.117.0"
+tzdata = "^2026.3"
 
 [tool.poetry.dev-dependencies]
 black = "^26.3.1"

--- a/services/candles_service.py
+++ b/services/candles_service.py
@@ -12,6 +12,7 @@ from utils.helper import (
     build_daily_candles_from_h1,
     build_h4_candles_from_h1,
     get_date_utc0,
+    market_in_utc,
 )
 from utils.logger import Logger
 
@@ -196,6 +197,8 @@ class CandlesService:
     def _build_h1_from_30m(
         self, data: list, market: Market, ut: UnitTime
     ) -> List[Candle]:
+        if data:
+            market = market_in_utc(market, data[0]["Time"])
         candles = []
         i = 0
         while i < len(data):
@@ -269,9 +272,7 @@ class CandlesService:
             date=date,
         )
         if len(data) == 0:
-            raise SaxoException(
-                f"No data returned for {code}"
-            )
+            raise SaxoException(f"No data returned for {code}")
         if data[0]["Time"].minute == market.open_minutes:
             data = data[1:]
         candles = self._build_h1_from_30m(data, market, ut)

--- a/services/candles_service.py
+++ b/services/candles_service.py
@@ -197,16 +197,15 @@ class CandlesService:
     def _build_h1_from_30m(
         self, data: list, market: Market, ut: UnitTime
     ) -> List[Candle]:
-        if data:
-            market = market_in_utc(market, data[0]["Time"])
         candles = []
         i = 0
         while i < len(data):
-            open_hour_ok = data[i]["Time"].hour >= market.open_hour
+            utc_market = market_in_utc(market, data[i]["Time"])
+            open_hour_ok = data[i]["Time"].hour >= utc_market.open_hour
             close_hour_ok = (
-                data[i]["Time"].hour <= market.close_hour
+                data[i]["Time"].hour <= utc_market.close_hour
                 if market.open_minutes == 0
-                else data[i]["Time"].hour <= market.close_hour + 1
+                else data[i]["Time"].hour <= utc_market.close_hour + 1
             )
             minutes_ok = (
                 data[i]["Time"].minute == 30

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -1069,6 +1069,89 @@ class TestHelper:
             == expected
         )
 
+    def test_build_daily_candles_cross_season_batch(self):
+        """A single batch spanning a DST transition must build a daily
+        candle for both the winter and the summer day.
+
+        Each candle's own date selects its DST regime, so the winter close
+        (16:00 UTC) and the summer close (15:00 UTC) are both recognised.
+        A single per-batch regime would drop one of the two days.
+        """
+        winter = [
+            Candle(
+                lower=200 + i,
+                higher=300 - i,
+                open=210 + i,
+                close=220 + i,
+                ut=UnitTime.H1,
+                date=datetime.datetime(2025, 1, 15, hour, 0),
+            )
+            for i, hour in enumerate(range(16, 7, -1))
+        ]
+        summer = [
+            Candle(
+                lower=100 + i,
+                higher=190 - i,
+                open=110 + i,
+                close=120 + i,
+                ut=UnitTime.H1,
+                date=datetime.datetime(2024, 8, 20, hour, 0),
+            )
+            for i, hour in enumerate(range(15, 6, -1))
+        ]
+
+        def daily(day, date):
+            return Candle(
+                lower=min(c.lower for c in day),
+                higher=max(c.higher for c in day),
+                open=day[-1].open,
+                close=day[0].close,
+                ut=UnitTime.D,
+                date=date,
+            )
+
+        expected = [
+            daily(winter, datetime.datetime(2025, 1, 15, 8, 0)),
+            daily(summer, datetime.datetime(2024, 8, 20, 7, 0)),
+        ]
+        assert (
+            build_daily_candles_from_h1(
+                candles=winter + summer, market=EUMarket()
+            )
+            == expected
+        )
+
+    def test_build_h4_candles_from_h1_winter_dst(self):
+        """In winter (CET) the EU session lands on UTC 08:00-16:00, so H4
+        blocks end at UTC 10/14/16 instead of the summer 09/13/15."""
+        winter = [
+            Candle(
+                lower=200 + i,
+                higher=300 - i,
+                open=210 + i,
+                close=220 + i,
+                ut=UnitTime.H1,
+                date=datetime.datetime(2025, 1, 15, hour, 0),
+            )
+            for i, hour in enumerate(range(16, 7, -1))
+        ]
+
+        def h4(day):
+            return Candle(
+                lower=min(c.lower for c in day),
+                higher=max(c.higher for c in day),
+                open=day[-1].open,
+                close=day[0].close,
+                ut=UnitTime.H4,
+                date=day[-1].date,
+            )
+
+        expected = [h4(winter[0:2]), h4(winter[2:6]), h4(winter[6:9])]
+        assert (
+            build_h4_candles_from_h1(candles=winter, market=EUMarket())
+            == expected
+        )
+
     @pytest.mark.parametrize(
         "candles, expected",
         [

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -9,6 +9,7 @@ from utils.helper import (
     build_daily_candles_from_h1,
     build_h4_candles_from_h1,
     build_weekly_candles_from_daily,
+    market_in_utc,
 )
 
 
@@ -1007,6 +1008,64 @@ class TestHelper:
     ):
         assert (
             build_daily_candles_from_h1(candles=candles, market=market)
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "market_factory, reference, expected_open, expected_close",
+        [
+            # Euronext Paris 09:00-17:00 local -> UTC 07:00-15:00 in CEST
+            (EUMarket, datetime.datetime(2024, 6, 21), 7, 15),
+            # ... and UTC 08:00-16:00 in CET (winter)
+            (EUMarket, datetime.datetime(2024, 1, 15), 8, 16),
+            # NYSE 09:30-15:00 local -> UTC 13:30-19:00 in EDT
+            (USMarket, datetime.datetime(2024, 6, 21), 13, 19),
+            # ... and UTC 14:30-20:00 in EST (winter)
+            (USMarket, datetime.datetime(2024, 1, 15), 14, 20),
+        ],
+    )
+    def test_market_in_utc(
+        self,
+        market_factory,
+        reference: datetime.datetime,
+        expected_open: int,
+        expected_close: int,
+    ):
+        market = market_in_utc(market_factory(), reference)
+        assert market.open_hour == expected_open
+        assert market.close_hour == expected_close
+        assert market.open_minutes == market_factory().open_minutes
+
+    def test_build_daily_candle_from_h1_winter_dst(self):
+        """In winter (CET) the EU session lands on UTC 08:00-16:00.
+
+        With the hardcoded summer UTC close hour (15) this batch produced
+        no daily candle; the DST-aware conversion now recognises the 16:00
+        UTC close.
+        """
+        candles = [
+            Candle(
+                lower=93 + i,
+                higher=118 - i,
+                open=97 + i,
+                close=99 + i,
+                ut=UnitTime.H1,
+                date=datetime.datetime(2024, 1, 15, hour, 0),
+            )
+            for i, hour in enumerate(range(16, 7, -1))
+        ]
+        expected = [
+            Candle(
+                lower=min(c.lower for c in candles),
+                higher=max(c.higher for c in candles),
+                open=candles[-1].open,
+                close=candles[0].close,
+                ut=UnitTime.D,
+                date=datetime.datetime(2024, 1, 15, 8, 0),
+            )
+        ]
+        assert (
+            build_daily_candles_from_h1(candles=candles, market=EUMarket())
             == expected
         )
 

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -58,15 +58,6 @@ def market_in_utc(market: Market, reference: datetime.datetime) -> Market:
     )
 
 
-def _market_reference_date(
-    candles: List[Candle],
-) -> datetime.datetime:
-    """Pick the DST reference date for a batch of candles (newest first)."""
-    if candles and candles[0].date is not None:
-        return candles[0].date
-    return get_date_utc0()
-
-
 def build_current_weekly_candle_from_daily(
     candles: List[Candle],
 ) -> Optional[Candle]:
@@ -124,24 +115,28 @@ def get_date_utc0() -> datetime.datetime:
     return datetime.datetime.now(tz=datetime.UTC)
 
 
-def build_h4_candles_from_h1(
-    candles: List[Candle], market: Market
-) -> List[Candle]:
-    market = market_in_utc(market, _market_reference_date(candles))
+def _h4_ending_hours(market: Market) -> dict:
+    """Map each H4 block's UTC ending hour to its size for `market`."""
     ending_hours = {}
     cumulative = 0
     for block_size in market.h4_blocks:
         cumulative += block_size
-        ending_hour = market.open_hour + cumulative - 1
-        ending_hours[ending_hour] = block_size
+        ending_hours[market.open_hour + cumulative - 1] = block_size
+    return ending_hours
 
+
+def build_h4_candles_from_h1(
+    candles: List[Candle], market: Market
+) -> List[Candle]:
     candles_h4 = []
     i = 0
     while i < len(candles):
         candle_date = candles[i].date
         if candle_date is None:
             i += 1
-        elif candle_date.hour in ending_hours:
+            continue
+        ending_hours = _h4_ending_hours(market_in_utc(market, candle_date))
+        if candle_date.hour in ending_hours:
             block_size = ending_hours[candle_date.hour]
             if i + block_size - 1 >= len(candles):
                 break
@@ -160,8 +155,6 @@ def build_h4_candles_from_h1(
 def build_daily_candles_from_h1(
     candles: List[Candle], market: Market
 ) -> List[Candle]:
-    market = market_in_utc(market, _market_reference_date(candles))
-    ending_hour = market.close_hour - (1 if market.open_minutes == 30 else 0)
     num_h1 = (
         market.close_hour
         - market.open_hour
@@ -174,7 +167,12 @@ def build_daily_candles_from_h1(
         candle_date = candles[i].date
         if candle_date is None:
             i += 1
-        elif candle_date.hour == ending_hour:
+            continue
+        utc_market = market_in_utc(market, candle_date)
+        ending_hour = utc_market.close_hour - (
+            1 if market.open_minutes == 30 else 0
+        )
+        if candle_date.hour == ending_hour:
             if i + num_h1 - 1 >= len(candles):
                 break
             candles_daily.append(

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,8 +1,64 @@
 import datetime
 from typing import List, Optional
+from zoneinfo import ZoneInfo
 
 from model import Candle, Market, UnitTime
 from utils.logger import Logger
+
+
+def market_in_utc(market: Market, reference: datetime.datetime) -> Market:
+    """Convert a market's exchange-local session hours to UTC, DST-aware.
+
+    The Saxo API returns candle timestamps in UTC, while an exchange's
+    session is defined in its local wall-clock time (Euronext Paris trades
+    09:00-17:00 local all year, NYSE 09:30-15:00 local). Because the UTC
+    offset of that local time changes with daylight saving, the session's
+    UTC hours shift by one hour between summer and winter. Centralising the
+    conversion here keeps every candle builder DST-correct instead of
+    hardcoding a single season's UTC hours.
+
+    Args:
+        market: Market whose ``open_hour``/``close_hour`` are exchange-local.
+        reference: Datetime whose date selects the DST regime. Naive values
+            are treated as UTC; tz-aware values are honoured as-is.
+
+    Returns:
+        A new ``Market`` with ``open_hour``/``close_hour`` expressed in UTC
+        for the reference date. ``open_minutes`` and ``h4_blocks`` are
+        preserved (DST offsets are whole hours, so minutes never shift).
+    """
+    tz = ZoneInfo(market.timezone)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=datetime.UTC)
+    local_date = reference.astimezone(tz).date()
+
+    def to_utc_hour(hour: int, minute: int) -> int:
+        local_dt = datetime.datetime(
+            local_date.year,
+            local_date.month,
+            local_date.day,
+            hour,
+            minute,
+            tzinfo=tz,
+        )
+        return local_dt.astimezone(datetime.UTC).hour
+
+    return Market(
+        open_hour=to_utc_hour(market.open_hour, market.open_minutes),
+        open_minutes=market.open_minutes,
+        close_hour=to_utc_hour(market.close_hour, 0),
+        h4_blocks=market.h4_blocks,
+        timezone="UTC",
+    )
+
+
+def _market_reference_date(
+    candles: List[Candle],
+) -> datetime.datetime:
+    """Pick the DST reference date for a batch of candles (newest first)."""
+    if candles and candles[0].date is not None:
+        return candles[0].date
+    return get_date_utc0()
 
 
 def build_current_weekly_candle_from_daily(
@@ -65,6 +121,7 @@ def get_date_utc0() -> datetime.datetime:
 def build_h4_candles_from_h1(
     candles: List[Candle], market: Market
 ) -> List[Candle]:
+    market = market_in_utc(market, _market_reference_date(candles))
     ending_hours = {}
     cumulative = 0
     for block_size in market.h4_blocks:
@@ -97,6 +154,7 @@ def build_h4_candles_from_h1(
 def build_daily_candles_from_h1(
     candles: List[Candle], market: Market
 ) -> List[Candle]:
+    market = market_in_utc(market, _market_reference_date(candles))
     ending_hour = market.close_hour - (1 if market.open_minutes == 30 else 0)
     num_h1 = (
         market.close_hour

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -26,6 +26,12 @@ def market_in_utc(market: Market, reference: datetime.datetime) -> Market:
         A new ``Market`` with ``open_hour``/``close_hour`` expressed in UTC
         for the reference date. ``open_minutes`` and ``h4_blocks`` are
         preserved (DST offsets are whole hours, so minutes never shift).
+
+    Note:
+        Only the UTC hour-of-day is kept, so this assumes the session stays
+        within a single UTC day with ``open_hour < close_hour`` (true for
+        Euronext and US exchanges). A market whose local->UTC conversion
+        crosses midnight would need day-aware handling.
     """
     tz = ZoneInfo(market.timezone)
     if reference.tzinfo is None:

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -6,6 +6,21 @@ from model import Candle, Market, UnitTime
 from utils.logger import Logger
 
 
+def _local_hour_to_utc(
+    local_date: datetime.date, hour: int, minute: int, tz: ZoneInfo
+) -> int:
+    """UTC hour of ``hour:minute`` local time on ``local_date`` in ``tz``."""
+    local_dt = datetime.datetime(
+        local_date.year,
+        local_date.month,
+        local_date.day,
+        hour,
+        minute,
+        tzinfo=tz,
+    )
+    return local_dt.astimezone(datetime.UTC).hour
+
+
 def market_in_utc(market: Market, reference: datetime.datetime) -> Market:
     """Convert a market's exchange-local session hours to UTC, DST-aware.
 
@@ -38,21 +53,12 @@ def market_in_utc(market: Market, reference: datetime.datetime) -> Market:
         reference = reference.replace(tzinfo=datetime.UTC)
     local_date = reference.astimezone(tz).date()
 
-    def to_utc_hour(hour: int, minute: int) -> int:
-        local_dt = datetime.datetime(
-            local_date.year,
-            local_date.month,
-            local_date.day,
-            hour,
-            minute,
-            tzinfo=tz,
-        )
-        return local_dt.astimezone(datetime.UTC).hour
-
     return Market(
-        open_hour=to_utc_hour(market.open_hour, market.open_minutes),
+        open_hour=_local_hour_to_utc(
+            local_date, market.open_hour, market.open_minutes, tz
+        ),
         open_minutes=market.open_minutes,
-        close_hour=to_utc_hour(market.close_hour, 0),
+        close_hour=_local_hour_to_utc(local_date, market.close_hour, 0, tz),
         h4_blocks=market.h4_blocks,
         timezone="UTC",
     )


### PR DESCRIPTION
Exchange sessions are defined in local wall-clock time (Euronext Paris
09:00-17:00, NYSE 09:30-15:00), but Saxo returns candle timestamps in
UTC. The Market models hardcoded the summer-UTC hours (EU 7-15, US
13-19), so every hour-matching comparison in the candle builders drifted
by one hour in winter (CET/EST), breaking H1/H4/daily aggregation for
roughly half the year.

Store the session in exchange-local time plus an IANA timezone on Market
and add a single helper, market_in_utc(), that converts those hours to
UTC for a given reference date using stdlib zoneinfo. Apply it at the
three occurrences (build_h4_candles_from_h1, build_daily_candles_from_h1,
CandlesService._build_h1_from_30m), each deriving its reference date from
the data it already holds. Summer conversions reproduce the previous UTC
hours exactly, so existing tests are unchanged; winter dates now resolve
correctly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LWuyypCv3WkEHC3SM1VDtx