### PR TITLE
feat: persist alert digests, read API, and homepage carousel (phase 5, US3)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.routers import (
+    alert_digest,
     alerting,
     asset_details,
     fund,
@@ -95,6 +96,7 @@ async def dynamodb_error_handler(
 
 
 # Include routers
+app.include_router(alert_digest.router)
 app.include_router(alerting.router)
 app.include_router(asset_details.router)
 app.include_router(fund.router)

--- a/api/models/alert_digest.py
+++ b/api/models/alert_digest.py
@@ -1,0 +1,51 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TriagedAssetResponse(BaseModel):
+    asset_code: str = Field(description="Asset symbol or ticker")
+    asset_description: str = Field(description="Human-readable asset name")
+    exchange: str = Field(
+        description="Exchange name (e.g., 'saxo', 'binance')"
+    )
+    country_code: Optional[str] = Field(
+        default=None,
+        description="Exchange or country code (null for crypto assets)",
+    )
+    conviction: str = Field(description="Conviction tier: high/watch/noise")
+    rank: Optional[int] = Field(
+        default=None,
+        description="1-based rank within high+watch (null for noise)",
+    )
+    rationale: str = Field(description="One-line rationale (empty for noise)")
+    patterns: List[str] = Field(
+        description="Distinct patterns that fired on this asset"
+    )
+    ma50_slope: Optional[float] = Field(
+        default=None, description="MA50 slope used in ranking"
+    )
+
+
+class AlertDigestResponse(BaseModel):
+    run_date: str = Field(description="Run date (YYYY-MM-DD)")
+    created_at: int = Field(description="Run timestamp (epoch seconds)")
+    summary: str = Field(description="Overall headline for the day")
+    counts: Dict[str, int] = Field(
+        description="Tier counts: {high, watch, noise}"
+    )
+    triaged_assets: List[TriagedAssetResponse] = Field(
+        description="Ranked assets for this run"
+    )
+    fallback_used: bool = Field(
+        description="True if the deterministic fallback produced this digest"
+    )
+    model: str = Field(
+        description="Reasoning model used, or 'deterministic-fallback'"
+    )
+
+
+class AlertDigestListResponse(BaseModel):
+    digests: List[AlertDigestResponse] = Field(
+        description="Full digests for the recent window, newest-first"
+    )

--- a/api/routers/alert_digest.py
+++ b/api/routers/alert_digest.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from api.dependencies import get_dynamodb_client
+from api.models.alert_digest import (
+    AlertDigestListResponse,
+    AlertDigestResponse,
+)
+from api.services.alert_digest_service import AlertDigestService
+from client.aws_client import DynamoDBClient
+from utils.logger import Logger
+
+router = APIRouter(prefix="/api/alert-digests", tags=["alert-digests"])
+logger = Logger.get_logger("alert_digest_router")
+
+
+def get_alert_digest_service(
+    dynamodb_client: DynamoDBClient = Depends(get_dynamodb_client),
+) -> AlertDigestService:
+    return AlertDigestService(dynamodb_client)
+
+
+@router.get("", response_model=AlertDigestListResponse)
+async def list_alert_digests(
+    limit: Optional[int] = Query(
+        None,
+        ge=1,
+        le=365,
+        description="Maximum number of digests to return (default all)",
+    ),
+    service: AlertDigestService = Depends(get_alert_digest_service),
+) -> AlertDigestListResponse:
+    """
+    List recent alert-triage digests, newest-first.
+
+    Returns full digests (including per-asset payloads) so the homepage
+    carousel can page client-side without per-day round-trips.
+    """
+    digests = await service.list_recent(limit=limit)
+    return AlertDigestListResponse(digests=digests)
+
+
+@router.get("/{run_date}", response_model=AlertDigestResponse)
+async def get_alert_digest(
+    run_date: str,
+    service: AlertDigestService = Depends(get_alert_digest_service),
+) -> AlertDigestResponse:
+    """Get the brief for a specific run date (YYYY-MM-DD)."""
+    digest = await service.get_by_run_date(run_date)
+    if digest is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No digest found for run date {run_date}",
+        )
+    return digest

--- a/api/services/alert_digest_service.py
+++ b/api/services/alert_digest_service.py
@@ -1,0 +1,79 @@
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+from cachetools import TTLCache
+
+from api.models.alert_digest import (
+    AlertDigestResponse,
+    TriagedAssetResponse,
+)
+from client.aws_client import DynamoDBClient
+from utils.logger import Logger
+
+logger = Logger.get_logger("alert_digest_api_service")
+
+
+class AlertDigestService:
+    """Service for reading persisted alert-triage digests via API."""
+
+    def __init__(self, dynamodb_client: DynamoDBClient):
+        self.dynamodb_client = dynamodb_client
+        self._cache: TTLCache = TTLCache(maxsize=8, ttl=300)
+        self._cache_lock = asyncio.Lock()
+
+    async def list_recent(
+        self, limit: Optional[int] = None
+    ) -> List[AlertDigestResponse]:
+        cache_key = f"digests_{limit}"
+        async with self._cache_lock:
+            if cache_key in self._cache:
+                logger.debug("Using cached alert digests")
+                return self._cache[cache_key]
+
+            logger.info("Cache miss - fetching alert digests from DynamoDB")
+            items = await self.dynamodb_client.get_alert_digests(limit=limit)
+            digests = [self._to_response(item) for item in items]
+            self._cache[cache_key] = digests
+            return digests
+
+    async def get_by_run_date(
+        self, run_date: str
+    ) -> Optional[AlertDigestResponse]:
+        item = await self.dynamodb_client.get_alert_digest(run_date)
+        if item is None:
+            return None
+        return self._to_response(item)
+
+    def _to_response(self, item: Dict[str, Any]) -> AlertDigestResponse:
+        return AlertDigestResponse(
+            run_date=item["run_date"],
+            created_at=int(item["created_at"]),
+            summary=item["summary"],
+            counts={k: int(v) for k, v in item["counts"].items()},
+            triaged_assets=[
+                self._to_triaged_asset(asset)
+                for asset in item.get("triaged_assets", [])
+            ],
+            fallback_used=bool(item["fallback_used"]),
+            model=item["model"],
+        )
+
+    def _to_triaged_asset(self, asset: Dict[str, Any]) -> TriagedAssetResponse:
+        return TriagedAssetResponse(
+            asset_code=asset["asset_code"],
+            asset_description=asset["asset_description"],
+            exchange=asset["exchange"],
+            country_code=asset.get("country_code"),
+            conviction=asset["conviction"],
+            rank=(
+                int(asset["rank"]) if asset.get("rank") is not None else None
+            ),
+            rationale=asset["rationale"],
+            patterns=asset["patterns"],
+            ma50_slope=(
+                float(asset["ma50_slope"])
+                if isinstance(asset.get("ma50_slope"), Decimal)
+                else asset.get("ma50_slope")
+            ),
+        )

--- a/client/aws_client.py
+++ b/client/aws_client.py
@@ -12,7 +12,7 @@ import aioboto3
 import boto3
 from botocore.exceptions import ClientError
 
-from model import Alert, AlertType
+from model import Alert, AlertDigest, AlertType
 from utils.json_util import dumps_indicator, hash_indicator
 from utils.logger import Logger
 
@@ -886,3 +886,86 @@ class DynamoDBClient(AwsClient):
                 f"Error querying orders for workflow {workflow_id}: {e}"
             )
             return []
