### PR TITLE
docs: Ouinex crypto provider — spec & plan (024)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Examples:
 - N/A — ephemeral, computed on demand per request, nothing persisted (Clarifications, Session 2026-07-14). (021-backtest-menu-hardcoded)
 - Python 3.12 (backend), TypeScript 5+ / React 19+ (frontend) + `anthropic` SDK (NEW, backend), FastAPI + Pydantic v2, Click, `aioboto3` (DynamoDB), `slack_sdk`, `cachetools` (TTLCache); React Router DOM v7+, Vite 7+, Axios (frontend) (023-alert-triage)
 - AWS DynamoDB — new `alert_digests` table (hash_key `run_date` String, range_key `created_at` Number, **no TTL**); existing `alerts` table unchanged (023-alert-triage)
+- Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend — minimal changes) + FastAPI, Pydantic v2, `cachetools` (TTLCache), `googleapiclient` (Google Sheets); NEW: a GraphQL/HTTP client for Ouinex (`httpx` or `requests` — POST GraphQL + JWT auth flow); frontend Axios + React Router DOM v7+ (024-ouinex-provider)
+- AWS DynamoDB `watchlist` table (existing `exchange` attribute, unchanged schema); Google Sheets trading journal (existing "Liste d'ordre" sheet, unchanged schema). No new tables. (024-ouinex-provider)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/specs/024-ouinex-provider/checklists/requirements.md
+++ b/specs/024-ouinex-provider/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Ouinex crypto provider
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- The provider name and journal-identity URL (https://api.ouinex.com/) appear only as a dependency reference, not as an implementation directive.
+- The single most impactful open question — whether Ouinex coexists with or replaces Binance — was resolved by a documented assumption (coexistence). Confirm during `/speckit.clarify` if that assumption is wrong.

--- a/specs/024-ouinex-provider/contracts/api-deltas.md
+++ b/specs/024-ouinex-provider/contracts/api-deltas.md
@@ -1,0 +1,54 @@
+# Phase 1 Contracts: API deltas for Ouinex
+
+This feature introduces **no new endpoints**. It extends existing endpoints to accept a new `exchange` value (`"ouinex"`) and a new account prefix (`"ouinex_"`). Request/response schemas are unchanged; only accepted values and returned lists grow.
+
+---
+
+## 1. `GET /api/search?keyword=...`
+
+- **Change**: results may now include items with `exchange: "ouinex"`.
+- **Response item** (`SearchResultItem`, unchanged shape):
+  ```json
+  { "symbol": "BTCUSD", "description": "BTC/USD", "identifier": null,
+    "asset_type": "Crypto", "exchange": "ouinex" }
+  ```
+- **Contract test**: given an Ouinex client returning one matching `Asset`, the response `results` includes an item with `exchange == "ouinex"`; Saxo/Binance results are unaffected; if the Ouinex client raises, search still returns Saxo/Binance results (FR-012).
+
+## 2. `GET /api/indicator/asset/{code}?exchange=ouinex&unit_time=daily`
+
+- **Change**: `exchange` query now accepts `"ouinex"`. When `exchange=ouinex`, indicators are computed from Ouinex candles.
+- **Request**: `exchange=ouinex`, `country_code` ignored (as for Binance), `unit_time` in {daily, weekly, monthly}.
+- **Response**: `AssetIndicatorsResponse` (unchanged) — moving averages (7/20/50/200), `current_price`, `variation_pct`.
+- **Contract test**: `Exchange.get_value("ouinex")` resolves; the route dispatches to the Ouinex candle path; a mocked `OuinexClient.get_candles` yields a valid `AssetIndicatorsResponse`.
+- **Edge (VERIFY)**: weekly/monthly for Ouinex — either supported via daily aggregation or returns a clear 400 if unsupported (research Decision 4).
+
+## 3. `GET /api/fund/accounts`
+
+- **Change**: the returned account list now also includes an Ouinex pseudo-account.
+  ```json
+  { "account_id": "ouinex_main", "account_key": "ouinex",
+    "account_name": "Ouinex", "total_fund": 0, "available_fund": 0 }
+  ```
+- **Contract test**: response contains both `binance_main` and `ouinex_main`; Saxo accounts still listed.
+
+## 4. `GET /api/report/orders` and `GET /api/report/summary`
+
+- **Change**: `account_id` starting with `"ouinex_"` routes to `OuinexReportService`.
+- **Request**: `account_id=ouinex_main`, `from_date=YYYY-MM-DD`.
+- **Response**: `ReportListResponse` / `ReportSummaryResponse` (unchanged shape).
+- **Contract test**: `account_id="ouinex_main"` selects `OuinexReportService.get_orders_report`; `binance_main` still selects `BinanceReportService`; Saxo ids unaffected.
+
+## 5. `POST /api/report/gsheet/create` and `POST /api/report/gsheet/update`
+
+- **Change**: `account_id` starting with `"ouinex_"` routes to `OuinexReportService`, which writes the journal row using the **Binance pseudo-account identity**.
+- **Request**: `CreateGSheetOrderRequest` / `UpdateGSheetOrderRequest` (unchanged), `account_id=ouinex_main`.
+- **Contract/behavior test** (the core "map as binance" guarantee):
+  - Given an Ouinex order written via `account_id="ouinex_main"`, the `Account` passed to `GSheetClient.create_order` has `name == "Coinbase"` and `key == "binance"` — **identical** to a Binance write.
+  - The provider column value written to the sheet for an Ouinex trade equals the value written for a Binance trade (SC-002: 0% appear under a separate "ouinex" identity).
+
+---
+
+## Cross-cutting contract guarantees
+
+- **Isolation (FR-012 / SC-005)**: any Ouinex client error surfaces as a provider-specific failure and never breaks Saxo or Binance responses on shared endpoints (search especially).
+- **No Binance regression (FR-013 / SC-004)**: all existing Binance contract behaviors (`binance_main` routing, public search, indicator dispatch) remain byte-for-byte unchanged.

--- a/specs/024-ouinex-provider/data-model.md
+++ b/specs/024-ouinex-provider/data-model.md
@@ -1,0 +1,81 @@
+# Phase 1 Data Model: Ouinex crypto provider
+
+No new persistence schema. This feature adds one enum value, one Client, one Service, and configuration — reusing existing domain models (`Asset`, `Candle`, `ReportOrder`, `Account`).
+
+## Enum change — `model/enum.py`
+
+```python
+class Exchange(EnumWithGetValue):
+    SAXO = "saxo"
+    BINANCE = "binance"
+    OUINEX = "ouinex"   # NEW
+```
+
+- `Exchange.get_value("ouinex")` must resolve (used by `indicator.py`, `homepage.py`).
+- Wherever code branches on `Exchange.BINANCE` for crypto treatment, it must also accept `Exchange.OUINEX` (indicator routing, watchlist crypto tagging, homepage mapping). Prefer a small helper (e.g., `Exchange.is_crypto()` or `exchange in CRYPTO_EXCHANGES`) over scattered `in (BINANCE, OUINEX)` checks, to keep the intent explicit and avoid missed branches.
+
+## Reused domain models (unchanged)
+
+- **`Asset`** (`model/asset.py`): `symbol`, `description`, `asset_type`, `exchange`, `identifier`. Ouinex search returns `Asset(exchange=Exchange.OUINEX, asset_type=AssetType.CRYPTO)`.
+- **`Candle`** (`model/workflow.py`): `open`, `higher`, `lower`, `close`, `ut`, `date`. `OuinexClient.get_candles` returns a list ordered **index 0 = newest** (Constitution V.1).
+- **`ReportOrder`** (`model/`): produced by `OuinexClient.get_report_all`; `asset_type=AssetType.CRYPTO`, `currency=Currency.USD` (or quote), commissions applied — same shape Binance produces.
+- **`Account`** (`model/__init__.py`): `key`, `name`, `fund`, `available_fund`, `client_key`. The **Binance pseudo-account is reused verbatim** for Ouinex journal writes:
+  - `Account(key="binance", name="Coinbase", fund=0, client_key="binance")`
+  - This is the concrete meaning of "map as binance": `account.name` is what the gsheet provider column stores.
+
+## New Client interface — `client/ouinex_client.py`
+
+Public method surface (must match what Services already call on `BinanceClient`):
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| `search` | `(keyword: str)` | `List[Asset]` | GraphQL `instruments`, client-side keyword filter, `exchange=OUINEX` |
+| `get_candles` | `(symbol: str, unit_time: UnitTime, limit: int = 200)` | `List[Candle]` | newest-first; **historical-bars query — see research Decision 4 (VERIFY)** |
+| `get_latest_candle` | `(symbol: str)` | `Candle` | most recent fine-grained bar for current price |
+| `get_report` | `(symbol: str, date: str, usdeur_rate: float)` | `List[ReportOrder]` | GraphQL `closed_orders`/`account_transactions` |
+| `get_report_all` | `(date: str, usdeur_rate: float)` | `List[ReportOrder]` | iterate tracked symbols |
+
+Internal (private, `_`-prefixed) helpers: JWT sign-in/refresh, GraphQL POST, periodicity mapping (`UnitTime` → Ouinex periodicity), bar→`Candle` mapping, trade→`ReportOrder` mapping.
+
+**UnitTime → Ouinex periodicity map** (VERIFY; note missing W/M):
+
+| UnitTime | Ouinex periodicity | Status |
+|----------|--------------------|--------|
+| M15 | `15m` | OK |
+| H1 | `1h` | OK |
+| H4 | `4h` | OK |
+| D | `1d` | OK |
+| W | — | **VERIFY** — aggregate from `1d` or unsupported |
+| M | — | **VERIFY** — aggregate from `1d` or unsupported |
+
+## New Service — `api/services/ouinex_report_service.py`
+
+Mirrors `BinanceReportService`:
+
+- `get_orders_report(account_id, from_date)` — TTLCache (128, 300s); calls `OuinexClient.get_report_all`.
+- `convert_order_to_eur`, `calculate_summary` — identical logic (reuse or share with Binance).
+- `create_gsheet_order` / `update_gsheet_order` — write via `GSheetClient` using the **shared Binance pseudo-account**.
+- Account factory centralized so `BinanceReportService` and `OuinexReportService` return an identical `Account` (single source of truth for the "binance" identity).
+
+## Configuration — `utils/configuration.py`
+
+```python
+@property
+def ouinex_keys(self) -> Tuple:
+    return (
+        self.secrets["ouinex_api_key"],
+        self.secrets["ouinex_secret_key"],
+    )
+
+@property
+def ouinex_graphql_url(self) -> str:
+    return self.config.get("ouinex_graphql_url", "https://live-api.ouinex.com/graphql")
+```
+
+- `secrets.yml` (gitignored) gains `ouinex_api_key`, `ouinex_secret_key`.
+- `config.yml` may set `ouinex_graphql_url` (non-secret).
+
+## State / lifecycle
+
+- No stored state changes. Watchlist items simply carry `exchange="ouinex"` (existing free-form attribute).
+- JWT token lifecycle lives entirely inside `OuinexClient` (in-memory, refreshed on expiry).

--- a/specs/024-ouinex-provider/plan.md
+++ b/specs/024-ouinex-provider/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Ouinex crypto provider
+
+**Branch**: `024-ouinex-provider` | **Date**: 2026-07-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/024-ouinex-provider/spec.md`
+
+## Summary
+
+Introduce Ouinex as a new crypto provider that mirrors the existing Binance feature set — instrument search, watchlist add/classification, candle retrieval for indicators, and trade-history reporting — while writing all journal entries under the existing Binance pseudo-account identity ("map as binance"). Ouinex coexists with Binance (both remain available); order execution is out of scope.
+
+The technical approach follows the established layered pattern: a new `OuinexClient` in the Client layer exposing the same method surface as `BinanceClient` (`search`, `get_candles`, `get_latest_candle`, `get_report_all`), a new `OuinexReportService` that reuses the Binance pseudo-account when writing to Google Sheets, a new `Exchange.OUINEX` enum value, and routing additions everywhere Binance is currently routed (search, indicators, watchlist, homepage, report, accounts). The key divergence from Binance is the Ouinex API itself: it is a **GraphQL API** (`POST https://live-api.ouinex.com/graphql`) with **JWT bearer authentication** and delivers OHLC bars via **WebSocket subscription**, versus Binance's simple public REST endpoints and static key/secret HMAC. This drives the bulk of the new Client-layer work and the primary risk (see `research.md`).
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend — minimal changes)
+**Primary Dependencies**: FastAPI, Pydantic v2, `cachetools` (TTLCache), `googleapiclient` (Google Sheets); NEW: a GraphQL/HTTP client for Ouinex (`httpx` or `requests` — POST GraphQL + JWT auth flow); frontend Axios + React Router DOM v7+
+**Storage**: AWS DynamoDB `watchlist` table (existing `exchange` attribute, unchanged schema); Google Sheets trading journal (existing "Liste d'ordre" sheet, unchanged schema). No new tables.
+**Testing**: `pytest` with `unittest.mock` mocking the Ouinex client; test data files under `tests/services/files/`
+**Target Platform**: Linux server / AWS Lambda (backend), plus local FastAPI + Vite dev
+**Project Type**: web (backend `api/` + frontend `frontend/`)
+**Performance Goals**: Parity with Binance — report fetches cached with 5-min TTL; candle/search requests complete within a few seconds; no added latency to Saxo/Binance paths
+**Constraints**: Ouinex requires valid credentials for **every** call (search, candles, reporting) — unlike Binance's public market-data endpoints (per Clarifications). JWT tokens are short-lived and must be refreshed. An Ouinex failure MUST NOT degrade Binance or Saxo.
+**Scale/Scope**: Single-user personal trading tool; crypto watchlist on the order of tens of instruments
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Layered Architecture Discipline | PASS | `OuinexClient` lives in `client/` and returns domain models (`Asset`, `Candle`, `ReportOrder`), never raw GraphQL responses. `OuinexReportService` in `api/services/` orchestrates the client. Routers stay thin. No service accesses client internals. Public methods carry no `_` prefix. |
+| II. Clean Code First | PASS | Mirror the `BinanceClient`/`BinanceReportService` shape; no speculative abstraction. The Binance→Ouinex mapping stays explicit, not clever. No unnecessary comments. |
+| III. Configuration-Driven Design | PASS | Ouinex credentials read from `secrets.yml` via a new `Configuration.ouinex_keys` property (mirrors `binance_keys`); GraphQL base URL in `config.yml`, no hardcoding. |
+| IV. Safe Deployment Practices | PASS | No infrastructure change (no new AWS resources). Conventional commits. |
+| V. Domain Model Integrity | PASS | Add explicit `Exchange.OUINEX = "ouinex"`; never infer exchange from `country_code`. Candle ordering (index 0 = newest) preserved in `OuinexClient.get_candles`. Reconstruction of current day/hour follows the existing pattern. Reporting maps to Binance identity **explicitly** at the write boundary, not by inference. |
+
+**Result**: No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/024-ouinex-provider/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — Ouinex API decisions & risks
+├── data-model.md        # Phase 1 output — entities, enum, client interface
+├── quickstart.md        # Phase 1 output — configure & verify
+├── contracts/           # Phase 1 output — API contract deltas
+│   └── api-deltas.md
+├── checklists/
+│   └── requirements.md  # From /speckit.specify
+└── tasks.md             # From /speckit.tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+client/
+├── ouinex_client.py          # NEW — GraphQL+JWT client; same method surface as BinanceClient
+└── binance_client.py         # reference implementation (unchanged)
+
+api/
+├── dependencies.py           # MODIFY — add get_ouinex_client(), get_ouinex_report_service()
+├── services/
+│   ├── ouinex_report_service.py   # NEW — reuses Binance pseudo-account ("map as binance")
+│   ├── binance_report_service.py  # reference (unchanged)
+│   ├── search_service.py     # MODIFY — include Ouinex results alongside Saxo+Binance
+│   ├── indicator_service.py  # MODIFY — route Exchange.OUINEX to Ouinex candles
+│   └── watchlist_service.py  # MODIFY — treat OUINEX like BINANCE (crypto tag, USD, indicators)
+└── routers/
+    ├── search.py             # MODIFY — inject Ouinex client
+    ├── indicator.py          # MODIFY — inject Ouinex client; accept exchange=ouinex
+    ├── report.py             # MODIFY — route account_id "ouinex_" → Ouinex report service
+    ├── fund.py               # MODIFY — add "ouinex_main" pseudo-account to /accounts
+    └── homepage.py           # MODIFY — map exchange_str "ouinex" → Exchange.OUINEX
+
+model/
+└── enum.py                   # MODIFY — add Exchange.OUINEX = "ouinex"
+
+utils/
+└── configuration.py          # MODIFY — add ouinex_keys property + graphql url
+
+saxo_order/commands/
+└── ouinex.py                 # NEW (optional) — CLI report command mirroring binance.py
+
+frontend/src/
+└── pages/SearchResults.css   # MODIFY — .exchange-badge.ouinex style (cosmetic)
+
+tests/
+├── client/test_ouinex_client.py            # NEW
+├── api/services/test_ouinex_report_service.py  # NEW
+├── api/routers/test_search.py              # MODIFY — assert Ouinex results included
+└── api/routers/test_report.py              # MODIFY — assert ouinex_ routing + binance identity
+```
+
+**Structure Decision**: Web application (backend + frontend) using the existing layered architecture. Ouinex is added as a sibling to Binance at each layer — a new Client, a new report Service, a new enum value, and routing branches in existing routers/services — rather than a parallel subsystem. The frontend is largely exchange-agnostic (it passes the `exchange` string through), so frontend work is limited to a badge style and the report account dropdown auto-populating from `/api/fund/accounts`.
+
+## Key Integration Points (Binance parity map)
+
+| Capability | Binance today | Ouinex change |
+|-----------|---------------|---------------|
+| Instrument search | `SearchService` calls `BinanceClient.search()` | Also call `OuinexClient.search()`; results tagged `Exchange.OUINEX` |
+| Indicators / candles | `IndicatorService._get_binance_asset_indicators` via `BinanceClient.get_candles` | Route `Exchange.OUINEX` → `OuinexClient.get_candles` |
+| Watchlist add | `watchlist_service` treats `exchange == "binance"` as crypto (USD, crypto tag) | Same treatment for `"ouinex"` |
+| Homepage enrichment | maps `"binance"` → `Exchange.BINANCE` | map `"ouinex"` → `Exchange.OUINEX` |
+| Accounts list | `/api/fund/accounts` prepends `binance_main` | Also prepend `ouinex_main` |
+| Report routing | `account_id.startswith("binance_")` → `BinanceReportService` | `startswith("ouinex_")` → `OuinexReportService` |
+| Journal write (gsheet) | `BinanceReportService._get_binance_account()` → `Account(key="binance", name="Coinbase")` | `OuinexReportService` reuses the **same** Binance pseudo-account → "map as binance" |
+| Credentials | `Configuration.binance_keys` from `secrets.yml` | NEW `Configuration.ouinex_keys` |
+
+## Scope notes / faithful parity
+
+- **Alerts**: `run_detection_for_asset` currently builds candles only via `saxo_client` and returns early when `saxo_uic is None`, so **crypto assets (Binance today) receive no alert detection**. Faithful parity means Ouinex inherits the same behavior — no new crypto alert capability is built as part of this feature. FR-007 is satisfied ("same alerts as Binance" = none in practice). Building real crypto alert detection would be a separate feature. This is called out so we neither over-build nor claim a capability that does not exist.
+- **Order execution**: out of scope per Clarifications (Binance has none).
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/024-ouinex-provider/quickstart.md
+++ b/specs/024-ouinex-provider/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Ouinex crypto provider
+
+How to configure, run, and verify the Ouinex provider once implemented. Mirrors the Binance setup.
+
+## 1. Credentials
+
+Add Ouinex API credentials to `secrets.yml` (gitignored):
+
+```yaml
+ouinex_api_key: "<your-ouinex-api-key>"
+ouinex_secret_key: "<your-ouinex-secret>"
+```
+
+Optionally override the GraphQL endpoint in `config.yml` (defaults to `https://live-api.ouinex.com/graphql`):
+
+```yaml
+ouinex_graphql_url: "https://live-api.ouinex.com/graphql"
+```
+
+## 2. Run backend + frontend
+
+```bash
+poetry run python run_api.py        # API on :8000
+cd frontend && npm run dev          # Vite on :5173
+```
+
+## 3. Verify each user story
+
+**US1 — provider recognized**
+```bash
+curl "http://localhost:8000/api/fund/accounts" | grep ouinex_main
+```
+Expect an `ouinex_main` account alongside `binance_main`.
+
+**US2 — search & watchlist**
+```bash
+curl "http://localhost:8000/api/search?keyword=btc" | jq '.results[] | select(.exchange=="ouinex")'
+```
+Expect at least one Ouinex crypto result. Add it via the Watchlist UI and confirm it is tagged crypto (USD price), like a Binance item.
+
+**US3 — indicators**
+```bash
+curl "http://localhost:8000/api/indicator/asset/BTCUSD?exchange=ouinex&unit_time=daily" | jq '.moving_averages, .current_price'
+```
+Expect MAs (7/20/50/200) and a current price. (Weekly/monthly: see research VERIFY item.)
+Note: crypto **alerts** are not produced — parity with Binance, which has no crypto alert detection today.
+
+**US4 — report as binance**
+```bash
+curl "http://localhost:8000/api/report/orders?account_id=ouinex_main&from_date=2026-07-01" | jq '.orders | length'
+```
+Then, in the Report UI, pick the **Ouinex** account, write a trade to the journal, and open the Google Sheet:
+- The provider column shows the **same value as Binance rows** ("Coinbase"). The row is indistinguishable from a native Binance entry (SC-002).
+
+## 4. Failure isolation check (FR-012 / SC-005)
+
+Temporarily set an invalid `ouinex_api_key`, then:
+```bash
+curl "http://localhost:8000/api/search?keyword=btc" | jq '.results[] | select(.exchange=="saxo" or .exchange=="binance") | .symbol' | head
+```
+Expect Saxo/Binance results still returned; only Ouinex results are absent, with an Ouinex-specific error logged.
+
+## 5. Quality gates
+
+```bash
+poetry run black . && poetry run isort . && poetry run mypy . && poetry run flake8
+poetry run pytest tests/client/test_ouinex_client.py tests/api/services/test_ouinex_report_service.py
+cd frontend && npm run build
+```

