### PR TITLE
feat: Slack digest (phase 6) + fix triage pattern semantics (spec 023)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,5 +4,6 @@ spreadsheet_id: 1nQiFW9Hs8tpXWIPlAg1Rj51ONPA2eJCmfUtFTzTPoBY
 trade_republic_sheet_name: "ETF / DCA"
 anthropic_model: claude-sonnet-5
 triage_slope_threshold: 1.0
+app_url: http://localhost:5173
 currencies_rate:
   usdeur: 0.5

--- a/prod_config.yml
+++ b/prod_config.yml
@@ -4,6 +4,7 @@ spreadsheet_id: 1oGvJLXe4wFRNzB0GbQgWYIMmM_kYaMQILqRRIh1pyO0
 trade_republic_sheet_name: "ETF / DCA"
 anthropic_model: claude-sonnet-5
 triage_slope_threshold: 1.0
+app_url: https://TODO-set-your-frontend-url  # set to the deployed frontend URL
 currencies_rate:
   usdeur: 0.86
   jpyeur: 0.0061

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -17,7 +17,7 @@ from model import Alert, AlertType, AssetType, Candle, EUMarket, UnitTime
 from saxo_order.async_utils import create_dynamodb_client
 from saxo_order.commands import catch_exception
 from services import congestion_indicator, indicator_service
-from services.alert_triage_service import TriageAgent
+from services.alert_triage_service import TriageAgent, format_slack_digest
 from utils.configuration import Configuration
 from utils.exception import SaxoException
 from utils.helper import build_daily_candles_from_h1
@@ -503,15 +503,6 @@ async def run_alerting(
             )
             return
 
-        slack_messages: Dict[str, List[str]] = {
-            "double_top": [],
-            "container_candle": [],
-            "combo": [],
-            "double_inside_bar": [],
-            "congestion": [],
-            "mm50_touch": [],
-        }
-        has_message = False
         all_alerts: List[Alert] = []
         for asset in assets:
             logger.debug(f"scan {asset['name']}")
@@ -537,104 +528,25 @@ async def run_alerting(
             )
             all_alerts.extend(asset_alerts)
 