+
+    @_dynamo_operation
+    async def store_alert_digest(self, digest: AlertDigest) -> Dict[str, Any]:
+        item = {
+            "run_date": digest.run_date,
+            "created_at": digest.created_at,
+            "summary": digest.summary,
+            "counts": digest.counts,
+            "triaged_assets": [
+                {
+                    "asset_code": asset.asset_code,
+                    "asset_description": asset.asset_description,
+                    "exchange": asset.exchange,
+                    "conviction": asset.conviction.value,
+                    "rationale": asset.rationale,
+                    "patterns": [p.value for p in asset.patterns],
+                    "ma50_slope": asset.ma50_slope,
+                    "rank": asset.rank,
+                    "country_code": asset.country_code,
+                }
+                for asset in digest.triaged_assets
+            ],
+            "fallback_used": digest.fallback_used,
+            "model": digest.model,
+        }
+        item = self._convert_floats_to_decimal(item)
+
+        table = await self._get_table("alert_digests")
+        response = await table.put_item(Item=item)
+
+        if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+            self.logger.error(f"DynamoDB put_item error: {response}")
+
+        return response
+
+    @_dynamo_operation
+    async def get_alert_digests(
+        self, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        digests: List[Dict[str, Any]] = []
+        table = await self._get_table("alert_digests")
+        response = await table.scan()
+
+        if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+            self.logger.error(f"DynamoDB scan error: {response}")
+            return digests
+
+        digests.extend(response.get("Items", []))
+
+        while "LastEvaluatedKey" in response:
+            response = await table.scan(
+                ExclusiveStartKey=response["LastEvaluatedKey"]
+            )
+            if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+                self.logger.error(f"DynamoDB scan error: {response}")
+                break
+            digests.extend(response.get("Items", []))
+
+        digests.sort(key=lambda d: int(d.get("created_at", 0)), reverse=True)
+
+        if limit is not None:
+            digests = digests[:limit]
+
+        return digests
+
+    @_dynamo_operation
+    async def get_alert_digest(
+        self, run_date: str
+    ) -> Optional[Dict[str, Any]]:
+        table = await self._get_table("alert_digests")
+        response = await table.query(
+            KeyConditionExpression="run_date = :run_date",
+            ExpressionAttributeValues={":run_date": run_date},
+            ScanIndexForward=False,
+            Limit=1,
+        )
+
+        if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+            self.logger.error(f"DynamoDB query error: {response}")
+            return None
+
+        items = response.get("Items", [])
+        return items[0] if items else None

--- a/frontend/src/components/DailyBrief.css
+++ b/frontend/src/components/DailyBrief.css
@@ -1,0 +1,26 @@
+.daily-brief-container {
+  max-width: 1400px;
+  margin: 0 auto 1.5rem;
+  padding: 0 2rem;
+}
+
+.daily-brief-message,
+.daily-brief-error {
+  text-align: center;
+  padding: 1.5rem;
+  font-size: 1rem;
+  color: #8b949e;
+}
+
+.daily-brief-error {
+  color: #f85149;
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid #f85149;
+  border-radius: 6px;
+}
+
+@media (max-width: 768px) {
+  .daily-brief-container {
+    padding: 0 1rem;
+  }
+}

--- a/frontend/src/components/DailyBrief.tsx
+++ b/frontend/src/components/DailyBrief.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import type { AlertDigest } from '../services/api';
+import { alertDigestService } from '../services/api';
+import { DailyBriefCarousel } from './DailyBriefCarousel';
+import './DailyBrief.css';
+
+const RECENT_DIGESTS_LIMIT = 14;
+
+export function DailyBrief() {
+  const [digests, setDigests] = useState<AlertDigest[]>([]);
+  const [index, setIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchDigests = async () => {
+      try {
+        setError(null);
+        const data = await alertDigestService.listRecent(
+          RECENT_DIGESTS_LIMIT
+        );
+        setDigests(data.digests);
+        setIndex(0);
+      } catch (err) {
+        console.error('Failed to fetch alert digests:', err);
+        setError('Failed to load the daily brief.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchDigests();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="daily-brief-container">
+        <div className="daily-brief-message">Loading daily brief...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="daily-brief-container">
+        <div className="daily-brief-error">{error}</div>
+      </div>
+    );
+  }
+
+  if (digests.length === 0) {
+    return null;
+  }
+
+  const digest = digests[index];
+
+  return (
+    <div className="daily-brief-container">
+      <DailyBriefCarousel
+        digest={digest}
+        hasPrev={index < digests.length - 1}
+        hasNext={index > 0}
+        onPrev={() => setIndex((i) => Math.min(i + 1, digests.length - 1))}
+        onNext={() => setIndex((i) => Math.max(i - 1, 0))}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/DailyBriefCarousel.css
+++ b/frontend/src/components/DailyBriefCarousel.css
@@ -1,0 +1,116 @@
+.daily-brief-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daily-brief-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.daily-brief-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.daily-brief-date {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.daily-brief-fallback-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #d29922;
+  background: rgba(210, 153, 34, 0.15);
+  border: 1px solid #d29922;
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.daily-brief-nav {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.daily-brief-nav:hover:not(:disabled) {
+  background: #2962ff;
+  border-color: #2962ff;
+}
+
+.daily-brief-nav:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.daily-brief-summary {
+  font-size: 0.9rem;
+  color: #c9d1d9;
+}
+
+.daily-brief-assets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.daily-brief-asset {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 0.6rem;
+  background: #0d1117;
+  border: 1px solid #21262d;
+  border-radius: 4px;
+}
+
+.daily-brief-asset-badge {
+  font-size: 0.9rem;
+}
+
+.daily-brief-asset-name {
+  font-weight: 600;
+  color: #e6edf3;
+  font-size: 0.9rem;
+}
+
+.daily-brief-asset-rationale {
+  color: #8b949e;
+  font-size: 0.8rem;
+}
+
+.daily-brief-empty {
+  color: #8b949e;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.daily-brief-noise {
+  color: #8b949e;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 768px) {
+  .daily-brief-card {
+    padding: 1rem;
+  }
+}

--- a/frontend/src/components/DailyBriefCarousel.tsx
+++ b/frontend/src/components/DailyBriefCarousel.tsx
@@ -1,0 +1,103 @@
+import type { AlertDigest, TriagedAsset } from '../services/api';
+import './DailyBriefCarousel.css';
+
+interface DailyBriefCarouselProps {
+  digest: AlertDigest;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+const CONVICTION_BADGE: Record<string, string> = {
+  high: '🔴',
+  watch: '🟡',
+};
+
+function AssetRow({ asset }: { asset: TriagedAsset }) {
+  return (
+    <div className="daily-brief-asset">
+      <span className="daily-brief-asset-badge">
+        {CONVICTION_BADGE[asset.conviction] ?? ''}
+      </span>
+      <span className="daily-brief-asset-name">
+        {asset.asset_description} ({asset.asset_code})
+      </span>
+      {asset.rationale && (
+        <span className="daily-brief-asset-rationale">
+          {asset.rationale}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function DailyBriefCarousel({
+  digest,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+}: DailyBriefCarouselProps) {
+  const rankedAssets = digest.triaged_assets
+    .filter((asset) => asset.conviction !== 'noise')
+    .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  const noiseCount = digest.counts['noise'] ?? 0;
+
+  return (
+    <div className="daily-brief-card">
+      <div className="daily-brief-header">
+        <button
+          className="daily-brief-nav"
+          onClick={onPrev}
+          disabled={!hasPrev}
+          aria-label="Previous day"
+        >
+          ‹
+        </button>
+        <div className="daily-brief-title">
+          <span className="daily-brief-date">{digest.run_date}</span>
+          {digest.fallback_used && (
+            <span
+              className="daily-brief-fallback-badge"
+              title="Produced by the deterministic fallback (reasoning was unavailable)"
+            >
+              fallback
+            </span>
+          )}
+        </div>
+        <button
+          className="daily-brief-nav"
+          onClick={onNext}
+          disabled={!hasNext}
+          aria-label="Next day"
+        >
+          ›
+        </button>
+      </div>
+
+      <div className="daily-brief-summary">{digest.summary}</div>
+
+      {rankedAssets.length > 0 ? (
+        <div className="daily-brief-assets">
+          {rankedAssets.map((asset) => (
+            <AssetRow
+              key={`${asset.asset_code}_${asset.country_code ?? ''}`}
+              asset={asset}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="daily-brief-empty">
+          No high or watch signals today.
+        </div>
+      )}
+
+      {noiseCount > 0 && (
+        <div className="daily-brief-noise">
+          + {noiseCount} lower-conviction signal{noiseCount > 1 ? 's' : ''}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { HomepageResponse } from '../services/api';
 import { homepageService } from '../services/api';
+import { DailyBrief } from './DailyBrief';
 import { HomepageCard } from './HomepageCard';
 import './Home.css';
 
@@ -32,39 +33,32 @@ export function Home() {
     return () => clearInterval(interval);
   }, []);
 
-  if (loading) {
-    return (
-      <div className="home-container">
-        <div className="home-message">Loading homepage assets...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="home-container">
-        <div className="home-error">{error}</div>
-      </div>
-    );
-  }
-
-  if (!homepageData || homepageData.items.length === 0) {
-    return (
-      <div className="home-container">
-        <div className="home-empty">
-          No assets on homepage. Add assets from the asset detail page.
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="home-container">
-      <div className="home-grid">
-        {homepageData.items.map((item) => (
-          <HomepageCard key={item.id} item={item} />
-        ))}
-      </div>
-    </div>
+    <>
+      <DailyBrief />
+      {loading ? (
+        <div className="home-container">
+          <div className="home-message">Loading homepage assets...</div>
+        </div>
+      ) : error ? (
+        <div className="home-container">
+          <div className="home-error">{error}</div>
+        </div>
+      ) : !homepageData || homepageData.items.length === 0 ? (
+        <div className="home-container">
+          <div className="home-empty">
+            No assets on homepage. Add assets from the asset detail page.
+          </div>
+        </div>
+      ) : (
+        <div className="home-container">
+          <div className="home-grid">
+            {homepageData.items.map((item) => (
+              <HomepageCard key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -894,3 +894,46 @@ export const tradeRepublicService = {
     return response.data;
   },
 };
+
+export interface TriagedAsset {
+  asset_code: string;
+  asset_description: string;
+  exchange: string;
+  country_code: string | null;
+  conviction: 'high' | 'watch' | 'noise';
+  rank: number | null;
+  rationale: string;
+  patterns: string[];
+  ma50_slope: number | null;
+}
+
+export interface AlertDigest {
+  run_date: string;
+  created_at: number;
+  summary: string;
+  counts: Record<string, number>;
+  triaged_assets: TriagedAsset[];
+  fallback_used: boolean;
+  model: string;
+}
+
+export interface AlertDigestListResponse {
+  digests: AlertDigest[];
+}
+
+export const alertDigestService = {
+  listRecent: async (limit?: number): Promise<AlertDigestListResponse> => {
+    const response = await api.get<AlertDigestListResponse>(
+      '/api/alert-digests',
+      { params: limit ? { limit } : undefined }
+    );
+    return response.data;
+  },
+
+  getByRunDate: async (runDate: string): Promise<AlertDigest> => {
+    const response = await api.get<AlertDigest>(
+      `/api/alert-digests/${runDate}`
+    );
+    return response.data;
+  },
+};

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -20,6 +20,7 @@ asset_details_table = dynamodb.asset_details_table()
 alerts_table = dynamodb.alerts_table()
 workflows_table = dynamodb.workflows_table()
 workflow_orders_table = dynamodb.workflow_orders_table()
+alert_digests_table = dynamodb.alert_digests_table()
 refresh_token_lambda = ecr_repository.repository_url.apply(
     lambda repository_url: lambda_.resfreh_token_lambda(
         repository_url, lambda_role.arn
@@ -49,6 +50,7 @@ iam.dynamodb_policy(
         alerts_table,
         workflows_table,
         workflow_orders_table,
+        alert_digests_table,
     ],
     lambda_role,
 )
@@ -60,6 +62,7 @@ iam.user_dynamodb_policy(
         alerts_table,
         workflows_table,
         workflow_orders_table,
+        alert_digests_table,
     ],
     user,
 )
@@ -134,3 +137,4 @@ pulumi.export("asset_details_table_name", asset_details_table.name)
 pulumi.export("alerts_table_name", alerts_table.name)
 pulumi.export("workflows_table_name", workflows_table.name)
 pulumi.export("workflow_orders_table_name", workflow_orders_table.name)
+pulumi.export("alert_digests_table_name", alert_digests_table.name)

--- a/pulumi/dynamodb.py
+++ b/pulumi/dynamodb.py
@@ -89,3 +89,19 @@ def workflow_orders_table() -> aws.dynamodb.Table:
             attribute_name="ttl",
         ),
     )
+
+
+def alert_digests_table() -> aws.dynamodb.Table:
+    return aws.dynamodb.Table(
+        "alert_digests",
+        attributes=[
+            aws.dynamodb.TableAttributeArgs(name="run_date", type="S"),
+            aws.dynamodb.TableAttributeArgs(name="created_at", type="N"),
+        ],
+        hash_key="run_date",
+        range_key="created_at",
+        name="alert_digests",
+        billing_mode="PAY_PER_REQUEST",
+        stream_enabled=True,
+        stream_view_type="NEW_AND_OLD_IMAGES",
+    )

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -630,6 +630,7 @@ async def run_alerting(
                 configuration.triage_slope_threshold,
             )
             digest = triage_agent.synthesize(all_alerts)
+            await dynamodb_client.store_alert_digest(digest)
             logger.info(
                 f"Triage digest for {digest.run_date}: {digest.counts} "
                 f"(fallback={digest.fallback_used})"

--- a/specs/023-alert-triage/tasks.md
+++ b/specs/023-alert-triage/tasks.md
@@ -99,9 +99,9 @@ Web + Lambda layout (per plan.md): backend at repo root (`model/`, `client/`, `s
 - [x] T020 [US3] Implement `AlertDigestService` in `api/services/alert_digest_service.py`: list full digests newest-first, get by run_date, short `TTLCache` like `AlertingService` (uses `DynamoDBClient` methods only — no client internals) (depends on T016, T019)
 - [x] T021 [US3] Test `AlertDigestService` newest-first list + get-by-run_date in `tests/api/test_alert_digest_service.py`
 - [x] T022 [US3] Implement router `api/routers/alert_digest.py` (`GET /api/alert-digests`, `GET /api/alert-digests/{run_date}`, 404 on missing) and `include_router` in `api/main.py` (depends on T020)
-- [ ] T023 [P] [US3] Add `alertDigestService` (`listRecent`, `getByRunDate`) + TS interfaces mirroring the Pydantic models in `frontend/src/services/api.ts`
-- [ ] T024 [US3] Build `DailyBrief.tsx` + `DailyBriefCarousel.tsx` (+ CSS) in `frontend/src/components/`: conviction badges (🔴 high / 🟡 watch), noise as a count, fallback indicator, reverse-chronological carousel paging (depends on T023)
-- [ ] T025 [US3] Render the `DailyBrief` section above the existing grid in `frontend/src/components/Home.tsx` (depends on T024)
+- [x] T023 [P] [US3] Add `alertDigestService` (`listRecent`, `getByRunDate`) + TS interfaces mirroring the Pydantic models in `frontend/src/services/api.ts`
+- [x] T024 [US3] Build `DailyBrief.tsx` + `DailyBriefCarousel.tsx` (+ CSS) in `frontend/src/components/`: conviction badges (🔴 high / 🟡 watch), noise as a count, fallback indicator, reverse-chronological carousel paging (depends on T023)
+- [x] T025 [US3] Render the `DailyBrief` section above the existing grid in `frontend/src/components/Home.tsx` (depends on T024)
 
 **Checkpoint**: Briefs persist indefinitely (SC-006) and are browsable on the homepage
 

--- a/specs/023-alert-triage/tasks.md
+++ b/specs/023-alert-triage/tasks.md
@@ -90,15 +90,15 @@ Web + Lambda layout (per plan.md): backend at repo root (`model/`, `client/`, `s
 
 ### Implementation for User Story 3
 
-- [ ] T014 [P] [US3] Add `alert_digests_table()` (hash `run_date` S, range `created_at` N, PAY_PER_REQUEST, streams on, **no TTL**) to `pulumi/dynamodb.py`
-- [ ] T015 [US3] Register the table in `pulumi/__main__.py` (instantiate + Lambda/API IAM grant + `pulumi.export`) (depends on T014)
-- [ ] T016 [US3] Add public `store_alert_digest`, `get_alert_digests(limit)`, `get_alert_digest(run_date)` to `client/aws_client.py` (float→Decimal on write; scan newest-first by `created_at`; query by `run_date`) (depends on T005)
-- [ ] T017 [P] [US3] Test store/get round-trip incl. float→Decimal and newest-first ordering in `tests/client/test_aws_client_alert_digests.py`
-- [ ] T018 [US3] Persist the digest: call `store_alert_digest` after `synthesize` in `run_alerting` (`saxo_order/commands/alerting.py`) (depends on T009, T016)
-- [ ] T019 [P] [US3] Pydantic v2 models `TriagedAssetResponse`, `AlertDigestResponse`, `AlertDigestListResponse` (list carries **full** digests) in `api/models/alert_digest.py` (field names mirror domain models exactly)
-- [ ] T020 [US3] Implement `AlertDigestService` in `api/services/alert_digest_service.py`: list full digests newest-first, get by run_date, short `TTLCache` like `AlertingService` (uses `DynamoDBClient` methods only — no client internals) (depends on T016, T019)
-- [ ] T021 [US3] Test `AlertDigestService` newest-first list + get-by-run_date in `tests/api/test_alert_digest_service.py`
-- [ ] T022 [US3] Implement router `api/routers/alert_digest.py` (`GET /api/alert-digests`, `GET /api/alert-digests/{run_date}`, 404 on missing) and `include_router` in `api/main.py` (depends on T020)
+- [x] T014 [P] [US3] Add `alert_digests_table()` (hash `run_date` S, range `created_at` N, PAY_PER_REQUEST, streams on, **no TTL**) to `pulumi/dynamodb.py`
+- [x] T015 [US3] Register the table in `pulumi/__main__.py` (instantiate + Lambda/API IAM grant + `pulumi.export`) (depends on T014)
+- [x] T016 [US3] Add public `store_alert_digest`, `get_alert_digests(limit)`, `get_alert_digest(run_date)` to `client/aws_client.py` (float→Decimal on write; scan newest-first by `created_at`; query by `run_date`) (depends on T005)
+- [x] T017 [P] [US3] Test store/get round-trip incl. float→Decimal and newest-first ordering in `tests/client/test_aws_client_alert_digests.py`
+- [x] T018 [US3] Persist the digest: call `store_alert_digest` after `synthesize` in `run_alerting` (`saxo_order/commands/alerting.py`) (depends on T009, T016)
+- [x] T019 [P] [US3] Pydantic v2 models `TriagedAssetResponse`, `AlertDigestResponse`, `AlertDigestListResponse` (list carries **full** digests) in `api/models/alert_digest.py` (field names mirror domain models exactly)
+- [x] T020 [US3] Implement `AlertDigestService` in `api/services/alert_digest_service.py`: list full digests newest-first, get by run_date, short `TTLCache` like `AlertingService` (uses `DynamoDBClient` methods only — no client internals) (depends on T016, T019)
+- [x] T021 [US3] Test `AlertDigestService` newest-first list + get-by-run_date in `tests/api/test_alert_digest_service.py`
+- [x] T022 [US3] Implement router `api/routers/alert_digest.py` (`GET /api/alert-digests`, `GET /api/alert-digests/{run_date}`, 404 on missing) and `include_router` in `api/main.py` (depends on T020)
 - [ ] T023 [P] [US3] Add `alertDigestService` (`listRecent`, `getByRunDate`) + TS interfaces mirroring the Pydantic models in `frontend/src/services/api.ts`
 - [ ] T024 [US3] Build `DailyBrief.tsx` + `DailyBriefCarousel.tsx` (+ CSS) in `frontend/src/components/`: conviction badges (🔴 high / 🟡 watch), noise as a count, fallback indicator, reverse-chronological carousel paging (depends on T023)
 - [ ] T025 [US3] Render the `DailyBrief` section above the existing grid in `frontend/src/components/Home.tsx` (depends on T024)

--- a/tests/api/services/test_alert_digest_service.py
+++ b/tests/api/services/test_alert_digest_service.py
@@ -1,0 +1,100 @@
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.services.alert_digest_service import AlertDigestService
+from client.aws_client import DynamoDBClient
+
+
+@pytest.fixture
+def mock_dynamodb_client():
+    return AsyncMock(spec=DynamoDBClient)
+
+
+@pytest.fixture
+def service(mock_dynamodb_client):
+    return AlertDigestService(mock_dynamodb_client)
+
+
+def _item(run_date: str, created_at: int) -> dict:
+    return {
+        "run_date": run_date,
+        "created_at": Decimal(created_at),
+        "summary": f"digest {run_date}",
+        "counts": {
+            "high": Decimal(1),
+            "watch": Decimal(0),
+            "noise": Decimal(0),
+        },
+        "triaged_assets": [
+            {
+                "asset_code": "SAN",
+                "asset_description": "Sanofi",
+                "exchange": "saxo",
+                "country_code": "xpar",
+                "conviction": "high",
+                "rank": Decimal(1),
+                "rationale": "double top + MA50 rejection",
+                "patterns": ["double_top", "mm50_touch"],
+                "ma50_slope": Decimal("-2.3"),
+            }
+        ],
+        "fallback_used": False,
+        "model": "claude-sonnet-5",
+    }
+
+
+class TestListRecent:
+    async def test_list_recent_returns_newest_first_and_converts_decimals(
+        self, service, mock_dynamodb_client
+    ):
+        mock_dynamodb_client.get_alert_digests.return_value = [
+            _item("2026-07-16", 300),
+            _item("2026-07-15", 200),
+        ]
+
+        digests = await service.list_recent()
+
+        assert [d.run_date for d in digests] == ["2026-07-16", "2026-07-15"]
+        assert digests[0].counts == {"high": 1, "watch": 0, "noise": 0}
+        assert digests[0].triaged_assets[0].ma50_slope == -2.3
+        assert digests[0].triaged_assets[0].rank == 1
+
+    async def test_list_recent_uses_cache_on_second_call(
+        self, service, mock_dynamodb_client
+    ):
+        mock_dynamodb_client.get_alert_digests.return_value = [
+            _item("2026-07-16", 300)
+        ]
+
+        await service.list_recent()
+        await service.list_recent()
+
+        mock_dynamodb_client.get_alert_digests.assert_called_once()
+
+
+class TestGetByRunDate:
+    async def test_get_by_run_date_returns_digest(
+        self, service, mock_dynamodb_client
+    ):
+        mock_dynamodb_client.get_alert_digest.return_value = _item(
+            "2026-07-16", 300
+        )
+
+        digest = await service.get_by_run_date("2026-07-16")
+
+        assert digest is not None
+        assert digest.run_date == "2026-07-16"
+        mock_dynamodb_client.get_alert_digest.assert_called_once_with(
+            "2026-07-16"
+        )
+
+    async def test_get_by_run_date_returns_none_when_missing(
+        self, service, mock_dynamodb_client
+    ):
+        mock_dynamodb_client.get_alert_digest.return_value = None
+
+        digest = await service.get_by_run_date("2026-01-01")
+
+        assert digest is None

--- a/tests/client/test_aws_client_alert_digests.py
+++ b/tests/client/test_aws_client_alert_digests.py
@@ -1,0 +1,138 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from client.aws_client import DynamoDBClient
+from model import AlertDigest, AlertType, Conviction, TriagedAsset
+
+
+@pytest.fixture
+def mock_dynamodb_resource():
+    mock_resource = AsyncMock()
+    mock_table = AsyncMock()
+    mock_resource.Table.return_value = mock_table
+    return mock_resource, mock_table
+
+
+@pytest.fixture
+def client(mock_dynamodb_resource):
+    mock_resource, _ = mock_dynamodb_resource
+    return DynamoDBClient(dynamodb_resource=mock_resource)
+
+
+def _digest(run_date: str, created_at: int) -> AlertDigest:
+    return AlertDigest(
+        run_date=run_date,
+        created_at=created_at,
+        summary="1 high, 0 watch, 0 noise.",
+        counts={"high": 1, "watch": 0, "noise": 0},
+        triaged_assets=[
+            TriagedAsset(
+                asset_code="SAN",
+                asset_description="Sanofi",
+                exchange="saxo",
+                conviction=Conviction.HIGH,
+                rationale="double top + MA50 rejection, slope -2.3%",
+                patterns=[AlertType.DOUBLE_TOP, AlertType.MM50_TOUCH],
+                ma50_slope=-2.3,
+                rank=1,
+                country_code="xpar",
+            )
+        ],
+        model="claude-sonnet-5",
+        fallback_used=False,
+    )
+
+
+class TestStoreAlertDigest:
+    async def test_store_alert_digest_converts_floats_and_enums(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.put_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200}
+        }
+
+        digest = _digest("2026-07-16", 1768579200)
+        await client.store_alert_digest(digest)
+
+        mock_table.put_item.assert_called_once()
+        item = mock_table.put_item.call_args[1]["Item"]
+        assert item["run_date"] == "2026-07-16"
+        assert item["created_at"] == 1768579200
+        assert item["fallback_used"] is False
+        assert item["model"] == "claude-sonnet-5"
+
+        asset = item["triaged_assets"][0]
+        assert asset["asset_code"] == "SAN"
+        assert asset["conviction"] == "high"
+        assert asset["patterns"] == ["double_top", "mm50_touch"]
+        assert str(asset["ma50_slope"]) == "-2.3"
+
+
+class TestGetAlertDigests:
+    async def test_get_alert_digests_returns_newest_first(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.scan.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [
+                {"run_date": "2026-07-14", "created_at": 100},
+                {"run_date": "2026-07-16", "created_at": 300},
+                {"run_date": "2026-07-15", "created_at": 200},
+            ],
+        }
+
+        digests = await client.get_alert_digests()
+
+        assert [d["created_at"] for d in digests] == [300, 200, 100]
+
+    async def test_get_alert_digests_respects_limit(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.scan.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [
+                {"run_date": "2026-07-14", "created_at": 100},
+                {"run_date": "2026-07-16", "created_at": 300},
+            ],
+        }
+
+        digests = await client.get_alert_digests(limit=1)
+
+        assert len(digests) == 1
+        assert digests[0]["created_at"] == 300
+
+
+class TestGetAlertDigest:
+    async def test_get_alert_digest_returns_latest_for_run_date(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.query.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [{"run_date": "2026-07-16", "created_at": 300}],
+        }
+
+        digest = await client.get_alert_digest("2026-07-16")
+
+        assert digest is not None
+        assert digest["created_at"] == 300
+        query_kwargs = mock_table.query.call_args[1]
+        assert query_kwargs["ScanIndexForward"] is False
+        assert query_kwargs["Limit"] == 1
+
+    async def test_get_alert_digest_returns_none_when_missing(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.query.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [],
+        }
+
+        digest = await client.get_alert_digest("2026-07-01")
+
+        assert digest is None


### PR DESCRIPTION
## Summary

Phase 5 (User Story 3) for spec **023 — Alert Triage & Synthesis Agent** (tasks T014–T025). Daily briefs now persist indefinitely and are browsable on the homepage — the payoff for the MVP built in phases 3–4 (#629–#631).

## Backend + API (commit `b066068`)

| Task | Change |
|------|--------|
| T014–T015 | `alert_digests` table in Pulumi (hash `run_date`, range `created_at`, **no TTL** — deliberate, buys history that outlives the 7-day raw-alert expiry), registered + IAM-granted in `pulumi/__main__.py` |
| T016–T017 | `store_alert_digest`, `get_alert_digests(limit)`, `get_alert_digest(run_date)` on `DynamoDBClient` (float/enum → Decimal/str on write, newest-first scan, query by run_date) + round-trip tests |
| T018 | `run_alerting` persists the digest after `synthesize` |
| T019–T022 | Pydantic models, `AlertDigestService` (TTLCache, Decimal→int/float conversion), router (`GET /api/alert-digests`, `GET /api/alert-digests/{run_date}`, 404 on missing) + tests |

## Frontend (commit `2e601fc`)

| Task | Change |
|------|--------|
| T023 | `alertDigestService` + `AlertDigest`/`TriagedAsset` TS interfaces in `api.ts`, mirroring the Pydantic models |
| T024 | `DailyBrief.tsx` (fetches last 14 digests, drives carousel index, loading/error/empty states) + `DailyBriefCarousel.tsx` (conviction badges 🔴/🟡, rationale, noise-as-count, fallback badge, prev/next paging) |
| T025 | Rendered above the existing grid in `Home.tsx` — **no new route or sidebar entry**, per the carousel-only homepage design (see spec assumptions) |

## Verification

- `black` / `isort` / `flake8` clean; `mypy` **Success: no issues found** (CI flags) on all backend files.
- Backend/API tests: **9 passed** (storage round-trip + service).
- Frontend: `tsc --noEmit` clean. `npm run build` / `npm run lint` produce the **identical pre-existing error set** (12 errors, 3 warnings, none in files this PR touches) on a fully clean tree (`git stash -u`) and with these changes applied — confirmed side-by-side, zero new errors introduced.
- The 14 `tests/api/routers/test_workflow.py` failures are pre-existing on `main` (unrelated to this change, verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_