### PR TITLE
fix: make main pass the new CI checks

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -87,7 +87,9 @@ async def dynamodb_error_handler(
     return JSONResponse(
         status_code=503,
         content={
-            "detail": "Service temporarily unavailable. Please try again later."
+            "detail": (
+                "Service temporarily unavailable. Please try again later."
+            )
         },
     )
 

--- a/frontend/src/components/AlertCard.tsx
+++ b/frontend/src/components/AlertCard.tsx
@@ -42,14 +42,15 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
     return `${days} days ago`;
   };
 
-  const formatMA50Slope = (slope: any): string => {
+  const formatMA50Slope = (slope: unknown): string => {
     // Handle null, undefined, or non-numeric values
     if (slope === null || slope === undefined || slope === '') {
       return 'N/A';
     }
 
     // Convert to number if it's a string
-    const numericSlope = typeof slope === 'number' ? slope : parseFloat(slope);
+    const numericSlope =
+      typeof slope === 'number' ? slope : parseFloat(String(slope));
 
     // Check if conversion was successful
     if (isNaN(numericSlope)) {
@@ -60,14 +61,15 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
     return `${sign}${numericSlope.toFixed(1)}%`;
   };
 
-  const getMA50SlopeClass = (slope: any): string => {
+  const getMA50SlopeClass = (slope: unknown): string => {
     // Handle null, undefined, or non-numeric values
     if (slope === null || slope === undefined || slope === '') {
       return 'ma50-slope-neutral';
     }
 
     // Convert to number if it's a string
-    const numericSlope = typeof slope === 'number' ? slope : parseFloat(slope);
+    const numericSlope =
+      typeof slope === 'number' ? slope : parseFloat(String(slope));
 
     // Check if conversion was successful
     if (isNaN(numericSlope)) {
@@ -119,7 +121,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
       }
     } catch (error) {
       console.error('Failed to exclude asset:', error);
-      alert('Failed to exclude asset. Please try again.');
+      window.alert('Failed to exclude asset. Please try again.');
     } finally {
       setIsExcluding(false);
     }

--- a/frontend/src/components/IndicatorCard.tsx
+++ b/frontend/src/components/IndicatorCard.tsx
@@ -59,8 +59,13 @@ export function IndicatorCard({ indicators, onTradingViewUrlUpdated }: Indicator
       if (onTradingViewUrlUpdated) {
         onTradingViewUrlUpdated(tradingViewUrl);
       }
-    } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to save TradingView URL');
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        setError(axiosError.response?.data?.detail || 'Failed to save TradingView URL');
+      } else {
+        setError('Failed to save TradingView URL');
+      }
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -14,7 +14,7 @@ export function Navigation() {
   useEffect(() => {
     loadIndexes();
 
-    let intervalId: NodeJS.Timeout | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
     let lastLoadTime = Date.now();
 
     const handleVisibilityChange = () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ export function Sidebar() {
   useEffect(() => {
     loadWatchlist();
 
-    let intervalId: NodeJS.Timeout | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
     // Function to start/stop auto-refresh based on visibility
     const handleVisibilityChange = () => {

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -85,9 +85,13 @@ export function Alerts() {
     .sort((a, b) => {
       if (sortBy === 'ma50_slope') {
         // Sort by MA50 slope descending (highest slope first)
-        // Treat missing/null values as 0
-        const aSlope = a.data?.ma50_slope ?? 0;
-        const bSlope = b.data?.ma50_slope ?? 0;
+        // Treat missing/null/non-numeric values as 0
+        const toSlope = (value: unknown): number => {
+          const numeric = typeof value === 'number' ? value : parseFloat(String(value));
+          return isNaN(numeric) ? 0 : numeric;
+        };
+        const aSlope = toSlope(a.data?.ma50_slope);
+        const bSlope = toSlope(b.data?.ma50_slope);
         return bSlope - aSlope; // Descending order
       } else {
         // Sort by date descending (newest first)

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import {
   workflowService,
   indicatorService,
@@ -219,15 +220,18 @@ export function AssetDetail() {
         // Refresh alerts section
         await fetchAlerts(symbol);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Run alerts error:', err);
 
       // Specific error message mapping
-      if (err.code === 'ECONNABORTED' || err.message?.includes('timeout')) {
+      if (
+        axios.isAxiosError(err) &&
+        (err.code === 'ECONNABORTED' || err.message?.includes('timeout'))
+      ) {
         setRunAlertsError(
           'Alert detection timed out. Please try again.'
         );
-      } else if (err.response) {
+      } else if (axios.isAxiosError(err) && err.response) {
         // HTTP error responses
         const status = err.response.status;
         switch (status) {
@@ -251,7 +255,7 @@ export function AssetDetail() {
               err.response.data?.detail || 'An error occurred during alert detection.'
             );
         }
-      } else if (err.request) {
+      } else if (axios.isAxiosError(err) && err.request) {
         // Network error (request made but no response)
         setRunAlertsError(
           'Connection failed. Please check your network and try again.'
@@ -361,8 +365,12 @@ export function AssetDetail() {
       }
 
       setTimeout(() => setWatchlistSuccess(null), 3000);
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to update watchlist';
+    } catch (err: unknown) {
+      let errorMessage = 'Failed to update watchlist';
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        errorMessage = axiosError.response?.data?.detail || errorMessage;
+      }
       setWatchlistError(errorMessage);
       console.error('Watchlist toggle error:', err);
       setTimeout(() => setWatchlistError(null), 5000);
@@ -396,8 +404,12 @@ export function AssetDetail() {
       setWatchlistSuccess(`${action} short-term positions: ${assetName}`);
 
       setTimeout(() => setWatchlistSuccess(null), 3000);
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to update label';
+    } catch (err: unknown) {
+      let errorMessage = 'Failed to update label';
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        errorMessage = axiosError.response?.data?.detail || errorMessage;
+      }
       setWatchlistError(errorMessage);
       console.error('Label toggle error:', err);
       setTimeout(() => setWatchlistError(null), 5000);
@@ -429,8 +441,12 @@ export function AssetDetail() {
       setWatchlistSuccess(`${action} long-term positions: ${assetName}`);
 
       setTimeout(() => setWatchlistSuccess(null), 3000);
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to update label';
+    } catch (err: unknown) {
+      let errorMessage = 'Failed to update label';
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        errorMessage = axiosError.response?.data?.detail || errorMessage;
+      }
       setWatchlistError(errorMessage);
       console.error('Label toggle error:', err);
       setTimeout(() => setWatchlistError(null), 5000);
@@ -463,8 +479,12 @@ export function AssetDetail() {
       setWatchlistSuccess(`${action} homepage: ${assetName}`);
 
       setTimeout(() => setWatchlistSuccess(null), 3000);
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to update label';
+    } catch (err: unknown) {
+      let errorMessage = 'Failed to update label';
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        errorMessage = axiosError.response?.data?.detail || errorMessage;
+      }
       setWatchlistError(errorMessage);
       console.error('Label toggle error:', err);
       setTimeout(() => setWatchlistError(null), 5000);
@@ -499,8 +519,12 @@ export function AssetDetail() {
       setWatchlistSuccess(`${action} SLWIN positions: ${assetName}`);
 
       setTimeout(() => setWatchlistSuccess(null), 3000);
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to update label';
+    } catch (err: unknown) {
+      let errorMessage = 'Failed to update label';
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { data?: { detail?: string } } };
+        errorMessage = axiosError.response?.data?.detail || errorMessage;
+      }
       setWatchlistError(errorMessage);
       console.error('Label toggle error:', err);
       setTimeout(() => setWatchlistError(null), 5000);

--- a/frontend/src/pages/LongTermPositions.tsx
+++ b/frontend/src/pages/LongTermPositions.tsx
@@ -14,7 +14,7 @@ export function LongTermPositions() {
   useEffect(() => {
     loadData();
 
-    let intervalId: NodeJS.Timeout | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import {
   fundService,
   reportConfigService,
@@ -476,14 +477,15 @@ function OrderModal({
         }
       }
       onSuccess();
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Handle Pydantic validation errors (array of objects) or string errors
-      const detail = err.response?.data?.detail;
+      const detail = axios.isAxiosError(err) ? err.response?.data?.detail : undefined;
       let errorMessage = 'Failed to save to Google Sheets';
 
       if (Array.isArray(detail)) {
         // Pydantic validation errors
-        errorMessage = detail.map((e: any) => `${e.loc?.join('.')}: ${e.msg}`).join(', ');
+        const validationErrors = detail as Array<{ loc?: (string | number)[]; msg: string }>;
+        errorMessage = validationErrors.map((e) => `${e.loc?.join('.')}: ${e.msg}`).join(', ');
       } else if (typeof detail === 'string') {
         errorMessage = detail;
       } else if (detail && typeof detail === 'object') {

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -15,7 +15,7 @@ export function Watchlist() {
   useEffect(() => {
     loadWatchlist();
 
-    let intervalId: NodeJS.Timeout | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
     // Function to start/stop auto-refresh based on visibility
     const handleVisibilityChange = () => {

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -41,7 +41,7 @@ function Workflows() {
   useEffect(() => {
     loadWorkflows();
 
-    let intervalId: NodeJS.Timeout | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -735,7 +735,7 @@ export interface AlertItem {
   exchange: string;
   country_code: string | null;
   date: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   age_hours: number;
   tradingview_url?: string;
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 exclude = pulumi
+plugins = pydantic.mypy
 
 [mypy-pulumi.*]
 follow_imports = skip

--- a/services/candles_service.py
+++ b/services/candles_service.py
@@ -250,7 +250,8 @@ class CandlesService:
         self.logger.info(f"Build candles for {code}, ut: {ut}, date: {date}")
         if market.open_minutes not in [0, 30]:
             raise SaxoException(
-                f"Wrong parameter {market.open_minutes}, we handle only 0 and 30"
+                f"Wrong parameter {market.open_minutes}, "
+                "we handle only 0 and 30"
             )
         nbr_30m = count * 2 * 3
         if ut == UnitTime.H4:

--- a/tests/api/routers/test_indicator.py
+++ b/tests/api/routers/test_indicator.py
@@ -481,7 +481,7 @@ class TestIndicatorEndpoint:
     def test_get_asset_indicators_exchange_parameter(
         self, mock_saxo_client, mock_candles_service, mock_historical_data
     ):
-        """Test that exchange parameter correctly routes to appropriate client."""
+        """Test that exchange parameter routes to the right client."""
         mock_saxo_client.get_historical_data.return_value = (
             mock_historical_data
         )

--- a/tests/api/routers/test_watchlist.py
+++ b/tests/api/routers/test_watchlist.py
@@ -220,14 +220,18 @@ class TestWatchlistEndpoint:
             exchange="saxo",
         )
 
-    def test_add_to_watchlist_missing_required_fields(self):
+    def test_add_to_watchlist_missing_required_fields(
+        self, mock_saxo_client, mock_dynamodb_client
+    ):
         """Test request with missing required fields."""
         # Missing asset_id and asset_symbol
         response = client.post("/api/watchlist", json={})
 
         assert response.status_code == 422  # Validation error
 
-    def test_add_to_watchlist_missing_asset_id(self):
+    def test_add_to_watchlist_missing_asset_id(
+        self, mock_saxo_client, mock_dynamodb_client
+    ):
         """Test request with missing asset_id."""
         response = client.post(
             "/api/watchlist",
@@ -240,7 +244,9 @@ class TestWatchlistEndpoint:
 
         assert response.status_code == 422  # Validation error
 
-    def test_add_to_watchlist_missing_asset_symbol(self):
+    def test_add_to_watchlist_missing_asset_symbol(
+        self, mock_saxo_client, mock_dynamodb_client
+    ):
         """Test request with missing asset_symbol."""
         response = client.post(
             "/api/watchlist",

--- a/tests/api/routers/test_workflow.py
+++ b/tests/api/routers/test_workflow.py
@@ -3,19 +3,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from api.dependencies import get_saxo_client
+from api.dependencies import get_dynamodb_client, get_saxo_client
 from api.main import app
 
 client = TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    """Clear dependency overrides after each test."""
+    yield
+    app.dependency_overrides.clear()
+
+
 @pytest.fixture
 def mock_dynamodb_client():
     """Mock DynamoDBClient with async methods."""
-    with patch("api.dependencies.DynamoDBClient") as mock_class:
-        mock_instance = AsyncMock()
-        mock_class.return_value = mock_instance
-        yield mock_instance
+    mock_instance = AsyncMock()
+    app.dependency_overrides[get_dynamodb_client] = lambda: mock_instance
+    yield mock_instance
 
 
 def create_workflow_data(
@@ -135,7 +141,7 @@ class TestWorkflowEndpoint:
         assert data["total"] == 0
         assert len(data["workflows"]) == 0
 
-    def test_get_asset_workflows_missing_code(self):
+    def test_get_asset_workflows_missing_code(self, mock_dynamodb_client):
         """Test request without required code parameter."""
         response = client.get("/api/workflow/asset")
 

--- a/tests/api/test_error_handling.py
+++ b/tests/api/test_error_handling.py
@@ -1,6 +1,3 @@
-from unittest.mock import AsyncMock, patch
-
-import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -12,7 +9,6 @@ client = TestClient(app)
 class TestDynamoDBErrorHandler:
     def test_dynamodb_error_returns_503(self):
         """Test that DynamoDBOperationError is caught by global handler."""
-        from fastapi import Request
 
         @app.get("/test-dynamo-error")
         async def test_endpoint():

--- a/tests/client/test_aws_client.py
+++ b/tests/client/test_aws_client.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from botocore.exceptions import ClientError
@@ -262,7 +262,7 @@ class TestDynamoDBErrorHandling:
     async def test_graceful_degradation_get_all_tradingview_links(
         self, mock_dynamodb_resource, client
     ):
-        """Methods with internal try/except should return defaults on ClientError."""
+        """Methods with internal try/except return defaults on ClientError."""
         _, mock_table = mock_dynamodb_resource
         mock_table.scan.side_effect = ClientError(
             {

--- a/tests/client/test_gsheet_client.py
+++ b/tests/client/test_gsheet_client.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import MagicMock
 
 from client.gsheet_client import GSheetClient
@@ -308,7 +309,7 @@ class TestGsheetClient:
 
 
 def _make_transaction(**overrides) -> TradeRepublicTransaction:
-    defaults = dict(
+    defaults: Dict[str, Any] = dict(
         date=datetime.strptime("2026-03-02", "%Y-%m-%d").date(),
         datetime=datetime.strptime("2026-03-02T09:15:00", "%Y-%m-%dT%H:%M:%S"),
         account_type="DEFAULT",


### PR DESCRIPTION
## Summary
Now that CI runs on every PR/push (#634), running the checks against `main` surfaced pre-existing issues that need fixing before the CI gate can be trusted. Two commits:

**Backend** (`8e00ee7`):
- flake8: line-length and unused-import cleanup in `api/main.py`, `services/candles_service.py`, and 3 test files
- mypy: enabled the Pydantic mypy plugin (`plugins = pydantic.mypy` in `mypy.ini`) — without it, mypy flagged Pydantic models with `Field(default=...)` as missing required args (false positive on `WorkflowIndicatorInfo`); also fixed one genuine `**kwargs` typing gap in a test fixture
- pytest: `test_workflow.py` and `test_watchlist.py` had tests that only passed because the host machine happened to have `AWS_PROFILE` set, making `get_dynamodb_client` succeed by accident. On a clean runner (like GitHub Actions) they returned 403 instead of the expected response. Fixed by properly overriding the FastAPI dependency via `app.dependency_overrides`, matching the working pattern already used elsewhere in the same file.

**Frontend** (`cbaee5a`):
- **Real bug**: `AlertCard.tsx`'s error handler called `alert(...)`, but the component's own `alert` prop (an `AlertItem` object) shadows `window.alert`, so a failed "exclude asset" action threw a second unhandled `TypeError` instead of notifying the user. Fixed by calling `window.alert(...)` explicitly.
- `tsc -b` was failing on `NodeJS.Timeout` (no `@types/node` in this browser app) in 5 files — switched to `ReturnType<typeof setInterval>`.
- `eslint` had 12 `no-explicit-any` errors — replaced the free-form alert `data` field with `Record<string, unknown>` and typed consumers accordingly, and replaced `err: any` catch blocks with `axios.isAxiosError()`/duck-typed narrowing (matching the existing pattern in `Orders.tsx`).

All checks pass locally with AWS env vars unset, simulating a clean CI runner.

## Test plan
- [ ] Confirm `backend` and `frontend` CI jobs are green on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01GoeKWuZhAqBBoxuBoaEvfy)_