--- a/specs/024-ouinex-provider/research.md
+++ b/specs/024-ouinex-provider/research.md
@@ -1,0 +1,75 @@
+# Phase 0 Research: Ouinex crypto provider
+
+Source: Ouinex API landing (https://api.ouinex.com/, live endpoint https://live-api.ouinex.com/graphql), plus the existing Binance implementation (`client/binance_client.py`, `api/services/binance_report_service.py`) used as the parity baseline.
+
+> ⚠️ The Ouinex API surface below was derived from the public landing page and is **incomplete**. Items marked **VERIFY** must be confirmed against full Ouinex docs (or the Ouinex team) before or during implementation. They do not block planning but shape the task list and risk profile.
+
+---
+
+## Decision 1: Provider modeled as a new `Exchange.OUINEX`, mapped to Binance only at the journal boundary
+
+- **Decision**: Add `Exchange.OUINEX = "ouinex"`. Ouinex flows through search / indicators / watchlist / homepage / reporting as its own exchange (real data source). Only when a trade is written to the Google Sheet does it adopt the Binance pseudo-account identity.
+- **Rationale**: Constitution V.4 forbids inferring the source exchange and requires an explicit `exchange` field. Ouinex is a genuinely distinct data source with its own credentials and API, so it must be a distinct enum value. "Map as binance" is a deliberate, explicit mapping at the write boundary — not a reuse of the Binance identity throughout.
+- **Alternatives considered**:
+  - *Make Ouinex masquerade as `Exchange.BINANCE` everywhere* — rejected: violates V.4 (source inference), and Ouinex candles/search would be indistinguishable from Binance, breaking watchlist provenance and routing.
+  - *Fully generic `CryptoProvider` abstraction* — rejected as over-engineering (Principle II); only two crypto providers exist.
+
+## Decision 2: New `OuinexClient` mirroring the `BinanceClient` method surface
+
+- **Decision**: Create `client/ouinex_client.py` exposing the same public methods the rest of the app already depends on:
+  - `search(keyword: str) -> List[Asset]` (assets tagged `Exchange.OUINEX`)
+  - `get_candles(symbol, unit_time, limit=200) -> List[Candle]` (index 0 = newest)
+  - `get_latest_candle(symbol) -> Candle`
+  - `get_report_all(date: str, usdeur_rate: float) -> List[ReportOrder]` (+ `get_report` per symbol)
+- **Rationale**: Keeps the Service/Router layers unchanged in shape — they already call these method names on `BinanceClient`. Client returns domain models, never raw GraphQL (Principle I, V.3).
+- **Alternatives considered**: A shared interface/ABC between the two clients — deferred; duplication of a 4-method surface is cheaper than premature abstraction.
+
+## Decision 3: Ouinex API is GraphQL + JWT (the main divergence from Binance)
+
+- **Findings** (VERIFY):
+  - **Transport**: `POST https://live-api.ouinex.com/graphql` with JSON `{query, variables}`. Not REST.
+  - **Auth**: JWT bearer token (`Authorization: Bearer <token>`), obtained by signing in with API-key credentials; tokens are short-lived and refreshed by re-signing in. Optional per-key HMAC signing.
+  - **Instruments (search)**: GraphQL query `instruments` returning name, base/quote currencies, decimal precision. Client-side keyword filtering (as Binance does over `exchangeInfo`).
+  - **Trade history (reporting)**: GraphQL queries `account_transactions` (by `wallet_id`, optional `currency_id`/`dateRange`/`pager`) and `closed_orders` (filter by status/side/date/instrument).
+- **Decision**: Implement a thin GraphQL transport in `OuinexClient` (using `httpx` or `requests`) plus a JWT sign-in/refresh helper. Base URL and any non-secret config in `config.yml`; API key/secret in `secrets.yml`.
+- **Rationale**: Encapsulate all GraphQL/JWT mechanics inside the Client layer so Services stay transport-agnostic.
+- **Dependency choice** (VERIFY): prefer `httpx` if async is desired for the WebSocket path; otherwise `requests` (already used by `BinanceClient.search`). No heavyweight GraphQL SDK — hand-built query strings are sufficient for ~4 operations.
+
+## Decision 4: Historical candles — PRIMARY RISK
+
+- **Finding** (VERIFY): OHLC bars appear to be exposed only via a **WebSocket subscription** `instrument_price_bar` (`wss://live-api.ouinex.com/graphql`) with `instrument_id` + `periodicity`. Supported periodicities observed: **1m, 5m, 15m, 1h, 4h, 1d** — no `1w` / `1M`.
+- **Problem**: `get_candles(symbol, unit_time, limit=200)` needs *historical* candles (e.g., last 210 daily candles for MA200). A live subscription streams new bars; it is not a bulk history fetch. Binance solves this trivially with `GET /klines?limit=1000`.
+- **Options**:
+  - **A (preferred, VERIFY)**: Find a Ouinex GraphQL *query* (not subscription) that returns historical bars for an instrument+periodicity+range. Landing docs are likely incomplete; a `price_bars`/`candles` history query probably exists. Confirm first.
+  - **B**: If only the subscription exists, buffer bars from the WS stream — unusable for backfilling 200 historical candles; not viable for indicators.
+  - **C**: Derive higher timeframes (4h/1d) by aggregating a lower timeframe history query if only fine granularity is queryable.
+- **Decision**: Task list MUST begin with confirming a historical-bars query (Option A). Treat A as the assumption; escalate if only B is available, since that would block the indicators/watchlist user stories for Ouinex.
+- **Missing weekly/monthly** (VERIFY): The indicator API only supports D/W/M unit times (`SUPPORTED_UNIT_TIMES`). If Ouinex lacks native 1w/1M, weekly/monthly indicators for Ouinex must be aggregated from daily candles, or those timeframes are unsupported for Ouinex. Flag as an acceptance-scope decision.
+
+## Decision 5: "Map as binance" — reuse the Binance pseudo-account verbatim
+
+- **Decision**: `OuinexReportService.create_gsheet_order` / `update_gsheet_order` write using the **same** `Account(key="binance", name="Coinbase", ...)` that `BinanceReportService._get_binance_account()` returns. The gsheet provider column is driven by `account.name`, so Ouinex rows show exactly what Binance rows show.
+- **Rationale**: Satisfies Clarification "Same 'binance' identity — indistinguishable from native Binance rows." To avoid duplicating the pseudo-account definition, centralize it (e.g., a shared factory) so both services return the identical `Account`.
+- **Report routing**: `report.py` selects the service by `account_id` prefix. Add `ouinex_` → `OuinexReportService`; keep `binance_` → `BinanceReportService`. `/api/fund/accounts` adds an `ouinex_main` account so the frontend dropdown offers Ouinex; its journal writes still land under Binance identity.
+- **Symbol/currency normalization** (VERIFY): Ouinex trade records must be mapped to `ReportOrder` with `asset_type=CRYPTO`, `currency=Currency.USD` (or the quote currency), and commissions applied, matching `BinanceClient.get_report`. Confirm Ouinex fee/commission fields.
+
+## Decision 6: Credentials required for all Ouinex calls
+
+- **Decision**: Per Clarifications, every Ouinex operation (search, candles, reporting) needs valid credentials. `OuinexClient` authenticates on init / lazily and refreshes JWT as needed. Missing/invalid credentials raise a clear Ouinex-specific error; callers (`SearchService`, indicator route) already wrap provider calls in try/except so Binance and Saxo remain unaffected (FR-012).
+- **Rationale**: Isolates provider failure; matches the existing `SearchService` pattern that logs and continues when one provider errors.
+
+## Decision 7: Alert parity is a no-op (documented)
+
+- **Finding**: `run_detection_for_asset` builds candles via `saxo_client` and returns early when `saxo_uic is None`. Crypto assets have no `saxo_uic`, so Binance/crypto assets get **no** alert detection today.
+- **Decision**: Ouinex inherits identical behavior — no crypto alert detection is built here. FR-007 ("same alerts as Binance") is satisfied. Real crypto alerting is out of scope and would be a separate feature.
+- **Rationale**: Faithful parity; avoid over-building (Principle II) and avoid claiming a non-existent capability.
+
+---
+
+## Open items to confirm during `/speckit.tasks` or early implementation
+
+1. **VERIFY** a historical-bars **query** exists (Decision 4, Option A) — highest priority; blocks indicators/watchlist for Ouinex.
+2. **VERIFY** weekly/monthly periodicity support, else define aggregation-from-daily (Decision 4).
+3. **VERIFY** exact GraphQL schema for `instruments`, `closed_orders`/`account_transactions` fields (symbol, side, price, qty, fee, timestamp, quote currency).
+4. **VERIFY** JWT sign-in mutation and token lifetime / refresh mechanics; whether HMAC signing is required for the configured key.
+5. **VERIFY** instrument identifier model (numeric `instrument_id` vs symbol string) and how it maps to the `code`/`symbol` used across watchlist, indicators, and TradingView links.

--- a/specs/024-ouinex-provider/spec.md
+++ b/specs/024-ouinex-provider/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Ouinex crypto provider
+
+**Feature Branch**: `024-ouinex-provider`  
+**Created**: 2026-07-21  
+**Status**: Draft  
+**Input**: User description: "Introduce this new provider ouinex. Here is the api doc https://api.ouinex.com/ It's a crypto provider and I want the same behavior that for binance. In the gsheet, ouinex has to be map as binance"
+
+## Overview
+
+Ouinex is a new cryptocurrency provider to be introduced alongside the existing Binance provider. It must offer the same capabilities the platform already offers for Binance — searching crypto instruments, adding them to the watchlist, retrieving market data for indicators and alerts, and reporting trading activity into the trading journal. When any Ouinex activity is written to the Google Sheet trading journal, it must be recorded under the existing "binance" provider so that all crypto activity stays consolidated under a single journal identity.
+
+## Clarifications
+
+### Session 2026-07-21
+
+- Q: What is the capability scope for Ouinex — full read-only parity with Binance, or also placing/executing orders? → A: Read-only parity — instrument search, candle/market data for indicators & alerts, and trade-history reporting only. Order placement/execution is out of scope (Binance has none today).
+- Q: Does Ouinex coexist with Binance, or replace it as the crypto provider? → A: Coexist — both providers remain available and independent; Binance is unchanged.
+- Q: Do Ouinex market-data endpoints (instrument search + candles) require API credentials, or are they public like Binance? → A: Require API key — all Ouinex operations, including search and candle retrieval, require authenticated Ouinex credentials (this differs from Binance's public market-data endpoints).
+- Q: In the Google Sheet journal, how exactly should Ouinex trades be recorded as "binance"? → A: Same "binance" identity — Ouinex journal entries are indistinguishable from native Binance rows.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recognize Ouinex as a selectable crypto provider (Priority: P1)
+
+As a trader, I can choose Ouinex as a provider wherever I currently choose Binance, so that I can work with crypto instruments sourced from Ouinex the same way I do with Binance.
+
+**Why this priority**: Nothing else in the feature can be exercised until the system recognizes Ouinex as a valid provider. This is the foundational slice that unlocks every other capability.
+
+**Independent Test**: Select Ouinex as the provider in any place that currently accepts Binance, and confirm the system accepts it as valid and routes subsequent actions to Ouinex without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the provider options that today include Binance, **When** I view the available crypto providers, **Then** Ouinex is offered as a selectable option.
+2. **Given** I select Ouinex as the provider, **When** I perform an action that requires provider credentials, **Then** the system uses the Ouinex credentials and does not fall back to Binance credentials.
+
+---
+
+### User Story 2 - Search and add Ouinex crypto instruments to the watchlist (Priority: P1)
+
+As a trader, I can search for crypto instruments available on Ouinex and add them to my watchlist, so that I can track them just like Binance instruments.
+
+**Why this priority**: Searching and watch-listing is the primary entry point for tracking any instrument. Delivered on its own, this already provides value by letting the trader curate Ouinex instruments.
+
+**Independent Test**: Search for a known Ouinex crypto pair, add it to the watchlist, and confirm it appears with the crypto classification, exactly as a Binance instrument would.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have selected Ouinex, **When** I search by keyword for a crypto pair, **Then** I see matching Ouinex instruments in the results.
+2. **Given** a matching Ouinex instrument, **When** I add it to my watchlist, **Then** it is stored as a crypto instrument tagged the same way a Binance crypto instrument is tagged.
+3. **Given** an Ouinex instrument in my watchlist, **When** I view the watchlist, **Then** it is presented consistently with how Binance crypto instruments are presented.
+
+---
+
+### User Story 3 - Retrieve Ouinex market data for indicators and alerts (Priority: P2)
+
+As a trader, I can view indicators and receive alerts for Ouinex instruments based on their market data (candles), so that I get the same analytical signals I get for Binance instruments.
+
+**Why this priority**: Indicators and alerts are the core analytical value of the platform, but they depend on the provider and watch-listing slices being in place first.
+
+**Independent Test**: Request indicators for an Ouinex instrument across supported timeframes and confirm candle-based indicators are computed and alerts can fire, matching Binance behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Ouinex instrument, **When** I request its indicators for a supported timeframe, **Then** the system retrieves Ouinex market data and computes the same indicators it computes for Binance.
+2. **Given** an Ouinex instrument being monitored, **When** market conditions meet an alert rule, **Then** the alert is raised the same way it would be for a Binance instrument.
+3. **Given** a request for a timeframe the provider does not return directly (such as the in-progress current day or hour), **When** indicators are computed, **Then** the current period is reconstructed from a smaller timeframe, exactly as done for Binance.
+
+---
+
+### User Story 4 - Report Ouinex trading activity into the journal as Binance (Priority: P2)
+
+As a trader, I can pull my Ouinex trading activity and record it in the Google Sheet trading journal, and those entries are recorded under the "binance" provider so that all my crypto trades stay consolidated in one place.
+
+**Why this priority**: Journal reporting is important for record-keeping and is the concrete embodiment of the "map as binance" requirement, but it depends on the provider being recognized first.
+
+**Independent Test**: Generate a report of Ouinex trades for a date range, write selected trades to the journal, and confirm the journal records them under the "binance" provider identity — indistinguishable in provider label from native Binance entries.
+
+**Acceptance Scenarios**:
+
+1. **Given** trading activity on Ouinex over a date range, **When** I generate a report, **Then** I see the Ouinex trades with the same fields shown for Binance reports.
+2. **Given** an Ouinex trade from the report, **When** I write it to the trading journal, **Then** the journal entry is recorded under the "binance" provider, not "ouinex".
+3. **Given** both native Binance trades and Ouinex trades written to the journal, **When** I inspect the journal, **Then** the provider identity is "binance" for both and crypto activity is consolidated.
+
+---
+
+### Edge Cases
+
+- What happens when Ouinex credentials are missing or invalid? Because every Ouinex operation requires credentials, all Ouinex actions (search, candles, alerts, reporting) fail with a clear provider-specific error, without affecting Binance functionality.
+- What happens when a search keyword matches no Ouinex instrument? An empty result set is returned, consistent with Binance search behavior.
+- What happens when Ouinex is temporarily unavailable or returns an error while fetching market data or trades? The failure should be isolated to Ouinex actions and should not degrade Binance or other providers.
+- What happens if the same crypto instrument (e.g., a BTC pair) exists on both Ouinex and Binance? The user can track and report each independently, but journal entries from either roll up under the "binance" provider identity.
+- What happens when Ouinex returns a currency or amount format that differs from Binance? Reported values must be normalized to the same journal conventions used for Binance entries.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recognize Ouinex as a valid crypto provider everywhere Binance is currently accepted as a provider (search, watchlist, indicators, alerts, and reporting).
+- **FR-002**: System MUST authenticate to Ouinex using Ouinex-specific credentials, kept separate from Binance credentials, and MUST NOT reuse Binance credentials for Ouinex actions. All Ouinex operations — including instrument search and candle retrieval — require valid Ouinex credentials (unlike Binance, whose market-data endpoints are public).
+- **FR-003**: Users MUST be able to search Ouinex for crypto instruments by keyword and see matching instruments in the results.
+- **FR-004**: Users MUST be able to add an Ouinex instrument to the watchlist, and the system MUST store and classify it as a crypto instrument using the same classification and tagging applied to Binance crypto instruments.
+- **FR-005**: System MUST retrieve Ouinex market data (candles) for all timeframes currently supported for Binance and compute the same indicators from it.
+- **FR-006**: System MUST reconstruct the in-progress current day and current hour candles for Ouinex from a smaller timeframe when the provider does not return them directly, consistent with the existing Binance behavior.
+- **FR-007**: System MUST raise the same alerts for Ouinex instruments, under the same rules, as it does for Binance instruments.
+- **FR-008**: Users MUST be able to generate a report of Ouinex trading activity for a given date range, presenting the same fields as a Binance report.
+- **FR-009**: System MUST allow selected Ouinex trades to be written to the Google Sheet trading journal.
+- **FR-010**: System MUST record every Ouinex journal entry under the "binance" provider identity, so that Ouinex activity is indistinguishable from native Binance activity in the journal's provider/account field.
+- **FR-011**: System MUST normalize Ouinex-reported amounts and currencies to the same conventions used for Binance journal entries.
+- **FR-012**: System MUST isolate Ouinex failures (missing credentials, provider errors, unavailability) so they do not affect Binance or other providers.
+- **FR-013**: Introducing Ouinex MUST NOT change or remove any existing Binance capability; Binance continues to operate independently and unchanged.
+- **FR-014**: Order placement/execution on Ouinex is OUT OF SCOPE. Parity with Binance covers read-only capabilities only (search, market data, indicators, alerts, and trade-history reporting); the system MUST NOT place or execute orders on Ouinex.
+
+### Key Entities *(include if feature involves data)*
+
+- **Provider (Exchange)**: The source of a crypto instrument and its market/trade data. Today includes Saxo and Binance; this feature adds Ouinex as a new crypto provider. For journal-writing purposes, Ouinex maps to the existing Binance provider identity.
+- **Crypto Instrument**: A tradable crypto pair sourced from a provider, tracked in the watchlist and analyzed via indicators/alerts. An Ouinex instrument behaves identically to a Binance instrument.
+- **Market Data (Candle)**: Time-series price data retrieved from the provider, used to compute indicators and evaluate alerts.
+- **Trade / Report Order**: A record of trading activity retrieved from the provider and written to the journal. Ouinex trades are written under the "binance" provider identity.
+- **Trading Journal Entry**: A row in the Google Sheet recording a trade under a provider/account. Ouinex entries carry the "binance" provider identity.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A trader can search, add to watchlist, view indicators/alerts for, and report trades from an Ouinex instrument using the same steps as Binance, with no Ouinex-specific detour.
+- **SC-002**: 100% of Ouinex trades written to the trading journal are recorded under the "binance" provider identity (0% appear under a separate "ouinex" identity).
+- **SC-003**: Every capability available for Binance instruments (search, watchlist, indicators, alerts, reporting) is available for Ouinex instruments — feature parity is complete with no capability gaps.
+- **SC-004**: All existing Binance workflows continue to function unchanged after Ouinex is introduced (no regressions).
+- **SC-005**: An Ouinex failure (bad credentials, provider outage) never prevents a Binance or Saxo action from succeeding.
+
+## Assumptions
+
+- **"Map as binance" scope**: The mapping to Binance applies to the provider/account identity written to the Google Sheet trading journal — Ouinex entries use the exact same "binance" identity (see Clarifications). Market data, search, and analytics operate against the real Ouinex source; only the journal provider label is "binance".
+- **Credential model**: Ouinex authenticates with a provider-issued API key/secret pair, supplied via the same secure configuration mechanism used for Binance credentials (separate keys). Per Clarifications, these credentials are required for every Ouinex call, including search and candles.
+- **Capability parity baseline**: "Same behavior as Binance" means matching the current Binance feature set — instrument search, watchlist add/classification, candle retrieval for indicators, alert evaluation, and trade reporting into the journal.
+- **Timeframe parity**: Ouinex supports (or can be made to support via reconstruction) the same set of timeframes currently used for Binance, including reconstruction of the in-progress current day/hour candle.
+- **API capabilities**: The Ouinex API (https://api.ouinex.com/) exposes equivalent endpoints for instrument search, historical market data (candles), and trade/order history sufficient to achieve Binance parity. Exact endpoint details are an implementation concern to be validated during planning.
+
+## Dependencies
+
+- **Ouinex API** (https://api.ouinex.com/): external provider API for instrument search, market data, and trade history.
+- **Ouinex account and credentials**: an active Ouinex account with API key/secret provisioned.
+- **Existing Google Sheet trading journal**: the destination for reported trades, where Ouinex entries are recorded under the "binance" provider identity.


### PR DESCRIPTION
## Summary

Planning artifacts for introducing **Ouinex** as a new crypto provider with Binance feature parity. No implementation code yet — this PR is the spec + plan for review before building.

- **Behavior**: same feature set as Binance — instrument search, watchlist add/classification, candle-based indicators, and trade-history reporting.
- **"Map as binance"**: Ouinex journal entries reuse the existing Binance pseudo-account (`name="Coinbase"`, `key="binance"`) at the Google Sheet write boundary — indistinguishable from native Binance rows.
- **Coexists** with Binance (Binance unchanged); **order execution is out of scope**.

## Artifacts

| File | Purpose |
|------|---------|
| `spec.md` | Feature spec (4 user stories, 14 FRs, success criteria) + Clarifications |
| `plan.md` | Technical context, constitution check, Binance→Ouinex parity map |
| `research.md` | Ouinex API decisions + risks (GraphQL/JWT, 5 VERIFY items) |
| `data-model.md` | `Exchange.OUINEX`, `OuinexClient` interface, config, account reuse |
| `contracts/api-deltas.md` | Deltas to 5 existing endpoints (no new endpoints) |
| `quickstart.md` | Configure & verify each user story |

## ⚠️ Open questions to resolve before implementation

1. **Historical candles (top risk)** — Ouinex is a **GraphQL** API and reachable docs show OHLC bars only via a **WebSocket subscription**, not a bulk history query. `get_candles(limit=200)` needs history for MA200. Must confirm a historical-bars query exists, else indicators/watchlist for Ouinex are blocked.
2. **Weekly/monthly periodicity** — not natively shown; may require aggregation from daily.
3. **Crypto alerts are a no-op today** — `run_detection_for_asset` skips assets without a `saxo_uic`, so Binance crypto gets no alerts. Faithful parity means Ouinex inherits this; no new crypto alerting is planned here.

## Next steps

- Resolve the VERIFY items in `research.md` (needs Ouinex API access)
- `/speckit.tasks` to generate the task breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)