### PR TITLE
feat: add double_bottom pattern detection

### DIFF
--- a/model/enum.py
+++ b/model/enum.py
@@ -111,6 +111,7 @@ class AlertType(EnumWithGetValue):
     CONGESTION100 = "congestion100"
     COMBO = "combo"
     DOUBLE_TOP = "double_top"
+    DOUBLE_BOTTOM = "double_bottom"
     DOUBLE_INSIDE_BAR = "double_inside_bar"
     CONTAINING_CANDLE = "containing_candle"
     MM50_TOUCH = "mm50_touch"

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -293,6 +293,30 @@ async def run_detection_for_asset(
                 )
             )
 
+        # Run DOUBLE_BOTTOM detection
+        if (
+            candle := _run_double_bottom(saxo_client, asset_dict, candles)
+        ) is not None:
+            asset_alerts.append(
+                Alert(
+                    alert_type=AlertType.DOUBLE_BOTTOM,
+                    date=(
+                        candle.date if candle.date else datetime.datetime.now()
+                    ),
+                    data={
+                        "close": candle.close,
+                        "open": candle.open,
+                        "higher": candle.higher,
+                        "lower": candle.lower,
+                        "ma50_slope": ma50_slope,
+                    },
+                    asset_code=asset_code,
+                    asset_description=asset_description,
+                    exchange=exchange,
+                    country_code=country_code,
+                )
+            )
+
         # Run CONTAINING_CANDLE detection
         if (candle := _run_containing_candle(asset_dict, candles)) is not None:
             asset_alerts.append(
@@ -607,6 +631,29 @@ def _run_double_top(
     ):
         logger.debug(f"{asset['name']}, {double_top_candle}")
         return double_top_candle
+    return None
+
+
+def _run_double_bottom(
+    saxo_client: SaxoClient,
+    asset: Dict,
+    candles: List[Candle],
+) -> Optional[Candle]:
+    detail = saxo_client.get_asset_detail(asset["saxo_uic"], AssetType.STOCK)
+    if "TickSizeScheme" not in detail:
+        tick = 0.0
+    else:
+        tick = client_helper.get_tick_size(
+            detail["TickSizeScheme"], candles[0].close
+        )
+    double_bottom_candle = indicator_service.double_bottom(candles, tick)
+    if (
+        double_bottom_candle is not None
+        and double_bottom_candle.date is not None
+        and (datetime.datetime.now() - double_bottom_candle.date).days <= 2
+    ):
+        logger.debug(f"{asset['name']}, {double_bottom_candle}")
+        return double_bottom_candle
     return None
 
 

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -46,6 +46,37 @@ def double_top(candles: List[Candle], tick=float) -> Optional[Candle]:
     return None
 
 
+def double_bottom(candles: List[Candle], tick=float) -> Optional[Candle]:
+    """
+    If a double bottom exist in the list, return the trough candle
+    The bottom can be another candle than the first one
+    We accept a spread of one tick between two bottoms
+    """
+    if len(candles) < 2:
+        return None
+
+    bottoms: List[Candle] = []
+
+    if candles[0].lower <= candles[1].lower:
+        bottoms.append(candles[0])
+
+    for i in range(1, len(candles) - 1):
+        if (
+            candles[i].lower <= candles[i - 1].lower
+            and candles[i].lower <= candles[i + 1].lower
+        ):
+            bottoms.append(candles[i])
+
+    if candles[-1].lower <= candles[-2].lower:
+        bottoms.append(candles[-1])
+    # Check if there are two bottoms within one tick spread
+    for i in range(len(bottoms)):
+        for j in range(i + 1, len(bottoms)):
+            if round(abs(bottoms[i].lower - bottoms[j].lower), 4) <= tick:
+                return bottoms[i]
+    return None
+
+
 def bollinger_bands(
     candles: List[Candle], multiply_std: float = 2.0, period: int = 20
 ) -> BollingerBands:

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -17,6 +17,7 @@ from services.indicator_service import (
     bollinger_bands,
     combo,
     containing_candle,
+    double_bottom,
     double_top,
     exponentiel_mobile_average,
     find_linear_function,
@@ -109,6 +110,60 @@ class TestIndicatorService:
             assert double_top(candles, tick) is None
         else:
             assert double_top(candles, tick).higher == expected
+
+    @pytest.mark.parametrize(
+        "lows, tick, expected",
+        [
+            (
+                [8, 9, 10, 8, 9],
+                0.5,
+                8,
+            ),
+            (
+                [8, 9, 10, 7.5, 9],
+                0.5,
+                8,
+            ),
+            (
+                [8, 9, 10, 7.4, 9],
+                0.5,
+                None,
+            ),
+            (
+                [8, 7, 10, 7.4, 9],
+                0.5,
+                7,
+            ),
+            (
+                [8, 7, 10, 7.4, 6.8],
+                0.2,
+                7,
+            ),
+            (
+                [8, 7, 10, 7.4, 6],
+                0.5,
+                None,
+            ),
+            (
+                [8, 6.9, 10, 7.4, 9, 15, 6.7, 9, 10],
+                0.2,
+                6.9,
+            ),
+        ],
+    )
+    def test_double_bottom(self, lows, tick, expected):
+        candles = list(
+            map(
+                lambda x: Candle(
+                    x, 0, 0, 0, UnitTime.D, datetime.datetime.now()
+                ),
+                lows,
+            )
+        )
+        if expected is None:
+            assert double_bottom(candles, tick) is None
+        else:
+            assert double_bottom(candles, tick).lower == expected
 
     @pytest.mark.parametrize(
         "candles, std, expected",


### PR DESCRIPTION
## Summary

Adds a `double_bottom` detector — the bullish-reversal mirror of the existing `double_top`. This closes a structural asymmetry in the pattern set: previously only `double_top` carried reversal direction, so the day's alerts could converge *bearish* on a reversal but had no equivalent way to converge *bullish*. More independent directional evidence directly strengthens the triage agent's **convergence** axis (the one it was most starved on).

## Changes

- **`model/enum.py`** — new `AlertType.DOUBLE_BOTTOM = "double_bottom"`.
- **`services/indicator_service.py`** — `double_bottom()`: mirror of `double_top()`, scanning candle **lows** for two troughs within a one-tick spread (local minima instead of maxima).
- **`saxo_order/commands/alerting.py`** — `_run_double_bottom()` helper (tick-size lookup + 2-day recency window, identical to `_run_double_top`) and a detection block emitting a `DOUBLE_BOTTOM` alert with the same `data` shape as `double_top`, including `ma50_slope`.
- **`tests/services/test_indicator_service.py`** — `test_double_bottom` parametrized over 7 cases mirroring the `double_top` suite (matched troughs, one-tick spread boundary, no-match, and a multi-trough case).

## Scope

- **Detection-only.** The triage prompt, `TRIAGE_RESPONSE_SCHEMA`, the deterministic fallback, persistence, and the order/workflow path are all untouched. The new pattern flows through the existing alert pipeline exactly like the other detectors.
- Independent of PR #640 (the convergence/opportunity prompt reframe). Teaching the triage prompt the semantics of `double_bottom` (bullish reversal, meaningful when it interrupts a prior downtrend) is a small follow-up best applied once #640 merges, to avoid editing the prompt on two branches at once.

## Testing

- `poetry run pytest tests/services/test_indicator_service.py` — 60 passed (incl. 7 new).
- `poetry run pytest -k "alerting or triage or indicator"` — 116 passed, 5 skipped.
- `black --check`, `isort --check-only`, `flake8`, `mypy` — all clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3JyXhzbEQfinBXsCRykUP

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3JyXhzbEQfinBXsCRykUP)_