### PR TITLE
feat: improve homepage daily brief UI

### DIFF
--- a/api/models/alert_digest.py
+++ b/api/models/alert_digest.py
@@ -25,6 +25,9 @@ class TriagedAssetResponse(BaseModel):
     ma50_slope: Optional[float] = Field(
         default=None, description="MA50 slope used in ranking"
     )
+    tradingview_url: Optional[str] = Field(
+        default=None, description="Custom TradingView URL if configured"
+    )
 
 
 class AlertDigestResponse(BaseModel):

--- a/api/services/alert_digest_service.py
+++ b/api/services/alert_digest_service.py
@@ -33,7 +33,12 @@ class AlertDigestService:
 
             logger.info("Cache miss - fetching alert digests from DynamoDB")
             items = await self.dynamodb_client.get_alert_digests(limit=limit)
-            digests = [self._to_response(item) for item in items]
+            tradingview_links = (
+                await self.dynamodb_client.get_all_tradingview_links()
+            )
+            digests = [
+                self._to_response(item, tradingview_links) for item in items
+            ]
             self._cache[cache_key] = digests
             return digests
 
@@ -43,28 +48,39 @@ class AlertDigestService:
         item = await self.dynamodb_client.get_alert_digest(run_date)
         if item is None:
             return None
-        return self._to_response(item)
+        tradingview_links = await self.dynamodb_client.get_all_tradingview_links()
+        return self._to_response(item, tradingview_links)
 
-    def _to_response(self, item: Dict[str, Any]) -> AlertDigestResponse:
+    def _to_response(
+        self, item: Dict[str, Any], tradingview_links: Dict[str, str]
+    ) -> AlertDigestResponse:
         return AlertDigestResponse(
             run_date=item["run_date"],
             created_at=int(item["created_at"]),
             summary=item["summary"],
             counts={k: int(v) for k, v in item["counts"].items()},
             triaged_assets=[
-                self._to_triaged_asset(asset)
+                self._to_triaged_asset(asset, tradingview_links)
                 for asset in item.get("triaged_assets", [])
             ],
             fallback_used=bool(item["fallback_used"]),
             model=item["model"],
         )
 
-    def _to_triaged_asset(self, asset: Dict[str, Any]) -> TriagedAssetResponse:
+    def _to_triaged_asset(
+        self, asset: Dict[str, Any], tradingview_links: Dict[str, str]
+    ) -> TriagedAssetResponse:
+        country_code = asset.get("country_code")
+        asset_id = (
+            f"{asset['asset_code']}:{country_code}"
+            if country_code
+            else asset["asset_code"]
+        )
         return TriagedAssetResponse(
             asset_code=asset["asset_code"],
             asset_description=asset["asset_description"],
             exchange=asset["exchange"],
-            country_code=asset.get("country_code"),
+            country_code=country_code,
             conviction=asset["conviction"],
             rank=(
                 int(asset["rank"]) if asset.get("rank") is not None else None
@@ -76,4 +92,5 @@ class AlertDigestService:
                 if isinstance(asset.get("ma50_slope"), Decimal)
                 else asset.get("ma50_slope")
             ),
+            tradingview_url=tradingview_links.get(asset_id),
         )

--- a/api/services/alert_digest_service.py
+++ b/api/services/alert_digest_service.py
@@ -48,7 +48,9 @@ class AlertDigestService:
         item = await self.dynamodb_client.get_alert_digest(run_date)
         if item is None:
             return None