-            # Build Slack messages from detected alerts
-            for alert in asset_alerts:
-                has_message = True
-                if alert.alert_type == AlertType.CONGESTION20:
-                    date = datetime.datetime.now().strftime("%Y-%m-%d")
-                    touch_points = alert.data.get("touch_points", [])
-                    slack_messages["congestion"].append(
-                        f"{asset['name']}: Congestion detected on {date}\n"
-                        + "Touch points:\n"
-                        + "\n".join(touch_points)
-                    )
-                elif alert.alert_type == AlertType.CONGESTION100:
-                    date = datetime.datetime.now().strftime("%Y-%m-%d")
-                    touch_points = alert.data.get("touch_points", [])
-                    slack_messages["congestion"].append(
-                        f"{asset['name']}: Congestion detected on {date}\n"
-                        + "Touch points:\n"
-                        + "\n".join(touch_points)
-                    )
-                elif alert.alert_type == AlertType.DOUBLE_TOP:
-                    date = (
-                        alert.date.strftime("%Y-%m-%d") if alert.date else ""
-                    )
-                    slack_messages["double_top"].append(
-                        f"{asset['name']}: {date} at "
-                        f"{alert.data.get('close')}"
-                    )
-                elif alert.alert_type == AlertType.CONTAINING_CANDLE:
-                    date = (
-                        alert.date.strftime("%Y-%m-%d") if alert.date else ""
-                    )
-                    slack_messages["container_candle"].append(
-                        f"{asset['name']}: {date} at "
-                        f"{alert.data.get('close')}"
-                    )
-                elif alert.alert_type == AlertType.DOUBLE_INSIDE_BAR:
-                    date = (
-                        alert.date.strftime("%Y-%m-%d") if alert.date else ""
-                    )
-                    slack_messages["double_inside_bar"].append(
-                        f"{asset['name']}: {date} at "
-                        f"{alert.data.get('close')}"
-                    )
-                elif alert.alert_type == AlertType.COMBO:
-                    date = datetime.datetime.now().strftime("%Y-%m-%d")
-                    direction = alert.data.get("direction")
-                    strength = alert.data.get("strength")
-                    price = alert.data.get("price")
-                    triggered = alert.data.get("has_been_triggered")
-                    slack_messages["combo"].append(
-                        f"{asset['name']}: combo {direction} "
-                        f"{strength} {date} at {price} "
-                        f"(has been triggered ? {triggered})"
-                    )
-                elif alert.alert_type == AlertType.MM50_TOUCH:
-                    date = datetime.datetime.now().strftime("%Y-%m-%d")
-                    close = alert.data.get("close")
-                    ma50 = alert.data.get("ma50")
-                    dist = alert.data.get("distance_pct")
-                    slope = alert.data.get("slope")
-                    slack_messages["mm50_touch"].append(
-                        f"{asset['name']}: {date} close={close} "
-                        f"ma50={ma50} dist={dist:.2f}% slope={slope:.2f}%"
-                    )
-        if has_message is False and len(assets) > 1:
-            slack_client.chat_postMessage(
-                channel="#stock",
-                text="No alert for today",
-            )
-        else:
-            for indicator in slack_messages.keys():
-                if len(slack_messages[indicator]) > 0:
-                    message = f"Indicator {indicator} \n```"
-                    for index, slack in enumerate(slack_messages[indicator]):
-                        if index % 10 == 0 and index != 0:
-                            slack_client.chat_postMessage(
-                                channel="#stock",
-                                text=f"{message}\n```",
-                            )
-                            message = f"Indicator {indicator} \n```"
-                        message += f"{slack}\n"
-                    message += "```"
-                    slack_client.chat_postMessage(
-                        channel="#stock",
-                        text=message,
-                    )
-
         try:
             triage_agent = TriageAgent(
                 AnthropicClient(configuration),
                 configuration.triage_slope_threshold,
             )
             digest = triage_agent.synthesize(all_alerts)
-            await dynamodb_client.store_alert_digest(digest)
+            try:
+                await dynamodb_client.store_alert_digest(digest)
+            except Exception as e:
+                logger.error(f"Failed to persist alert digest: {e}")
             logger.info(
                 f"Triage digest for {digest.run_date}: {digest.counts} "
                 f"(fallback={digest.fallback_used})"
             )
+            if len(digest.triaged_assets) > 0 or len(assets) > 1:
+                slack_client.chat_postMessage(
+                    channel="#stock",
+                    text=format_slack_digest(digest, configuration.app_url),
+                )
         except Exception as e:
             logger.error(f"Triage step failed: {e}")
 

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -280,3 +280,38 @@ class TriageAgent:
             f"{counts[Conviction.WATCH.value]} watch, "
             f"{counts[Conviction.NOISE.value]} noise."
         )
+
+
+def format_slack_digest(digest: AlertDigest, app_url: str) -> str:
+    if len(digest.triaged_assets) == 0:
+        return digest.summary
+
+    high = digest.counts.get(Conviction.HIGH.value, 0)
+    watch = digest.counts.get(Conviction.WATCH.value, 0)
+    noise = digest.counts.get(Conviction.NOISE.value, 0)
+
+    lines = [
+        f"\U0001f4ca Daily brief ({digest.run_date}): "
+        f"{high} high, {watch} watch, {noise} filtered"
+    ]
+
+    high_assets = sorted(
+        (
+            asset
+            for asset in digest.triaged_assets
+            if asset.conviction == Conviction.HIGH
+        ),
+        key=lambda asset: asset.rank or 0,
+    )
+    if high_assets:
+        names = ", ".join(
+            f"{asset.asset_description} ({asset.asset_code})"
+            for asset in high_assets
+        )
+        lines.append(f"Top: {names}")
+
+    if digest.fallback_used:
+        lines.append("(fallback ranking - reasoning was unavailable)")
+
+    lines.append(app_url)
+    return "\n".join(lines)

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from client.anthropic_client import AnthropicClient
-from model import Alert, AlertDigest, Conviction, TriagedAsset
+from model import Alert, AlertDigest, AlertType, Conviction, TriagedAsset
 from utils.exception import AnthropicException
 from utils.logger import Logger
 
