### PR TITLE
feat: add CSV export for backtest range summary and day detail

### DIFF
--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -1,6 +1,8 @@
-"""Pydantic request/response models for the Backtest API."""
+"""Pydantic request/response models and CSV export for the Backtest API."""
 
+import csv
 import datetime
+import io
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -152,3 +154,69 @@ def backtest_run_result_to_response(
         summary=_backtest_summary_to_response(run_result.summary),
         days=[_day_result_summary_to_response(day) for day in run_result.days],
     )
+
+
+def backtest_run_result_to_csv(run_result: BacktestRunResult) -> str:
+    """FR-017: one row per day in run_result.days (no-data days already
+    excluded by BacktestService.run_range)."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["date", "status", "trade_count", "points"])
+    for day in run_result.days:
+        writer.writerow(
+            [
+                day.date.isoformat(),
+                day.status.value,
+                day.trade_count,
+                day.points,
+            ]
+        )
+    return output.getvalue()
+
+
+def day_result_to_csv(day_result: DayResult) -> str:
+    """FR-018: H1 levels, 5-minute candles, and trades as three blocks
+    separated by a blank line."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    writer.writerow(["h1_high", "h1_low"])
+    writer.writerow([day_result.h1_high, day_result.h1_low])
+    writer.writerow([])
+
+    writer.writerow(["date", "open", "higher", "lower", "close"])
+    for candle in day_result.candles:
+        writer.writerow(
+            [
+                candle.date.isoformat() if candle.date else "",
+                candle.open,
+                candle.higher,
+                candle.lower,
+                candle.close,
+            ]
+        )
+    writer.writerow([])
+
+    writer.writerow(
+        [
+            "entry_time",
+            "entry_price",
+            "exit_time",
+            "exit_price",
+            "exit_reason",
+            "points",
+        ]
+    )
+    for trade in day_result.trades:
+        writer.writerow(
+            [
+                trade.entry_time.isoformat(),
+                trade.entry_price,
+                trade.exit_time.isoformat(),
+                trade.exit_price,
+                trade.exit_reason.value,
+                trade.points,
+            ]
+        )
+
+    return output.getvalue()

--- a/api/routers/backtest.py
+++ b/api/routers/backtest.py
@@ -2,6 +2,7 @@ import datetime
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
 
 from api.date_utils import parse_iso_date
 from api.dependencies import get_backtest_service
@@ -10,7 +11,9 @@ from api.models.backtest import (
     BacktestRunResponse,
     DayDetailResponse,
     backtest_definition_to_response,
+    backtest_run_result_to_csv,
     backtest_run_result_to_response,
+    day_result_to_csv,
     day_result_to_response,
 )
 from api.services.backtest_service import (
@@ -59,14 +62,67 @@ async def get_backtest_run(
     """Run the backtest across a date range and return the aggregate
     summary plus a compact per-day list."""
     backtest_definition = _resolve_definition(backtest_service, definition)
+    start, end = _parse_range(start_date, end_date)
+    run_result = backtest_service.run_range(backtest_definition, start, end)
+    return backtest_run_result_to_response(run_result)
+
+
+@router.get("/day/csv")
+async def get_backtest_day_csv(
+    definition: str = Query(..., description="Backtest definition code"),
+    date: str = Query(..., description="Trading day (YYYY-MM-DD)"),
+    backtest_service: BacktestService = Depends(get_backtest_service),
+) -> Response:
+    """CSV export of a single day's detail (FR-018)."""
+    backtest_definition = _resolve_definition(backtest_service, definition)
+    trading_date = _parse_date(date)
+    day_result = backtest_service.evaluate_day(
+        backtest_definition, trading_date
+    )
+    return Response(
+        content=day_result_to_csv(day_result),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="backtest-{definition}-{date}.csv"'
+            )
+        },
+    )
+
+
+@router.get("/run/csv")
+async def get_backtest_run_csv(
+    definition: str = Query(..., description="Backtest definition code"),
+    start_date: str = Query(..., description="Start date (YYYY-MM-DD)"),
+    end_date: str = Query(..., description="End date (YYYY-MM-DD)"),
+    backtest_service: BacktestService = Depends(get_backtest_service),
+) -> Response:
+    """CSV export of a range run's day-by-day summary (FR-017)."""
+    backtest_definition = _resolve_definition(backtest_service, definition)
+    start, end = _parse_range(start_date, end_date)
+    run_result = backtest_service.run_range(backtest_definition, start, end)
+    return Response(
+        content=backtest_run_result_to_csv(run_result),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": (
+                "attachment; "
+                f'filename="backtest-{definition}-{start_date}-{end_date}.csv"'
+            )
+        },
+    )
+
+
+def _parse_range(
+    start_date: str, end_date: str
+) -> tuple[datetime.date, datetime.date]:
     start = _parse_date(start_date)
     end = _parse_date(end_date)
     if end < start:
         raise HTTPException(
             status_code=400, detail="end_date must not be before start_date"
         )
