### PR TITLE
feat: use structured outputs for triage responses (spec 023)

### DIFF
--- a/client/anthropic_client.py
+++ b/client/anthropic_client.py
@@ -34,8 +34,17 @@ class AnthropicClient:
         return self._model
 
     def complete_json(
-        self, system: str, user_payload: str, max_tokens: int = 4096
+        self,
+        system: str,
+        user_payload: str,
+        output_schema: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 4096,
     ) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {}
+        if output_schema is not None:
+            kwargs["output_config"] = {
+                "format": {"type": "json_schema", "schema": output_schema}
+            }
         try:
             response = self._client.messages.create(
                 model=self._model,
@@ -43,6 +52,7 @@ class AnthropicClient:
                 thinking={"type": "disabled"},
                 system=system,
                 messages=[{"role": "user", "content": user_payload}],
+                **kwargs,
             )
         except (anthropic.APIError, anthropic.APIConnectionError) as e:
             raise AnthropicException(f"Anthropic API call failed: {e}")

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -67,10 +67,40 @@ returned assets with a 1-based "rank" (1 = best) and give each a one-line \
 Be selective: most days only a few assets are high or watch. Do not inflate \
 tiers, and do not pad confluence with redundant or non-directional patterns.
 
-Respond with ONLY a JSON object, no prose, no code fences:
-{"summary": "<one or two sentence headline of the day>",
- "assets": [{"id": "<echoed id>", "conviction": "high|watch", \
-"rank": <int>, "rationale": "<one line>"}]}"""
+"summary" is a one or two sentence headline of the day. "assets" is the \
+ranked list of high/watch assets, each with its echoed "id", "conviction", \
+1-based "rank", and a one-line "rationale" naming the patterns and the \
+trend context."""
+
+# Enforced via output_config.format (structured outputs) so the response is
+# always valid JSON matching this exact shape - no prose preamble, no code
+# fences, no risk of triggering the deterministic fallback on a well-formed
+# answer just because it wasn't formatted the way the prompt asked.
+TRIAGE_RESPONSE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "assets": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "conviction": {
+                        "type": "string",
+                        "enum": ["high", "watch"],
+                    },
+                    "rank": {"type": "integer"},
+                    "rationale": {"type": "string"},
+                },
+                "required": ["id", "conviction", "rank", "rationale"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["summary", "assets"],
+    "additionalProperties": False,
+}
 
 
 FALLBACK_MODEL = "deterministic-fallback"
@@ -111,7 +141,9 @@ class TriageAgent:
 
         try:
             raw = self.anthropic_client.complete_json(
-                TRIAGE_SYSTEM_PROMPT, self._build_payload(grouped)
+                TRIAGE_SYSTEM_PROMPT,
+                self._build_payload(grouped),
+                output_schema=TRIAGE_RESPONSE_SCHEMA,
             )
             triaged = self._parse_triaged(raw, grouped)
             counts = self._count_tiers(triaged)

--- a/tests/services/test_alert_triage_service.py
+++ b/tests/services/test_alert_triage_service.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from client.anthropic_client import AnthropicClient
 from model import Alert, AlertDigest, AlertType, Conviction, TriagedAsset
@@ -14,7 +14,11 @@ class FakeAnthropicClient(AnthropicClient):
         self.calls = 0
 
     def complete_json(
-        self, system: str, user_payload: str, max_tokens: int = 16000
+        self,
+        system: str,
+        user_payload: str,
+        output_schema: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 16000,
     ) -> Dict[str, Any]:
         self.calls += 1
         self.last_payload = user_payload
@@ -26,7 +30,11 @@ class RaisingAnthropicClient(AnthropicClient):
         self._model = "test-model"
 
     def complete_json(
-        self, system: str, user_payload: str, max_tokens: int = 16000
+        self,
+        system: str,
+        user_payload: str,
+        output_schema: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 16000,
     ) -> Dict[str, Any]:
         raise AssertionError("complete_json must not be called")
 
@@ -36,7 +44,11 @@ class FailingAnthropicClient(AnthropicClient):
         self._model = "test-model"
 
     def complete_json(
-        self, system: str, user_payload: str, max_tokens: int = 16000
+        self,
+        system: str,
+        user_payload: str,
+        output_schema: Optional[Dict[str, Any]] = None,
+        max_tokens: int = 16000,
     ) -> Dict[str, Any]:
         raise AnthropicException("boom")
 


### PR DESCRIPTION
## Summary

A real digest run showed Claude prefacing its JSON answer with prose ("Looking at this dataset, I need to focus on...") before the ` ```json ` fence. `_parse_json` only strips a fence when the response *starts* with it, so that response would have failed to parse and triggered the deterministic fallback unnecessarily — despite containing a perfectly good, well-reasoned answer. This switches to Anthropic's **structured outputs**, which enforces the response shape server-side instead of hoping the model follows a formatting instruction.

## Changes

- `AnthropicClient.complete_json` gains an optional `output_schema` param. When provided, it sets `output_config.format` (structured outputs) on the SDK call — the API guarantees the response is valid JSON matching the schema, eliminating prose preambles and code fences at the source. Omitting `output_schema` leaves behavior unchanged (verified: `output_config` only appears in the SDK call when a schema is passed).
- `services/alert_triage_service.py`: added `TRIAGE_RESPONSE_SCHEMA` matching the existing `{summary, assets: [{id, conviction, rank, rationale}]}` contract, passed on the triage call. Trimmed the now-redundant "no prose, no code fences" prompt instruction since the schema enforces it structurally.
- Updated the three fake `AnthropicClient` test doubles to accept the new keyword argument.

## Verification

- Manually verified `output_config` is only sent when a schema is passed, and carries the exact schema through to the SDK call.
- Triage tests: **14 passed**.
- Full-repo `isort`/`black`/`flake8`/`mypy`: clean (150 files).
- `pytest --cov`: **341 passed, 10 skipped**, no regressions.

## Note on branch history

#638 was merged before this commit was pushed, so the branch was restarted from the updated `main` and this (previously unmerged) commit was cherry-picked forward rather than lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYkUqdvr2c9BD8WkeHqGDC)_