-        tradingview_links = await self.dynamodb_client.get_all_tradingview_links()
+        tradingview_links = (
+            await self.dynamodb_client.get_all_tradingview_links()
+        )
         return self._to_response(item, tradingview_links)
 
     def _to_response(

--- a/frontend/src/components/DailyBrief.tsx
+++ b/frontend/src/components/DailyBrief.tsx
@@ -5,12 +5,24 @@ import { DailyBriefCarousel } from './DailyBriefCarousel';
 import './DailyBrief.css';
 
 const RECENT_DIGESTS_LIMIT = 14;
+const COLLAPSED_STORAGE_KEY = 'daily_brief_collapsed';
 
 export function DailyBrief() {
   const [digests, setDigests] = useState<AlertDigest[]>([]);
   const [index, setIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem(COLLAPSED_STORAGE_KEY) === 'true'
+  );
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(COLLAPSED_STORAGE_KEY, String(next));
+      return next;
+    });
+  };
 
   useEffect(() => {
     const fetchDigests = async () => {
@@ -61,6 +73,8 @@ export function DailyBrief() {
         hasNext={index > 0}
         onPrev={() => setIndex((i) => Math.min(i + 1, digests.length - 1))}
         onNext={() => setIndex((i) => Math.max(i - 1, 0))}
+        collapsed={collapsed}
+        onToggleCollapsed={toggleCollapsed}
       />
     </div>
   );

--- a/frontend/src/components/DailyBriefCarousel.css
+++ b/frontend/src/components/DailyBriefCarousel.css
@@ -21,6 +21,23 @@
   gap: 0.5rem;
 }
 
+.daily-brief-collapse {
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0.15rem 0.3rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.daily-brief-collapse:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
 .daily-brief-date {
   font-size: 1rem;
   font-weight: 700;
@@ -74,13 +91,18 @@
 
 .daily-brief-asset {
   display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.25rem;
   padding: 0.4rem 0.6rem;
   background: #0d1117;
   border: 1px solid #21262d;
   border-radius: 4px;
+}
+
+.daily-brief-asset-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .daily-brief-asset-badge {
@@ -88,14 +110,39 @@
 }
 
 .daily-brief-asset-name {
+  flex: 1;
   font-weight: 600;
   color: #e6edf3;
   font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.daily-brief-asset-name:hover {
+  color: #58a6ff;
+  text-decoration: underline;
+}
+
+.daily-brief-asset-tradingview {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.daily-brief-asset-tradingview:hover {
+  background: #2962ff;
+  transform: scale(1.1);
 }
 
 .daily-brief-asset-rationale {
   color: #8b949e;
   font-size: 0.8rem;
+  padding-left: 1.4rem;
 }
 
 .daily-brief-empty {

--- a/frontend/src/components/DailyBriefCarousel.tsx
+++ b/frontend/src/components/DailyBriefCarousel.tsx
@@ -1,4 +1,6 @@
+import { useNavigate } from 'react-router-dom';
 import type { AlertDigest, TriagedAsset } from '../services/api';
+import { getTradingViewUrl } from '../utils/tradingview';
 import './DailyBriefCarousel.css';
 
 interface DailyBriefCarouselProps {
@@ -7,6 +9,8 @@ interface DailyBriefCarouselProps {
   hasNext: boolean;
   onPrev: () => void;
   onNext: () => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
 }
 
 const CONVICTION_BADGE: Record<string, string> = {
@@ -14,19 +18,48 @@ const CONVICTION_BADGE: Record<string, string> = {
   watch: '🟡',
 };
 
+function assetSymbol(asset: TriagedAsset): string {
+  return asset.country_code
+    ? `${asset.asset_code}:${asset.country_code}`
+    : asset.asset_code;
+}
+
 function AssetRow({ asset }: { asset: TriagedAsset }) {
+  const navigate = useNavigate();
+
+  const handleAssetClick = () => {
+    const symbol = assetSymbol(asset);
+    navigate(
+      `/asset/${encodeURIComponent(symbol)}?exchange=${asset.exchange}`,
+      { state: { description: asset.asset_description } }
+    );
+  };
+
+  const handleTradingViewClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const url = asset.tradingview_url || getTradingViewUrl(assetSymbol(asset));
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <div className="daily-brief-asset">
-      <span className="daily-brief-asset-badge">
-        {CONVICTION_BADGE[asset.conviction] ?? ''}
-      </span>
-      <span className="daily-brief-asset-name">
-        {asset.asset_description} ({asset.asset_code})
-      </span>
-      {asset.rationale && (
-        <span className="daily-brief-asset-rationale">
-          {asset.rationale}
+      <div className="daily-brief-asset-row">
+        <span className="daily-brief-asset-badge">
+          {CONVICTION_BADGE[asset.conviction] ?? ''}
         </span>
+        <span className="daily-brief-asset-name" onClick={handleAssetClick}>
+          {asset.asset_description} ({asset.asset_code})
+        </span>
+        <button
+          className="daily-brief-asset-tradingview"
+          onClick={handleTradingViewClick}
+          title="View on TradingView"
+        >
+          📊
+        </button>
+      </div>
+      {asset.rationale && (
+        <div className="daily-brief-asset-rationale">{asset.rationale}</div>
       )}
     </div>
   );
@@ -38,6 +71,8 @@ export function DailyBriefCarousel({
   hasNext,
   onPrev,
   onNext,
+  collapsed,
+  onToggleCollapsed,
 }: DailyBriefCarouselProps) {
   const rankedAssets = digest.triaged_assets
     .filter((asset) => asset.conviction !== 'noise')
@@ -56,6 +91,14 @@ export function DailyBriefCarousel({
           ‹
         </button>
         <div className="daily-brief-title">
+          <button
+            className="daily-brief-collapse"
+            onClick={onToggleCollapsed}
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
+            title={collapsed ? 'Expand' : 'Collapse'}
+          >
+            {collapsed ? '▸' : '▾'}
+          </button>
           <span className="daily-brief-date">{digest.run_date}</span>
           {digest.fallback_used && (
             <span
@@ -76,27 +119,32 @@ export function DailyBriefCarousel({
         </button>
       </div>
 
-      <div className="daily-brief-summary">{digest.summary}</div>
+      {!collapsed && (
+        <>
+          <div className="daily-brief-summary">{digest.summary}</div>
 
-      {rankedAssets.length > 0 ? (
-        <div className="daily-brief-assets">
-          {rankedAssets.map((asset) => (
-            <AssetRow
-              key={`${asset.asset_code}_${asset.country_code ?? ''}`}
-              asset={asset}
-            />
-          ))}
-        </div>
-      ) : (
-        <div className="daily-brief-empty">
-          No high or watch signals today.
-        </div>
-      )}
+          {rankedAssets.length > 0 ? (
+            <div className="daily-brief-assets">
+              {rankedAssets.map((asset) => (
+                <AssetRow
+                  key={`${asset.asset_code}_${asset.country_code ?? ''}`}
+                  asset={asset}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="daily-brief-empty">
+              No high or watch signals today.
+            </div>
+          )}
 
-      {noiseCount > 0 && (
-        <div className="daily-brief-noise">
-          + {noiseCount} lower-conviction signal{noiseCount > 1 ? 's' : ''}
-        </div>
+          {noiseCount > 0 && (
+            <div className="daily-brief-noise">
+              + {noiseCount} lower-conviction signal
+              {noiseCount > 1 ? 's' : ''}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -905,6 +905,7 @@ export interface TriagedAsset {
   rationale: string;
   patterns: string[];
   ma50_slope: number | null;
+  tradingview_url: string | null;
 }
 
 export interface AlertDigest {

--- a/tests/api/services/test_alert_digest_service.py
+++ b/tests/api/services/test_alert_digest_service.py
@@ -53,6 +53,9 @@ class TestListRecent:
             _item("2026-07-16", 300),
             _item("2026-07-15", 200),
         ]
+        mock_dynamodb_client.get_all_tradingview_links.return_value = {
+            "SAN:xpar": "https://www.tradingview.com/chart/custom"
+        }
 
         digests = await service.list_recent()
 
@@ -60,6 +63,10 @@ class TestListRecent:
         assert digests[0].counts == {"high": 1, "watch": 0, "noise": 0}
         assert digests[0].triaged_assets[0].ma50_slope == -2.3
         assert digests[0].triaged_assets[0].rank == 1
+        assert (
+            digests[0].triaged_assets[0].tradingview_url
+            == "https://www.tradingview.com/chart/custom"
+        )
 
     async def test_list_recent_uses_cache_on_second_call(
         self, service, mock_dynamodb_client
@@ -67,6 +74,7 @@ class TestListRecent:
         mock_dynamodb_client.get_alert_digests.return_value = [
             _item("2026-07-16", 300)
         ]
+        mock_dynamodb_client.get_all_tradingview_links.return_value = {}
 
         await service.list_recent()
         await service.list_recent()
@@ -81,6 +89,7 @@ class TestGetByRunDate:
         mock_dynamodb_client.get_alert_digest.return_value = _item(
             "2026-07-16", 300
         )
+        mock_dynamodb_client.get_all_tradingview_links.return_value = {}
 
         digest = await service.get_by_run_date("2026-07-16")
 


### PR DESCRIPTION
## Summary
- Add a collapse toggle (▾/▸) to the daily brief card, persisted in `localStorage` so it stays collapsed/expanded across reloads
- Add a TradingView icon per triaged asset, using a custom link when one is configured for that asset (falls back to the auto-generated URL)
- Make each asset name in the digest link to its asset detail page
- Split each asset row into a name+icons line and a rationale line for readability

## Backend changes
- `TriagedAssetResponse` now exposes `tradingview_url`, resolved via `DynamoDBClient.get_all_tradingview_links()` the same way the alerts endpoint already does
- `AlertDigestService` threads the resolved links through `list_recent` and `get_by_run_date`

## Test plan
- [x] `poetry run pytest tests/api -q` (109 passed)
- [x] `npx tsc --noEmit` (frontend typecheck clean)
- [x] Rendered the updated `DailyBriefCarousel`/`DailyBrief` CSS with mock data to confirm the collapse arrow, TradingView icon, and asset link render as expected (screenshot shared with the requester; live backend requires AWS credentials not available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WvcMvn6heELHQiJkQcugjb)_