-    run_result = backtest_service.run_range(backtest_definition, start, end)
-    return backtest_run_result_to_response(run_result)
+    return start, end
 
 
 def _resolve_definition(

--- a/frontend/src/components/BacktestDayDetail.css
+++ b/frontend/src/components/BacktestDayDetail.css
@@ -4,6 +4,13 @@
   margin-bottom: 0.5rem;
 }
 
+.backtest-day-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .backtest-status {
   color: #a0a0a0;
 }

--- a/frontend/src/components/BacktestDayDetail.tsx
+++ b/frontend/src/components/BacktestDayDetail.tsx
@@ -1,3 +1,4 @@
+import { backtestService } from '../services/api';
 import type { BacktestDayDetail as BacktestDayDetailData } from '../services/api';
 import { formatParisTime } from '../utils/backtestTime';
 import './BacktestDayDetail.css';
@@ -7,12 +8,18 @@ const pointsClass = (points: number) => (points >= 0 ? 'positive' : 'negative');
 
 interface BacktestDayDetailProps {
   detail: BacktestDayDetailData;
+  definition: string;
 }
 
-export function BacktestDayDetail({ detail }: BacktestDayDetailProps) {
+export function BacktestDayDetail({ detail, definition }: BacktestDayDetailProps) {
   return (
     <div className="backtest-day-detail">
-      <h2>{detail.date}</h2>
+      <div className="backtest-day-detail-header">
+        <h2>{detail.date}</h2>
+        <button onClick={() => backtestService.exportDayCsv(definition, detail.date)}>
+          Export CSV
+        </button>
+      </div>
 
       {detail.status === 'no_data' && (
         <p className="backtest-status backtest-status--no-data">

--- a/frontend/src/pages/Backtest.css
+++ b/frontend/src/pages/Backtest.css
@@ -138,6 +138,10 @@
   margin-bottom: 1.5rem;
 }
 
+.backtest-export-csv {
+  margin-bottom: 1rem;
+}
+
 .backtest-summary-tile {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/Backtest.tsx
+++ b/frontend/src/pages/Backtest.tsx
@@ -191,10 +191,19 @@ export function Backtest() {
 
       {error && <div className="backtest-error">{error}</div>}
 
-      {mode === 'day' && dayResult && <BacktestDayDetail detail={dayResult} />}
+      {mode === 'day' && dayResult && (
+        <BacktestDayDetail detail={dayResult} definition={selectedDefinition} />
+      )}
 
       {mode === 'range' && runResult && (
         <div className="backtest-range-result">
+          <button
+            className="backtest-export-csv"
+            onClick={() => backtestService.exportRunCsv(selectedDefinition, startDate, endDate)}
+          >
+            Export CSV
+          </button>
+
           <div className="backtest-summary-grid">
             <div className="backtest-summary-tile">
               <span className="label">Days</span>
@@ -264,7 +273,7 @@ export function Backtest() {
           {drilldownError && <div className="backtest-error">{drilldownError}</div>}
           {drilldown && (
             <div className="backtest-day-drilldown">
-              <BacktestDayDetail detail={drilldown} />
+              <BacktestDayDetail detail={drilldown} definition={selectedDefinition} />
             </div>
           )}
         </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,15 @@ export const api = axios.create({
   },
 });
 
+function downloadFile(url: string): void {
+  const link = document.createElement('a');
+  link.href = url;
+  link.rel = 'noopener';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
 export interface AccountInfo {
   account_id: string;
   account_key: string;
@@ -1019,5 +1028,19 @@ export const backtestService = {
       params: { definition, start_date: startDate, end_date: endDate },
     });
     return response.data;
+  },
+
+  exportDayCsv: (definition: string, date: string): void => {
+    const params = new URLSearchParams({ definition, date });
+    downloadFile(`${API_BASE_URL}/api/backtest/day/csv?${params.toString()}`);
+  },
+
+  exportRunCsv: (definition: string, startDate: string, endDate: string): void => {
+    const params = new URLSearchParams({
+      definition,
+      start_date: startDate,
+      end_date: endDate,
+    });
+    downloadFile(`${API_BASE_URL}/api/backtest/run/csv?${params.toString()}`);
   },
 };

--- a/specs/021-backtest-menu-hardcoded/contracts/backtest-api.md
+++ b/specs/021-backtest-menu-hardcoded/contracts/backtest-api.md
@@ -122,6 +122,47 @@ Returns full detail for exactly one day — H1 reference levels, the 5-minute ca
 | 400 | `date` in the future, or unknown `definition` code |
 | 500 | Unexpected error |
 
+## `GET /api/backtest/run/csv`
+
+CSV export of a range run's day-by-day summary (FR-017). Same query parameters, validation, and day set as `GET /api/backtest/run` — this endpoint re-runs the backtest rather than reusing a prior `/run` response (consistent with the "ephemeral, not persisted" decision in Assumptions).
+
+**Query parameters**: identical to `GET /api/backtest/run` (`definition`, `start_date`, `end_date`).
+
+**Response 200** — `text/csv`, `Content-Disposition: attachment; filename="backtest-{definition}-{start_date}-{end_date}.csv"`
+
+```csv
+date,status,trade_count,points
+2026-06-01,no_trade,0,0.0
+2026-06-02,traded,2,-8.0
+```
+
+One row per day in the results (no-data days excluded, same as `/run`'s `days` list).
+
+**Errors**: same as `GET /api/backtest/run` (400 for invalid range/definition, 500 unexpected).
+
+## `GET /api/backtest/day/csv`
+
+CSV export of a single day's detail (FR-018). Same query parameters and validation as `GET /api/backtest/day`.
+
+**Query parameters**: identical to `GET /api/backtest/day` (`definition`, `date`).
+
+**Response 200** — `text/csv`, `Content-Disposition: attachment; filename="backtest-{definition}-{date}.csv"`
+
+```csv
+h1_high,h1_low
+8042.5,8011.0
+
+date,open,higher,lower,close
+2026-06-02T10:00:00,8009.5,8013.0,8005.0,8012.0
+
+entry_time,entry_price,exit_time,exit_price,exit_reason,points
+2026-06-02T10:20:00,8012.5,2026-06-02T11:05:00,7962.5,stop_loss,-50.0
+```
+
+Three blocks in one file (H1 levels, candles, trades), each separated by a blank line — trades off `status == "no_data"` days produce only the (empty) candles/trades blocks with `h1_high`/`h1_low` blank.
+
+**Errors**: same as `GET /api/backtest/day` (400 for future date/unknown definition, 500 unexpected).
+
 ## Frontend service mapping (`frontend/src/services/api.ts`)
 
 ```ts
@@ -129,6 +170,8 @@ export const backtestService = {
   getDefinitions: (): Promise<BacktestDefinition[]> => ...,
   runRange: (definition: string, startDate: string, endDate: string): Promise<BacktestRunResponse> => ...,
   getDayDetail: (definition: string, date: string): Promise<DayDetailResponse> => ...,
+  exportRunCsv: (definition: string, startDate: string, endDate: string): void => ..., // triggers browser download
+  exportDayCsv: (definition: string, date: string): void => ...,                        // triggers browser download
 };
 ```
 

--- a/specs/021-backtest-menu-hardcoded/plan.md
+++ b/specs/021-backtest-menu-hardcoded/plan.md
@@ -12,14 +12,14 @@ Add a "Backtest" menu that runs one hardcoded strategy — "CAC40 Bougie de 9h" 
 ## Technical Context
 
 **Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) — no change from existing stack.
-**Primary Dependencies**: FastAPI (backend, existing), Pydantic v2 (existing), `zoneinfo` (Python stdlib — new usage in this codebase for DST-aware Paris-local time math, see research.md §1), existing `SaxoClient`/`CandlesService`; React Router DOM v7+, Axios, Vite (frontend, existing).
+**Primary Dependencies**: FastAPI (backend, existing), Pydantic v2 (existing), `zoneinfo` (Python stdlib — new usage in this codebase for DST-aware Paris-local time math, see research.md §1), Python stdlib `csv` module (CSV export, FR-017/FR-018 — same stdlib usage as 022-trade-republic-report), existing `SaxoClient`/`CandlesService`; React Router DOM v7+, Axios, Vite (frontend, existing).
 **Storage**: N/A — ephemeral, computed on demand per request, nothing persisted (Clarifications, Session 2026-07-14).
 **Testing**: pytest with mocked `SaxoClient`/`MockSaxoClient` (backend, existing convention); no frontend test framework configured (existing gap, unchanged by this feature).
 **Target Platform**: Existing FastAPI backend (Lambda-deployable) + React SPA (Vite), served locally via `run_api.py` / `npm run dev` in development.
 **Project Type**: Web application (existing backend at repo root + `frontend/`) — matches the codebase's established layout, not the generic `backend/`+`frontend/` template split.
 **Performance Goals**: Single-day run and its underlying Saxo calls complete within a few seconds (SC-001); range runs are synchronous and scale with the number of trading days requested (each day needs one H1 + one 5-minute Saxo history call) — no explicit SLA beyond "completes without a dedicated job queue," consistent with this being a single-user, on-demand analysis tool and with the "no application-level range cap" clarification.
 **Constraints**: Must respect Constitution I (Layered Architecture) — new candle-fetch logic lives in `services/candles_service.py`, not called directly from the API service; must use existing enums (`Strategy.B9H`) instead of new hardcoded strings; must follow Candle conventions (index 0 = newest list ordering where lists are produced that way, `model.workflow.Candle` everywhere outside `SaxoClient`); strategy thresholds (50/10/20 points, 9–10 window) are intentionally hardcoded in code per FR-002 ("no generic engine"), not exposed via `config.yml` — see Complexity Tracking.
-**Scale/Scope**: One hardcoded `BacktestDefinition` (`B9H`); 3 new/changed backend endpoints' worth of surface (`/definitions`, `/run`, `/day`); one new frontend page + sidebar entry; single-user tool, no concurrency/multi-tenant concerns.
+**Scale/Scope**: One hardcoded `BacktestDefinition` (`B9H`); 5 new/changed backend endpoints' worth of surface (`/definitions`, `/run`, `/day`, plus CSV exports `/run/csv` and `/day/csv` for FR-017/FR-018); one new frontend page + sidebar entry, plus two "Export CSV" buttons; single-user tool, no concurrency/multi-tenant concerns.
 
 ## Constitution Check
 
@@ -69,7 +69,8 @@ api/
 ├── models/
 │   └── backtest.py                # NEW: Pydantic request/response models
 ├── routers/
-│   └── backtest.py                # NEW: GET /definitions, /run, /day
+│   └── backtest.py                # NEW: GET /definitions, /run, /day,
+                                    #      /run/csv, /day/csv (FR-017/FR-018)
 ├── services/
 │   └── backtest_service.py        # NEW: breakout/exit rule engine + aggregation
 ├── dependencies.py                # + get_backtest_service()
@@ -77,13 +78,15 @@ api/
 
 frontend/src/
 ├── pages/
-│   ├── Backtest.tsx                # NEW: page (single-day + range modes)
+│   ├── Backtest.tsx                # NEW: page (single-day + range modes);
+                                    #      + "Export CSV" buttons (FR-017/FR-018)
 │   └── Backtest.css                # NEW
 ├── components/
 │   └── Sidebar.tsx                 # + "Backtest" NavLink entry
 ├── App.tsx                         # + <Route path="/backtest" .../>
 └── services/
-    └── api.ts                      # + backtestService + TS interfaces
+    └── api.ts                      # + backtestService + TS interfaces;
+                                    #   + exportRunCsv/exportDayCsv helpers
 
 tests/
 ├── services/

--- a/specs/021-backtest-menu-hardcoded/spec.md
+++ b/specs/021-backtest-menu-hardcoded/spec.md
@@ -53,6 +53,7 @@ A trader wants to enter a start date and end date in the UI, run the "CAC40 Boug
 3. **Given** a date range where no trade signal ever occurs, **When** the backtest runs, **Then** the system displays number of trades as 0, number of winning, losing, and break-even positions as 0, average win and average loss as not applicable, and a final result of 0 points.
 4. **Given** a date range containing at least one trade that closed via the break-even mechanism, **When** the backtest runs, **Then** that trade counts toward "number of BE" and toward "number of trades," but not toward "number of winning positions" or "number of losing positions," and its 0-point result is excluded from the average win and average loss calculations.
 5. **Given** an end date before the start date, or a start or end date in the future, entered in the UI, **When** the trader submits the request, **Then** the system rejects it with a validation error and does not run the backtest.
+6. **Given** a completed range run, **When** the trader requests a CSV export, **Then** the system downloads a CSV file with one row per day in the range results (date, status, trade count, points), matching the displayed summary.
 
 ---
 
@@ -67,6 +68,7 @@ A trader wants to see, for a given backtested day, the H1 opening-range high/low
 **Acceptance Scenarios**:
 
 1. **Given** a backtested day with a trade, **When** the trader opens that day's detail view, **Then** the system shows the 9:00–10:00 H1 high and low, the sequence of 5-minute candles from 10:00 onward, and the entry and exit points marked against that data.
+2. **Given** a backtested day's detail view, **When** the trader requests a CSV export, **Then** the system downloads a CSV file containing the H1 high/low, the 5-minute candle sequence, and the day's trades.
 
 ---
 
@@ -124,6 +126,8 @@ A trader wants to see, for a given backtested day, the H1 opening-range high/low
 - **FR-014**: Trade results MUST be expressed in index points (entry/exit price and points gained or lost), consistent with how the strategy's thresholds (50 points, 10 points) are defined.
 - **FR-015**: System MUST let a trader open a detail view for any backtested day that produced at least one trade, showing the H1 high/low reference levels, the 5-minute candles used from 10:00 onward, and the entry/exit points for every trade taken that day.
 - **FR-016**: System MUST validate the trader-provided start and end date before running the backtest, and MUST reject the request with a clear error, without evaluating any day, when the end date is before the start date or when either date is in the future.
+- **FR-017**: System MUST let a trader export a range run's day-by-day summary as a downloadable CSV file, with one row per day in the results (date, status, trade count, points) — the same set of days already returned by the range run (FR-012).
+- **FR-018**: System MUST let a trader export a single day's detail (FR-015) as a downloadable CSV file, containing the H1 high/low reference levels, the sequence of 5-minute candles (date, open, high, low, close), and the day's trades (entry time/price, exit time/price, exit reason, points).
 
 ### Key Entities
 

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -239,6 +239,135 @@ class TestGetBacktestRun:
         mock_backtest_service.run_range.assert_not_called()
 
 
+class TestGetBacktestDayCsv:
+    def test_traded_day_returns_csv(self, mock_backtest_service):
+        mock_backtest_service.get_definition.return_value = MagicMock(
+            code="B9H"
+        )
+        mock_backtest_service.evaluate_day.return_value = DayResult(
+            date=datetime.date(2026, 6, 2),
+            status=DayStatus.TRADED,
+            h1_high=8050.0,
+            h1_low=8000.0,
+            candles=[
+                Candle(
+                    lower=8005.0,
+                    higher=8013.0,
+                    open=8009.5,
+                    close=8012.0,
+                    ut=UnitTime.M5,
+                    date=datetime.datetime(2026, 6, 2, 8, 0),
+                )
+            ],
+            trades=[
+                Trade(
+                    entry_time=datetime.datetime(2026, 6, 2, 8, 5),
+                    entry_price=8010.0,
+                    exit_time=datetime.datetime(2026, 6, 2, 9, 0),
+                    exit_price=7960.0,
+                    exit_reason=ExitReason.STOP_LOSS,
+                    points=-50.0,
+                )
+            ],
+        )
+
+        response = client.get(
+            "/api/backtest/day/csv",
+            params={"definition": "B9H", "date": "2026-06-02"},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert (
+            'attachment; filename="backtest-B9H-2026-06-02.csv"'
+            in response.headers["content-disposition"]
+        )
+        body = response.text
+        assert "h1_high,h1_low" in body
+        assert "8050.0,8000.0" in body
+        assert "2026-06-02T08:00:00" in body
+        assert "stop_loss" in body
+
+    def test_invalid_date_format_returns_400(self, mock_backtest_service):
+        mock_backtest_service.get_definition.return_value = MagicMock(
+            code="B9H"
+        )
+
+        response = client.get(
+            "/api/backtest/day/csv",
+            params={"definition": "B9H", "date": "not-a-date"},
+        )
+
+        assert response.status_code == 400
+        mock_backtest_service.evaluate_day.assert_not_called()
+
+
+class TestGetBacktestRunCsv:
+    def test_populated_range_returns_csv(self, mock_backtest_service):
+        mock_backtest_service.get_definition.return_value = MagicMock(
+            code="B9H"
+        )
+        mock_backtest_service.run_range.return_value = BacktestRunResult(
+            summary=BacktestSummary(
+                definition_code="B9H",
+                start_date=datetime.date(2026, 6, 1),
+                end_date=datetime.date(2026, 6, 2),
+                number_of_days=2,
+                number_of_trades=1,
+                number_of_winning_positions=1,
+                number_of_losing_positions=0,
+                number_of_be=0,
+                average_win=30.0,
+                average_loss=None,
+                final_result=30.0,
+            ),
+            days=[
+                DayResultSummary(
+                    date=datetime.date(2026, 6, 2),
+                    status=DayStatus.TRADED,
+                    trade_count=1,
+                    points=30.0,
+                )
+            ],
+        )
+
+        response = client.get(
+            "/api/backtest/run/csv",
+            params={
+                "definition": "B9H",
+                "start_date": "2026-06-01",
+                "end_date": "2026-06-02",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert (
+            'attachment; filename="backtest-B9H-2026-06-01-2026-06-02.csv"'
+            in response.headers["content-disposition"]
+        )
+        body = response.text
+        assert "date,status,trade_count,points" in body
+        assert "2026-06-02,traded,1,30.0" in body
+
+    def test_end_before_start_returns_400(self, mock_backtest_service):
+        mock_backtest_service.get_definition.return_value = MagicMock(
+            code="B9H"
+        )
+
+        response = client.get(
+            "/api/backtest/run/csv",
+            params={
+                "definition": "B9H",
+                "start_date": "2026-06-10",
+                "end_date": "2026-06-01",
+            },
+        )
+
+        assert response.status_code == 400
+        mock_backtest_service.run_range.assert_not_called()
+
+
 class TestGetBacktestDefinitions:
     def test_returns_definitions_list(self, mock_backtest_service):
         mock_backtest_service.list_definitions.return_value = [

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -301,6 +301,35 @@ class TestGetBacktestDayCsv:
         assert response.status_code == 400
         mock_backtest_service.evaluate_day.assert_not_called()
 
+    def test_no_data_day_returns_blank_h1_and_empty_blocks(
+        self, mock_backtest_service
+    ):
+        """Pins the empty-block contract for a no_data day: h1_high/
+        h1_low render as blank cells (not "None"), and the candles/
+        trades blocks are present but have no rows."""
+        mock_backtest_service.get_definition.return_value = MagicMock(
+            code="B9H"
+        )
+        mock_backtest_service.evaluate_day.return_value = DayResult(
+            date=datetime.date(2026, 6, 2), status=DayStatus.NO_DATA
+        )
+
+        response = client.get(
+            "/api/backtest/day/csv",
+            params={"definition": "B9H", "date": "2026-06-02"},
+        )
+
+        assert response.status_code == 200
+        assert response.text == (
+            "h1_high,h1_low\r\n"
+            ",\r\n"
+            "\r\n"
+            "date,open,higher,lower,close\r\n"
+            "\r\n"
+            "entry_time,entry_price,exit_time,exit_price,"
+            "exit_reason,points\r\n"
+        )
+
 
 class TestGetBacktestRunCsv:
     def test_populated_range_returns_csv(self, mock_backtest_service):


### PR DESCRIPTION
## Summary
- Add `GET /api/backtest/run/csv` (FR-017) — CSV export of a range run's day-by-day summary (date, status, trade count, points).
- Add `GET /api/backtest/day/csv` (FR-018) — CSV export of a single day's full detail (H1 high/low, 5-minute candles, trades), as three blank-line-separated blocks in one file.
- "Export CSV" buttons on the range results view and the day-detail component (both single-day mode and the range drilldown), triggering a native browser download via the server-set `Content-Disposition` filename.
- Updated `specs/021-backtest-menu-hardcoded/spec.md` (new FR-017/FR-018 + acceptance scenarios), `plan.md` (Scale/Scope, Source Code tree, `csv` stdlib dependency), and `contracts/backtest-api.md` to match.

Motivated by needing to pull specific days' full candle traces out of the app quickly instead of copy-pasting from the UI table, for debugging why the backtest entered/exited trades the way it did on particular days.

## Test plan
- [x] `poetry run pytest` — 416 passed, 10 skipped (unrelated AWS-context skips)
- [x] 100% coverage on `api/models/backtest.py` and `api/routers/backtest.py`
- [x] `black` / `isort` / `flake8` / `mypy` clean on all changed Python files
- [x] `tsc --noEmit` and `npm run lint` clean on frontend changes (no new warnings/errors)
- [x] `npm run build` succeeds
- [x] Verified end-to-end in a real browser (Playwright against the Vite dev server + FastAPI backend, mocked API responses): both "Export CSV" buttons trigger a download with the correct filename and query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012S2PLVTLEPLCB15S2FV4j6)_