### PR TITLE
feat: teach triage prompt the double_bottom pattern semantics

### DIFF
--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -39,6 +39,13 @@ stock was rising, then topped out). If the stock is already in an \
 established downtrend (strongly negative ma50_slope), a "double_top" is not \
 a fresh reversal - it is just noise inside an ongoing decline, and should \
 NOT be described as "confirming" or "reinforcing" the bearish bias.
+- double_bottom: the bullish mirror of double_top - a geometric match of two \
+similar recent lows. It is only a meaningful bullish reversal signal when it \
+interrupts a PRIOR downtrend (the stock was falling, then bottomed out). If \
+the stock is already in an established uptrend (strongly positive \
+ma50_slope), a "double_bottom" is not a fresh reversal - it is just noise \
+inside an ongoing advance, and should NOT be described as "confirming" or \
+"reinforcing" the bullish bias.
 - containing_candle and double_inside_bar: pure geometric consolidation / \
 indecision patterns. They carry no directional meaning on their own and \
 should not be described as bearish or bullish by themselves.


### PR DESCRIPTION
## Summary

Follow-up to the `double_bottom` detector (#641), stacked on the convergence/opportunity prompt reframe (#640). Adds a `double_bottom` entry to the triage system prompt's pattern-semantics section — the bullish mirror of the existing `double_top` guidance — so the agent reasons about the new signal with the right meaning instead of inferring it from the pattern name.

The added semantics mirror `double_top` exactly:
- meaningful **bullish reversal** only when it interrupts a **prior downtrend**;
- **noise inside an ongoing advance** when `ma50_slope` is already strongly positive (must NOT be described as confirming/reinforcing the bullish bias).

This is what lets `double_bottom` contribute correctly to the **convergence** axis rather than being double-counted or mis-directed.

## Stacking / merge order

- **Base branch:** `claude/triage-agent-prompt-ck0630` (PR #640), so this diff shows only the prompt addition.
- **Depends on #641** for the actual detector + `AlertType.DOUBLE_BOTTOM`. This PR only touches prompt text (a string constant) and does not reference the enum member, so it's independently valid, but the semantics are only exercised once #641 has merged and the pattern can fire.
- **Suggested order:** merge #640 → #641 → this. Kept as a **draft** until #640 lands; rebase onto `main` and retarget once its parent merges.

## Testing

- `poetry run pytest tests/services/test_alert_triage_service.py` — 14 passed.
- `black --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3JyXhzbEQfinBXsCRykUP

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3JyXhzbEQfinBXsCRykUP)_