@@ -17,17 +17,47 @@ You receive a JSON object with an "assets" array. Each asset has:
 - ma50_slope: percent slope of the 50-period moving average (medium-term \
 trend); positive = uptrend, negative = downtrend, null = unknown
 
-Rank the day's opportunities using two ideas:
-1. Confluence - an asset where several distinct patterns fired at once is \
-stronger than one with a single isolated pattern.
-2. Trend alignment - a bearish setup is higher conviction when ma50_slope is \
-negative (trend agrees); a bullish setup is higher conviction when ma50_slope \
-is positive. A signal fighting the trend is weaker.
+Pattern semantics - know what each pattern actually means before reasoning \
+about confluence or trend alignment:
+- combo: the only pattern with an explicit computed direction. Treat it as \
+the primary source of directional bias.
+- mm50_touch: can ONLY fire when the 50-MA is already rising strongly (its \
+detector requires ma50_slope >= +3%). It is a bullish continuation signal \
+(price pulling back to a rising average) - NEVER cite it as confirming a \
+bearish thesis or as "trend-aligned" with a negative slope. If you see \
+mm50_touch alongside a claimed bearish setup, that combination is internally \
+inconsistent, not "confluence that overrides a conflict" - treat it as a red \
+flag on the bearish read, not a supporting signal.
+- congestion20 and congestion100: the SAME underlying consolidation detector \
+run at two different lookback windows (20 vs 100 candles). If both fire \
+together, count them as ONE point of confluence, not two - they are not \
+independent evidence. Congestion itself has no inherent direction (price is \
+range-bound, could break either way).
+- double_top: a geometric match of two similar recent highs. It is only a \
+meaningful bearish reversal signal when it interrupts a PRIOR uptrend (the \
+stock was rising, then topped out). If the stock is already in an \
+established downtrend (strongly negative ma50_slope), a "double_top" is not \
+a fresh reversal - it is just noise inside an ongoing decline, and should \
+NOT be described as "confirming" or "reinforcing" the bearish bias.
+- containing_candle and double_inside_bar: pure geometric consolidation / \
+indecision patterns. They carry no directional meaning on their own and \
+should not be described as bearish or bullish by themselves.
+
+Rank the day's opportunities using two ideas, applied with the pattern \
+semantics above (not just pattern names or counts):
+1. Confluence - genuinely independent patterns pointing the same direction \
+is stronger than one isolated or internally-redundant pattern (see \
+congestion20/100 above).
+2. Trend alignment - only meaningful when the pattern's actual direction \
+(per the semantics above) matches ma50_slope. Do not award trend alignment \
+to a pattern that has no real direction, or that structurally cannot occur \
+against the claimed trend (e.g. mm50_touch during a "bearish" thesis).
 
 Conviction tiers:
-- "high": a genuine, actionable setup worth looking at now.
+- "high": a genuine, actionable setup worth looking at now, with directional \
+evidence that actually holds up under the pattern semantics above.
 - "watch": a plausible setup to keep an eye on.
-- "noise": low-signal, isolated, or trend-conflicting hits.
+- "noise": low-signal, isolated, redundant, or internally-inconsistent hits.
 
 RETURN ONLY the "high" and "watch" assets - the ones worth surfacing. Any \
 asset you omit is treated as "noise", so never list noise assets. Rank the \
@@ -35,7 +65,7 @@ returned assets with a 1-based "rank" (1 = best) and give each a one-line \
 "rationale" naming the patterns and the trend context.
 
 Be selective: most days only a few assets are high or watch. Do not inflate \
