### PR TITLE
feat: log estimated cost and raw response on parse failure (spec 023)

### DIFF
--- a/client/anthropic_client.py
+++ b/client/anthropic_client.py
@@ -1,12 +1,23 @@
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 import anthropic
 
 from utils.configuration import Configuration
 from utils.exception import AnthropicException
 from utils.logger import Logger
+
+# Standard (non-introductory) USD price per million tokens: (input, output).
+_MODEL_PRICING_PER_MILLION: Dict[str, Tuple[float, float]] = {
+    "claude-fable-5": (10.00, 50.00),
+    "claude-opus-4-8": (5.00, 25.00),
+    "claude-opus-4-7": (5.00, 25.00),
+    "claude-opus-4-6": (5.00, 25.00),
+    "claude-sonnet-5": (3.00, 15.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+}
 
 
 class AnthropicClient:
@@ -36,11 +47,35 @@ class AnthropicClient:
         except (anthropic.APIError, anthropic.APIConnectionError) as e:
             raise AnthropicException(f"Anthropic API call failed: {e}")
 
+        self._log_cost(response)
+
         if response.stop_reason == "max_tokens":
             raise AnthropicException(
                 "Anthropic response truncated (max_tokens)"
             )
         return self._parse_json(self._extract_text(response))
+
+    def _log_cost(self, response: Any) -> None:
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+        cost = self._estimate_cost(input_tokens, output_tokens)
+        cost_text = f"${cost:.4f}" if cost is not None else "unknown"
+        self.logger.info(
+            f"Anthropic call model={self._model} "
+            f"input_tokens={input_tokens} output_tokens={output_tokens} "
+            f"estimated_cost={cost_text}"
+        )
+
+    def _estimate_cost(
+        self, input_tokens: int, output_tokens: int
+    ) -> Optional[float]:
+        pricing = _MODEL_PRICING_PER_MILLION.get(self._model)
+        if pricing is None:
+            return None
+        input_price, output_price = pricing
+        return (
+            input_tokens * input_price + output_tokens * output_price
+        ) / 1_000_000
 
     def _extract_text(self, response: Any) -> str:
         for block in response.content:
@@ -60,7 +95,13 @@ class AnthropicClient:
         try:
             data = json.loads(cleaned)
         except json.JSONDecodeError as e:
+            self.logger.warning(
+                f"Anthropic response is not valid JSON: {text!r}"
+            )
             raise AnthropicException(f"Invalid JSON from Anthropic: {e}")
         if not isinstance(data, dict):
+            self.logger.warning(
+                f"Anthropic response is not a JSON object: {text!r}"
+            )
             raise AnthropicException("Anthropic JSON is not an object")
         return data


### PR DESCRIPTION
## Summary

Observability follow-up for the triage agent's Anthropic client, requested after the truncation incident in #630: make cost and failure diagnostics visible in logs without digging through the code.

## Changes (`client/anthropic_client.py`)

- **WARN on JSON parse failure**: both failure paths in `_parse_json` (invalid JSON, and valid JSON that isn't an object) now log the raw response text before raising `AnthropicException`. When `TriageAgent` falls back to the deterministic path, the actual model output that caused it is now visible in logs instead of just the exception message.
- **INFO on every successful call**: logs `model`, `input_tokens`, `output_tokens`, and an `estimated_cost` computed from a small per-model USD pricing table (standard, non-introductory rates for the models in the current catalog — Sonnet 5, Opus 4.6/4.7/4.8, Haiku 4.5, Fable 5). Falls back to `estimated_cost=unknown` for an unrecognized model rather than guessing a number.

Example output:
```
INFO anthropic_client: Anthropic call model=claude-sonnet-5 input_tokens=5000 output_tokens=300 estimated_cost=$0.0195
WARNING anthropic_client: Anthropic response is not valid JSON: 'not json at all'
```

## Verification

- Manual smoke test (constructed a fake SDK response, no real API): confirmed both log lines fire with correct content for known and unknown models, and for both JSON-failure modes.
- Full-repo `isort`/`black`/`flake8`/`mypy`: clean (150 files).
- `pytest --cov`: **341 passed, 10 skipped**, no regressions.

No new automated test file — the standalone `AnthropicClient` unit-test task was dropped earlier in this feature's task list, so this was verified by direct smoke test instead, consistent with that decision.

## Note on branch history

#637 was merged before this commit was pushed, so the branch was restarted from the updated `main` and this (previously unmerged) commit was cherry-picked forward rather than lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_