-tiers.
+tiers, and do not pad confluence with redundant or non-directional patterns.
 
 Respond with ONLY a JSON object, no prose, no code fences:
 {"summary": "<one or two sentence headline of the day>",
@@ -44,6 +74,11 @@ Respond with ONLY a JSON object, no prose, no code fences:
 
 
 FALLBACK_MODEL = "deterministic-fallback"
+
+# congestion20 and congestion100 are the same underlying detector run at two
+# lookback windows, not independent signals - collapse them to one family
+# when counting confluence in the deterministic fallback.
+_PATTERN_FAMILY = {AlertType.CONGESTION100: AlertType.CONGESTION20}
 
 
 class TriageAgent:
@@ -107,7 +142,7 @@ class TriageAgent:
         ordered = sorted(
             grouped.values(),
             key=lambda entry: (
-                len(entry["patterns"]),
+                len(self._pattern_families(entry["patterns"])),
                 self._abs_slope(entry["ma50_slope"]),
             ),
             reverse=True,
@@ -144,11 +179,11 @@ class TriageAgent:
         )
 
     def _fallback_conviction(self, entry: Dict[str, Any]) -> Conviction:
-        pattern_count = len(entry["patterns"])
-        if pattern_count >= 2:
+        family_count = len(self._pattern_families(entry["patterns"]))
+        if family_count >= 2:
             return Conviction.HIGH
         if (
-            pattern_count == 1
+            family_count == 1
             and self._abs_slope(entry["ma50_slope"]) >= self.slope_threshold
         ):
             return Conviction.WATCH
@@ -158,7 +193,11 @@ class TriageAgent:
         patterns = ", ".join(p.value for p in entry["patterns"])
         slope = entry["ma50_slope"]
         slope_text = f", slope {slope:.1f}%" if slope is not None else ""
-        return f"{len(entry['patterns'])} pattern(s): {patterns}{slope_text}"
+        family_count = len(self._pattern_families(entry["patterns"]))
+        return f"{family_count} pattern(s): {patterns}{slope_text}"
+
+    def _pattern_families(self, patterns: List[AlertType]) -> set[AlertType]:
+        return {_PATTERN_FAMILY.get(p, p) for p in patterns}
 
     def _abs_slope(self, slope: Optional[float]) -> float:
         return abs(slope) if slope is not None else 0.0

--- a/specs/023-alert-triage/tasks.md
+++ b/specs/023-alert-triage/tasks.md
@@ -115,8 +115,8 @@ Web + Lambda layout (per plan.md): backend at repo root (`model/`, `client/`, `s
 
 ### Implementation for User Story 4
 
-- [ ] T026 [US4] In `run_alerting` (`saxo_order/commands/alerting.py`), replace the per-indicator `slack_messages` posting with a single concise digest message (counts + top high-conviction names + homepage link from config); preserve the "no signals" message (depends on T009)
-- [ ] T027 [US4] Test the concise-message formatting (counts, top names, link, and no-signals branch) in `tests/services/test_alert_triage_service.py` or a dedicated formatter test — assert real output, not mock calls
+- [x] T026 [US4] In `run_alerting` (`saxo_order/commands/alerting.py`), replace the per-indicator `slack_messages` posting with a single concise digest message (counts + top high-conviction names + homepage link from config); preserve the "no signals" message (depends on T009)
+- [x] T027 [US4] Test the concise-message formatting (counts, top names, link, and no-signals branch) in `tests/services/test_alert_triage_service.py` or a dedicated formatter test — assert real output, not mock calls
 
 **Checkpoint**: Firehose removed; app is source of truth (SC-001)
 

--- a/tests/services/test_alert_triage_service.py
+++ b/tests/services/test_alert_triage_service.py
@@ -2,8 +2,8 @@ import datetime
 from typing import Any, Dict, List
 
 from client.anthropic_client import AnthropicClient
-from model import Alert, AlertType, Conviction
-from services.alert_triage_service import TriageAgent
+from model import Alert, AlertDigest, AlertType, Conviction, TriagedAsset
+from services.alert_triage_service import TriageAgent, format_slack_digest
 from utils.exception import AnthropicException
 
 
@@ -212,3 +212,94 @@ def test_fallback_slope_threshold_is_configurable() -> None:
         FailingAnthropicClient(), slope_threshold=1.0
     ).synthesize(alerts)
     assert lenient.triaged_assets[0].conviction == Conviction.WATCH
+
+
+def _triaged_asset(
+    code: str, conviction: Conviction, rank: int | None = None
+) -> TriagedAsset:
+    return TriagedAsset(
+        asset_code=code,
+        asset_description=f"{code} SA",
+        exchange="saxo",
+        conviction=conviction,
+        rationale="double top + MA50 rejection",
+        patterns=[AlertType.DOUBLE_TOP],
+        ma50_slope=-2.3,
+        rank=rank,
+        country_code="xpar",
+    )
+
+
+def test_format_slack_digest_no_signals_returns_summary() -> None:
+    digest = AlertDigest(
+        run_date="2026-07-16",
+        created_at=1768579200,
+        summary="No signals detected today.",
+        counts={"high": 0, "watch": 0, "noise": 0},
+        triaged_assets=[],
+        model="claude-sonnet-5",
+        fallback_used=False,
+    )
+
+    message = format_slack_digest(digest, "https://app.example.com")
+
+    assert message == "No signals detected today."
+
+
+def test_format_slack_digest_includes_counts_top_names_and_link() -> None:
+    digest = AlertDigest(
+        run_date="2026-07-16",
+        created_at=1768579200,
+        summary="28 signals across 22 stocks.",
+        counts={"high": 2, "watch": 1, "noise": 20},
+        triaged_assets=[
+            _triaged_asset("SAN", Conviction.HIGH, rank=1),
+            _triaged_asset("TTE", Conviction.HIGH, rank=2),
+            _triaged_asset("AIR", Conviction.WATCH, rank=3),
+        ],
+        model="claude-sonnet-5",
+        fallback_used=False,
+    )
+
+    message = format_slack_digest(digest, "https://app.example.com")
+
+    assert "2 high, 1 watch, 20 filtered" in message
+    assert "SAN" in message
+    assert "TTE" in message
+    assert message.index("SAN") < message.index("TTE")
+    assert "AIR" not in message.split("\n")[1]
+    assert message.endswith("https://app.example.com")
+    assert "fallback" not in message
+
+
+def test_format_slack_digest_flags_fallback() -> None:
+    digest = AlertDigest(
+        run_date="2026-07-16",
+        created_at=1768579200,
+        summary="1 high",
+        counts={"high": 1, "watch": 0, "noise": 0},
+        triaged_assets=[_triaged_asset("SAN", Conviction.HIGH, rank=1)],
+        model="deterministic-fallback",
+        fallback_used=True,
+    )
+
+    message = format_slack_digest(digest, "https://app.example.com")
+
+    assert "fallback ranking" in message
+
+
+def test_format_slack_digest_handles_no_high_assets() -> None:
+    digest = AlertDigest(
+        run_date="2026-07-16",
+        created_at=1768579200,
+        summary="1 watch",
+        counts={"high": 0, "watch": 1, "noise": 0},
+        triaged_assets=[_triaged_asset("SAN", Conviction.WATCH, rank=1)],
+        model="claude-sonnet-5",
+        fallback_used=False,
+    )
+
+    message = format_slack_digest(digest, "https://app.example.com")
+
+    assert "Top:" not in message
+    assert "0 high, 1 watch, 0 filtered" in message

--- a/tests/services/test_alert_triage_service.py
+++ b/tests/services/test_alert_triage_service.py
@@ -200,6 +200,23 @@ def test_fallback_ranks_by_confluence_then_slope() -> None:
     assert digest.counts == {"high": 1, "watch": 1, "noise": 1}
 
 
+def test_fallback_treats_congestion20_and_100_as_one_family() -> None:
+    # congestion20 and congestion100 are the same detector at two lookback
+    # windows - they must not count as two distinct patterns toward
+    # confluence, or a purely redundant hit gets wrongly promoted to HIGH.
+    alerts = [
+        _alert("SAN", AlertType.CONGESTION20, 0.5),
+        _alert("SAN", AlertType.CONGESTION100, 0.5),
+    ]
+    digest = TriageAgent(
+        FailingAnthropicClient(), slope_threshold=1.0
+    ).synthesize(alerts)
+
+    asset = digest.triaged_assets[0]
+    assert asset.conviction == Conviction.NOISE
+    assert asset.rank is None
+
+
 def test_fallback_slope_threshold_is_configurable() -> None:
     alerts = [_alert("TTE", AlertType.CONGESTION20, 1.5)]
 

--- a/utils/configuration.py
+++ b/utils/configuration.py
@@ -153,5 +153,9 @@ class Configuration:
         return float(self.config.get("triage_slope_threshold", 1.0))
 
     @property
+    def app_url(self) -> str:
+        return self.config.get("app_url", "http://localhost:5173")
+
+    @property
     def api_mode(self) -> bool:
         return os.getenv("API_MODE", "false").lower() == "true"


### PR DESCRIPTION
## Summary

Two commits on top of merged `main` (#633):

1. **Phase 6 (US4)** — replaces the raw Slack firehose with a single concise digest message.
2. **Bug fix** — the triage agent was treating pattern names as generically "bearish" without knowing what they structurally mean, producing self-contradictory rationales in production.

## Commit 1: `3e11c10` — Phase 6, concise Slack digest (US4)

| Task | Change |
|------|--------|
| T026 | `run_alerting` no longer builds the per-indicator `slack_messages` dict or posts per-type batches. After `synthesize`, it persists the digest (storage failure logged, never blocks notification) and posts one `format_slack_digest(digest, app_url)` message. Single-asset on-demand runs that find nothing stay silent, matching prior behavior. |
| T027 | `format_slack_digest`: headline tier counts, ranked top high-conviction names, a fallback marker, a homepage link — or the digest's own "No signals detected today." on a zero-signal day (FR-019). 4 new tests assert real formatted output. |
| — | Added `Configuration.app_url` (config-driven). No deployed frontend URL exists anywhere in the repo, so `config.yml` defaults to `http://localhost:5173` and `prod_config.yml` gets an explicit `https://TODO-set-your-frontend-url` placeholder — **needs to be set to the real production URL before this ships live**. |

## Commit 2: `86c665e` — fix triage pattern semantics

A live daily brief showed the model citing `mm50_touch` as "confirming bearish bias" alongside a negative slope — but `mm50_touch`'s detector (`services/indicator_service.py`) *requires* `ma50_slope >= +3%` to fire at all, so that combination is structurally impossible to be bearish. Verified against the actual detector code, four issues:

- `mm50_touch` can only fire on a rising MA50 — never bearish-aligned.
- `congestion20`/`congestion100` are the **same detector** at two lookback windows (`services/congestion_indicator.py`), not independent confluence — was being double-counted.
- `double_top` is a naive two-swing-high match with no prior-trend validation — not a confirmed reversal, especially inside an already-established downtrend.
- `containing_candle`/`double_inside_bar` are non-directional consolidation patterns with no inherent bullish/bearish meaning.

Fixes:
- `TRIAGE_SYSTEM_PROMPT`: added a pattern-semantics section so the LLM reasons about what each pattern actually means instead of pattern-matching on names.
- Deterministic fallback: fixed the same double-counting bug — `congestion20`+`congestion100` now collapse to one pattern family (`_PATTERN_FAMILY`) for confluence purposes, so a redundant-only hit is no longer wrongly promoted to `HIGH`.
- New regression test covering the fallback fix.

## Verification

- Full-repo `isort`/`black`/`flake8`/`mypy`: clean (150 files).
- `pytest --cov`: **341 passed, 10 skipped**.
- Manually smoke-tested `format_slack_digest` output for both the signal and no-signal cases.

## Note on branch history

PR #633 was squash-merged into `main` before the Phase 6 work landed, so this branch was restarted from the updated `main` and the unmerged Phase 6 commit was cherry-picked forward (not discarded) before adding the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_