### PR TITLE
docs: add spec 025 GER40 Bougie de 9h double take-profit backtest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ Examples:
 - AWS DynamoDB — new `alert_digests` table (hash_key `run_date` String, range_key `created_at` Number, **no TTL**); existing `alerts` table unchanged (023-alert-triage)
 - Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend — minimal changes) + FastAPI, Pydantic v2, `cachetools` (TTLCache), `googleapiclient` (Google Sheets); NEW: a GraphQL/HTTP client for Ouinex (`httpx` or `requests` — POST GraphQL + JWT auth flow); frontend Axios + React Router DOM v7+ (024-ouinex-provider)
 - AWS DynamoDB `watchlist` table (existing `exchange` attribute, unchanged schema); Google Sheets trading journal (existing "Liste d'ordre" sheet, unchanged schema). No new tables. (024-ouinex-provider)
+- Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) — no change from existing stack. + FastAPI + Pydantic v2 (existing), `zoneinfo` (already used by the backtest service for Paris-local math), Python stdlib `csv` (existing exports), existing `SaxoClient`/`CandlesService`; React Router DOM v7+, Axios, Vite (frontend, existing). **No new dependency.** (025-ger40-bougie-9h)
+- N/A — ephemeral, computed on demand per request, nothing persisted (inherits spec 021's decision). (025-ger40-bougie-9h)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/specs/025-ger40-bougie-9h/contracts/backtest-api.md
+++ b/specs/025-ger40-bougie-9h/contracts/backtest-api.md
@@ -1,0 +1,106 @@
+# API Contract: GER40 Bougie de 9h (spec 025 delta)
+
+This feature adds **no new endpoint**. It adds a third `BacktestDefinition` (`"G9H"`) reachable through the existing `/api/backtest/*` endpoints (spec 021, `api/routers/backtest.py`) and makes two backward-compatible additions:
+
+1. `GET /api/backtest/definitions` now returns three definitions, each carrying its **default thresholds** and a `double_take_profit` flag.
+2. The optional strategy-threshold query parameters now fall back to the **selected definition's** defaults instead of a single global default set (per-definition resolution). CAC40 defaults are unchanged (50/10/20/20); GER40 defaults are 150/10/50/40.
+
+See `specs/021-backtest-menu-hardcoded/contracts/backtest-api.md` for the full endpoint set (`/run`, `/day`, `/run/csv`, `/day/csv`) — request shapes, validation (400 for bad range/date/unknown definition, 422 for a non-positive threshold), and CSV formats are all unchanged.
+
+## `GET /api/backtest/definitions` (extended response)
+
+```json
+[
+  {
+    "code": "B9H",
+    "display_name": "CAC40 Bougie de 9h",
+    "instrument": "FRA40.I",
+    "double_take_profit": false,
+    "default_parameters": {
+      "stop_loss_points": 50,
+      "take_profit_offset_points": 10,
+      "break_even_trigger_points": 20,
+      "max_entry_distance_points": 20
+    }
+  },
+  {
+    "code": "B9HTC",
+    "display_name": "CAC40 Bougie de 9h (time cut)",
+    "instrument": "FRA40.I",
+    "double_take_profit": false,
+    "default_parameters": {
+      "stop_loss_points": 50,
+      "take_profit_offset_points": 10,
+      "break_even_trigger_points": 20,
+      "max_entry_distance_points": 20
+    }
+  },
+  {
+    "code": "G9H",
+    "display_name": "GER40 Bougie de 9h",
+    "instrument": "GER40.I",
+    "double_take_profit": true,
+    "default_parameters": {
+      "stop_loss_points": 150,
+      "take_profit_offset_points": 10,
+      "break_even_trigger_points": 50,
+      "max_entry_distance_points": 40
+    }
+  }
+]
+```
+
+`default_parameters` and `double_take_profit` are **additive** fields — existing clients that ignore them are unaffected. The frontend uses `default_parameters` to pre-fill the threshold inputs for the selected definition (replacing the hardcoded `PARAM_FIELDS` defaults in `Backtest.tsx`).
+
+## Threshold parameters (per-definition defaults)
+
+The four optional query parameters (`stop_loss_points`, `take_profit_offset_points`, `break_even_trigger_points`, `max_entry_distance_points`) are unchanged in name, type, and `> 0` validation (422 on a non-positive value, before any day runs). The only change is the **fallback**: an omitted parameter now resolves to the *selected definition's* `default_parameters` value rather than a single global default. Concretely, for `definition=G9H` an omitted `stop_loss_points` resolves to **150** (measured from the H1 low/high, FR-G05), an omitted `break_even_trigger_points` to **50**, and an omitted `max_entry_distance_points` to **40**. For `definition=B9H`/`B9HTC` the resolved values are exactly as before.
+
+Resolution happens after the definition is looked up (unknown definition → 400 as today), so the endpoint must resolve `definition` before merging overrides.
+
+## `GET /api/backtest/run` / `GET /api/backtest/day` for `G9H`
+
+Identical request/response **shapes** to CAC40. A `G9H` day that traded returns each two-lot position as **one aggregated `Trade`** (FR-G07/FR-G10): `entry_price` is the shared entry, `exit_price`/`exit_time`/`exit_reason` reflect the runner's final exit, and `points` is the **net of both lots**. Example `/day` trade for a TP1-then-TP2 full winner (entry 18000, H1 low 17990 → stop 17840, H1 high 18120 → TP2 18110, midpoint TP1 18055):
+
+```json
+{
+  "entry_time": "2026-06-02T10:20:00",
+  "entry_price": 18000.0,
+  "exit_time": "2026-06-02T11:05:00",
+  "exit_price": 18110.0,
+  "exit_reason": "take_profit",
+  "direction": "Buy",
+  "points": 165.0
+}
+```
+
+`points = (18055 − 18000) + (18110 − 18000) = 55 + 110 = 165`. A both-lots stop-out on the same setup would report `exit_price = 17840`, `exit_reason = "stop_loss"`, `points = 2 · (17840 − 18000) = −320` (the "SL is x2"). A TP1-then-break-even runner reports `exit_reason = "break_even"` with a **net-positive** `points` (≈ the banked 55).
+
+## Aggregate summary (`/run`) classification for `G9H`
+
+Unchanged response shape. For a `double_take_profit` definition the counts are classified by the **sign of each position's net points** (FR-G08): net > 0 → winning, net < 0 → losing, net == 0 → BE. `average_win`/`average_loss` use the net points; the BE bucket holds only genuinely-flat positions. CAC40's mechanism-based classification is unchanged.
+
+## CSV exports
+
+`/run/csv` and `/day/csv` are unchanged in format. For `G9H` each row/trade is the aggregated position (one row per position, net points). The leading parameters block echoes the **resolved** thresholds (so a GER40 export shows 150/10/50/40 when defaults are used).
+
+## Frontend service mapping (`frontend/src/services/api.ts`)
+
+```ts
+export interface BacktestParameters {
+  stop_loss_points?: number;
+  take_profit_offset_points?: number;
+  break_even_trigger_points?: number;
+  max_entry_distance_points?: number;
+}
+
+export interface BacktestDefinition {
+  code: string;
+  display_name: string;
+  instrument: string;
+  double_take_profit: boolean;              // NEW
+  default_parameters: Required<BacktestParameters>; // NEW — four numbers
+}
+```
+
+`runRange` / `getDayDetail` / `exportRunCsv` / `exportDayCsv` signatures are unchanged; the page seeds its threshold inputs from `selectedDefinition.default_parameters` instead of the hardcoded constants.

--- a/specs/025-ger40-bougie-9h/data-model.md
+++ b/specs/025-ger40-bougie-9h/data-model.md
@@ -1,0 +1,132 @@
+# Data Model: Hardcoded "GER40 Bougie de 9h" Backtest (double take-profit)
+
+All entities are in-memory / request-response only (inherits spec 021 — no persistence). This feature **adds no new response model and no new domain dataclass**; it extends the existing `model/backtest.py` types and adds one `Strategy` enum member. `Trade`, `DayResult`, `DayResultSummary`, `BacktestSummary`, `BacktestRunResult` are unchanged in shape (FR-G10). See `specs/021-backtest-menu-hardcoded/data-model.md` for their full field definitions.
+
+## New enum member (`model/enum.py`)
+
+### `Strategy.G9H`
+
+Add `G9H = "Bougie de 9h GER40"` alongside the existing `B9H = "Bougie de 9h"` and `B9HTC = "Bougie de 9h (time cut)"`. Reused as the `name` of the new `BacktestDefinition` (Constitution II — no hardcoded strategy string). No new `ExitReason` or `DayStatus` member is needed: the double-TP outcomes map onto the existing `TAKE_PROFIT` / `BREAK_EVEN` / `STOP_LOSS` / `END_OF_DAY` reasons (FR-G07).
+
+## Extended entity — `BacktestDefinition` (`model/backtest.py`)
+
+New optional fields, all defaulting to the CAC40 behavior so `B9H`/`B9HTC` are unchanged:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `code` | `str` | — | existing |
+| `name` | `str` | — | existing (`Strategy.*.value`) |
+| `display_name` | `str` | — | existing |
+| `instrument` | `str` | — | existing |
+| `time_cut_minutes` | `Optional[int]` | `None` | existing (time-cut variant) |
+| `time_cut_min_favorable_points` | `Optional[float]` | `None` | existing |
+| **`default_parameters`** | `BacktestParameters` | `field(default_factory=BacktestParameters)` | Per-definition threshold defaults (FR-G09 / research §5). CAC40 uses the dataclass defaults (50/10/20/20); GER40 supplies `BacktestParameters(150, 10, 50, 40)`. Resolved against per-run overrides in the router. |
+| **`double_take_profit`** | `bool` | `False` | When `True` (GER40), every entry opens **two lots** with the split-exit / take-first-then-break-even mechanic (FR-G02–FR-G04). When `False`, single-lot behavior exactly as today. Also selects the points-sign summary classification (FR-G08). |
+| **`first_target_fraction`** | `Optional[float]` | `None` | The TP1 fraction of the H1 range; `0.5` for GER40 ⇒ TP1 = `h1_low + 0.5·(h1_high − h1_low)` = midpoint (FR-G03). `None` when `double_take_profit` is `False`. A fixed strategy property, not a `BacktestParameter`. |
+| **`stop_from_reference_level`** | `bool` | `False` | When `True` (GER40), the initial stop is `stop_loss_points` **beyond the H1 reference level** (H1 low − 150 long / H1 high + 150 short, FR-G05); when `False`, `stop_loss_points` from **entry** (CAC40, unchanged). |
+
+`BACKTEST_DEFINITIONS` gains a third entry:
+
+```python
+BacktestDefinition(
+    code="G9H",
+    name=Strategy.G9H.value,
+    display_name="GER40 Bougie de 9h",
+    instrument="GER40.I",
+    default_parameters=BacktestParameters(
+        stop_loss_points=150,
+        take_profit_offset_points=10,
+        break_even_trigger_points=50,
+        max_entry_distance_points=40,
+    ),
+    double_take_profit=True,
+    first_target_fraction=0.5,
+    stop_from_reference_level=True,
+)
+```
+
+## `BacktestParameters` (`model/backtest.py`) — unchanged shape
+
+The four tunable thresholds keep the same dataclass and the same **CAC40 defaults** (50/10/20/20). GER40 does **not** change these dataclass defaults; it supplies its own via `BacktestDefinition.default_parameters`. `stop_loss_points` is reinterpreted per definition: distance from entry (CAC40) or from the H1 reference level (GER40, via `stop_from_reference_level`). The 50% first-target fraction and the two-lot count are **not** parameters (FR-G09) — they live on the definition.
+
+## `Trade` (`model/backtest.py`) — unchanged shape, new semantics for double-TP
+
+Same seven fields (`entry_time`, `entry_price`, `exit_time`, `exit_price`, `exit_reason`, `direction`, `points`). For a two-lot GER40 position, the fields carry the **aggregated** position (FR-G07):
+
+| Field | Double-TP meaning |
+|---|---|
+| `entry_time` / `entry_price` | The single confirmed entry (both lots enter here). |
+| `exit_time` / `exit_price` | The **runner's** final exit (TP2 / break-even / stop / end-of-day). For a both-lots-stop-out (no TP1), this is the shared stop level. |
+| `exit_reason` | How the **position finally closed** (runner's exit): `TAKE_PROFIT` (runner hit TP2), `BREAK_EVEN` (runner closed at its moved-to-entry stop after TP1, or both lots at break-even), `STOP_LOSS` (both lots stopped before any TP), `END_OF_DAY`. |
+| `points` | **Net points = lot-A P&L + lot-B P&L**, computed explicitly (research §2). Not `exit_price − entry_price` in general. Examples: both-lots stop-out = `2·(stop − entry)`; TP1-then-TP2 = `(TP1 − entry) + (TP2 − entry)`; TP1-then-break-even = `(TP1 − entry) + ≈0` (net-positive). |
+
+**Validation rules** (enforced in `api/services/backtest_service.py`, not on the dataclass — consistent with spec 021):
+- `entry_time < exit_time`.
+- For double-TP, `points` is the summed net and may differ from the price-difference formula — the aggregated `Trade` is built by a dedicated close helper (`_close_double_trade`), not the single-lot `_close_trade`.
+
+## Engine state — `_OpenPosition` (`api/services/backtest_service.py`) — extended
+
+New optional fields on the existing class (all inert when `double=False`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `double` | `bool` | True for a GER40 position (from `definition.double_take_profit`). |
+| `first_target_level` | `Optional[float]` | TP1 = H1 midpoint (long and short share the level). |
+| `first_target_taken` | `bool` (default `False`) | Set when lot A exits at TP1; arms the runner's break-even (FR-G04). |
+| `banked_points` | `float` (default `0.0`) | Lot-A realised points, added to the runner's points at close. |
+| `initial_stop_price` | `float` | Absolute initial stop level. For GER40 = H1 low − 150 (long) / H1 high + 150 (short). For CAC40 the existing `stop_loss_points`-from-entry computation is kept (this field unused). |
+
+`stop_level` property gains a reference-based branch: if `be_armed` → entry; elif `stop_from_reference_level` → `initial_stop_price`; else → `entry ± stop_loss_points` (unchanged CAC40 path).
+
+## State transitions — double-TP position (GER40), within a single day
+
+The **entry** machinery (breakout/reversal detection, entry validity, one-position-at-a-time) is identical to spec 021 (`_DirectionSearch`), judged against the full take-profit level (TP2) for validity (FR-G03 / spec 021 FR-006a). Only the **open-position** exit handling changes. Long shown; short is the mirror around the H1 high.
+
+```
+[entry confirmed] --> [open, 2 lots, stop = H1_low - 150, TP1 = midpoint, TP2 = H1_high - 10]
+
+Both lots open (first_target_taken = False), per candle, in order:
+  - candle low <= stop        --> [closed: STOP_LOSS (or BREAK_EVEN if +50 already armed)]
+                                   net points = 2 * (stop - entry)            # "SL is x2"
+  - candle high >= TP1         --> lot A exits at TP1 (gap-fill FR-010):
+                                   banked_points = TP1 - entry
+                                   first_target_taken = True; be_armed = True # FR-G04
+                                   (if same candle high >= TP2, runner also exits at TP2 -> closed TAKE_PROFIT,
+                                    net = (TP1-entry)+(TP2-entry))
+  - candle high >= entry + 50  --> be_armed = True (shared stop -> entry, from next candle)  # FR-G06
+
+Runner only (first_target_taken = True), stop at entry (break-even), per candle:
+  - candle low <= entry        --> [closed: BREAK_EVEN] net = banked_points + (fill - entry)  # ~banked (net-positive)
+  - candle high >= TP2         --> [closed: TAKE_PROFIT] net = banked_points + (TP2 - entry)
+
+Any state:
+  - session end                --> [closed: END_OF_DAY]
+                                   both-lots open: net = 2 * (close - entry)
+                                   runner only:   net = banked_points + (close - entry)
+```
+
+Same-candle precedence (extends spec 021 FR-009): while both lots are open, **stop beats TP1** on a candle that would reach both (conservative). Once only the runner remains, its break-even stop beats TP2 on a same-candle collision (unreachable in practice since TP2 > entry for a long). TP1-and-TP2 on the same candle fills lot A at TP1 and the runner at TP2.
+
+## Response mapping — `BacktestDefinitionResponse` (`api/models/backtest.py`)
+
+Extended so the frontend can pre-fill per-definition defaults (research §5):
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | `str` | existing |
+| `display_name` | `str` | existing |
+| `instrument` | `str` | existing |
+| **`default_parameters`** | `BacktestParametersResponse` | echoes the definition's `default_parameters` (four floats) |
+| **`double_take_profit`** | `bool` | lets the frontend label/hint the two-lot strategy (optional UI use) |
+
+`TradeResponse`, `DayDetailResponse`, `DayResultSummaryResponse`, `BacktestSummaryResponse`, `BacktestRunResponse` are **unchanged** (FR-G10).
+
+## Relationships
+
+```
+BacktestDefinition (3 hardcoded: B9H, B9HTC, G9H)
+  ├─ default_parameters : BacktestParameters (per definition)
+  ├─ double_take_profit / first_target_fraction / stop_from_reference_level (G9H only)
+  └─> BacktestRunResult / DayResult (per request)
+        └─ Trade (0..n; for G9H each is one aggregated 2-lot position)
+```

--- a/specs/025-ger40-bougie-9h/plan.md
+++ b/specs/025-ger40-bougie-9h/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Hardcoded "GER40 Bougie de 9h" Backtest (double take-profit)
+
+**Branch**: `claude/ger40-backtest-spec-025-k9togf` | **Date**: 2026-07-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/025-ger40-bougie-9h/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add a third hardcoded backtest — **"GER40 Bougie de 9h"** — to the existing Backtest menu. It reuses the entire "CAC40 Bougie de 9h" engine (spec 021): the 9:00–10:00 Paris-local H1 reference range, both-direction 5-minute breakout/reversal detection, entry-validity, exit ordering, gap-fill, one-position-at-a-time, and the range/day/CSV outputs. It differs only by: (1) instrument `GER40.I`; (2) GER40 default thresholds (stop **150**, take-profit offset **10**, break-even trigger **50**, max entry distance **40**); (3) a **two-lot / double take-profit** overlay — every entry opens two lots, the first exits at the H1 midpoint (TP1 = `(h1_high+h1_low)/2`), the runner at the full target (TP2 = H1 high − 10 / H1 low + 10), and once TP1 fills the runner's stop moves to break-even; (4) the stop-loss is measured **from the H1 reference level** (150 pts below the H1 low / above the H1 high), not from entry as CAC40 does.
+
+The implementation stays inside the existing layered architecture: a new `Strategy.G9H` enum value, per-definition **default parameters** and **double-TP properties** on `BacktestDefinition`, a double-TP branch in the existing `api/services/backtest_service.py` trade engine, no new response shape (a two-lot position is surfaced as **one aggregated `Trade`**, FR-G07/FR-G10), and the definition auto-appears in the frontend menu. The `/definitions` response is extended to carry each definition's default thresholds so the frontend pre-fills the correct GER40 defaults. No new external dependency, no persistence, no infrastructure change.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) — no change from existing stack.
+**Primary Dependencies**: FastAPI + Pydantic v2 (existing), `zoneinfo` (already used by the backtest service for Paris-local math), Python stdlib `csv` (existing exports), existing `SaxoClient`/`CandlesService`; React Router DOM v7+, Axios, Vite (frontend, existing). **No new dependency.**
+**Storage**: N/A — ephemeral, computed on demand per request, nothing persisted (inherits spec 021's decision).
+**Testing**: pytest with the existing mocked-`CandlesService` convention used by `tests/api/services/test_backtest_service.py`; no frontend test framework (existing gap, unchanged).
+**Target Platform**: Existing FastAPI backend (Lambda-deployable) + React SPA (Vite).
+**Project Type**: Web application (backend packages at repo root + `frontend/`) — the codebase's established flat layout.
+**Performance Goals**: Single-day run within a few seconds (SC-G01); range runs synchronous, scaling with the number of trading days (one H1 + one 5-minute Saxo call per day) — identical cost profile to CAC40; the double-TP overlay is pure in-memory arithmetic per candle.
+**Constraints**: Constitution I (Layered Architecture) — engine logic stays in `api/services/backtest_service.py`, candle fetches in `services/candles_service.py`; Constitution II — reuse `Strategy` enum (new `G9H` member), no hardcoded strings, no speculative generic engine; the 50% first-target fraction and two-lot count are **fixed** strategy properties (not tunable), the four numeric thresholds stay tunable per run with **GER40 defaults** (FR-G09). GER40.I uses the same `EUMarket`/Europe/Paris session logic as FRA40.I (Xetra ≈ Euronext hours), so no new market/timezone code is needed.
+**Scale/Scope**: One new `BacktestDefinition` (`G9H`); no new endpoints (the existing `/definitions`, `/run`, `/day`, `/run/csv`, `/day/csv` all take the definition code); `/definitions` response gains per-definition default-threshold + double-TP fields; one new `Strategy` enum value; a double-TP branch in the trade engine; frontend pre-fills per-definition defaults. Single-user tool, no concurrency concerns.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Check | Result |
+|---|---|---|
+| I. Layered Architecture Discipline | No new router; the existing thin `api/routers/backtest.py` gains only per-definition default resolution. Double-TP rule logic lives in the Service layer (`api/services/backtest_service.py`); candle fetches stay in `services/candles_service.py`. New domain fields live in `model/backtest.py` (dataclasses, no external deps). Frontend keeps all API calls in `frontend/src/services/api.ts`; the page reads per-definition defaults from the definitions response (props in). | PASS |
+| II. Clean Code First | Reuses the `Strategy` enum via a new `G9H` member instead of a hardcoded name; reuses `Direction`/`ExitReason`/`DayStatus`; the two-lot mechanic is expressed as fields on the existing `_OpenPosition`/`BacktestDefinition`, not a parallel engine; no generic backtest-authoring capability is built (FR-G01). No `assert` in production code (Constitution II.5 / 1.3.0) — invariant violations raise explicit exceptions, matching `_candle_date`. | PASS |
+| III. Configuration-Driven Design | Thresholds remain per-run analysis inputs (defaults now attached per `BacktestDefinition` rather than a single global default), not deployment config — appropriate, same rationale as spec 021's resolved exception. No new external integration or credential. | PASS |
+| IV. Safe Deployment Practices | Additive within the existing API/frontend deployment; no new Lambda, ECR, or Pulumi change. Conventional commits (`feat:`). | PASS |
+| V. Domain Model Integrity | Reuses `model.workflow.Candle` everywhere outside the client; GER40.I is a single hardcoded Saxo instrument (index), so the `exchange`/`country_code` inference rule does not apply; the H1/5-minute historical fetches for closed past days respect the "current period not returned" Saxo limitation the same way CAC40 does. | PASS |
+
+No violations requiring justification — see Complexity Tracking for the one design point (stop measured from the H1 level) that is a spec-mandated per-definition difference, not a constitutional exception.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-ger40-bougie-9h/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   └── backtest-api.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+model/
+├── enum.py                        # + Strategy.G9H = "Bougie de 9h GER40"
+└── backtest.py                    # BacktestDefinition: + default_parameters,
+                                    #   double_take_profit, first_target_fraction,
+                                    #   stop_from_reference_level fields.
+                                    #   BacktestParameters unchanged (shape); its
+                                    #   defaults stay the CAC40 values, GER40 supplies
+                                    #   its own via default_parameters.
+
+api/
+├── models/
+│   └── backtest.py                # BacktestDefinitionResponse: + default_parameters
+                                    #   (+ double_take_profit flag) so the frontend
+                                    #   pre-fills GER40 defaults. Trade/Day/Run
+                                    #   response shapes UNCHANGED (FR-G10).
+├── routers/
+│   └── backtest.py                # _params -> optional overrides; resolve against
+                                    #   the definition's default_parameters after the
+                                    #   definition is looked up (per-definition
+                                    #   defaults, not a single global default).
+└── services/
+    └── backtest_service.py        # BACKTEST_DEFINITIONS: + G9H entry (GER40.I,
+                                    #   GER40 defaults, double-TP props). _OpenPosition:
+                                    #   + first_target_level/first_target_taken/
+                                    #   banked_points + reference-based stop. New
+                                    #   double-TP exit path in _resolve_exit +
+                                    #   aggregated-trade close helper. _build_summary:
+                                    #   points-sign classification for double-TP defs
+                                    #   (FR-G08). resolve_parameters helper.
+
+frontend/src/
+├── pages/
+│   └── Backtest.tsx               # Pre-fill threshold inputs from the selected
+                                    #   definition's default_parameters (falls back
+                                    #   to the current constants for CAC40).
+└── services/
+    └── api.ts                     # BacktestDefinition interface + default_parameters
+                                    #   (+ double_take_profit) fields.
+
+tests/
+└── api/
+    ├── services/
+    │   └── test_backtest_service.py  # + GER40 double-TP engine tests (all SC-G02
+                                    #   outcome types) mirroring the acceptance scenarios
+    └── routers/
+        └── test_backtest.py          # + G9H definition listed w/ GER40 defaults;
+                                    #   run/day/csv against G9H; per-definition default
+                                    #   resolution; positivity validation still 422
+```
+
+**Structure Decision**: Follows the codebase's existing flat layout (backend packages `api/`, `services/`, `model/` at repo root, `frontend/` alongside), matching spec 021 and every prior feature. The feature extends the existing backtest modules rather than adding new ones, and introduces no new top-level directory.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No constitutional violations. Two design points are recorded here because they are deliberate deviations from "CAC40 Bougie de 9h" mandated by the spec, not because they need justification against a principle:
+
+| Design point | Why | Note |
+|---|---|---|
+| Stop-loss measured from the **H1 reference level** (150 pts beyond it) for `G9H`, while `B9H` measures its stop from **entry**. | Spec FR-G05 / user rule "SL 150 points below the lower". | Implemented as a `stop_from_reference_level` flag on `BacktestDefinition` so `B9H`/`B9HTC` behavior is byte-for-byte unchanged; only `G9H` takes the reference-based branch. Surfaced in the spec Clarifications for the owner to confirm during validation. |
+| A two-lot position is surfaced as **one aggregated `Trade`** whose `points` ≠ `exit_price − entry_price`. | Spec FR-G07 (owner chose one aggregated trade over two rows). | Kept within the existing `Trade` shape (no response change, FR-G10); the engine computes the summed points explicitly via a dedicated close helper. The aggregated `exit_price`/`exit_reason` reflect the runner's final exit. |

--- a/specs/025-ger40-bougie-9h/quickstart.md
+++ b/specs/025-ger40-bougie-9h/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: GER40 Bougie de 9h (double take-profit) backtest
+
+Prerequisites: the spec 021 Backtest menu is already working (CAC40 Bougie de 9h). This feature adds the `G9H` definition; nothing new to install.
+
+## Run it (once implemented)
+
+Backend:
+
+```bash
+poetry install
+poetry run python run_api.py      # API on :8000
+```
+
+Frontend:
+
+```bash
+cd frontend && npm run dev        # Vite on :5173
+```
+
+In the app: **Backtest** menu → select **"GER40 Bougie de 9h"** → the threshold inputs pre-fill with the GER40 defaults (stop **150**, take-profit offset **10**, break-even trigger **50**, max entry distance **40**). Pick a past day (single-day, full detail) or a date range (aggregate summary). Export CSV from either view.
+
+Direct API check:
+
+```bash
+# Definitions now include G9H with its defaults + double_take_profit: true
+curl 'http://localhost:8000/api/backtest/definitions'
+
+# Single day (full detail) — each traded position is one aggregated 2-lot trade
+curl 'http://localhost:8000/api/backtest/day?definition=G9H&date=2026-06-02'
+
+# Range summary (counts classified by net-points sign for G9H)
+curl 'http://localhost:8000/api/backtest/run?definition=G9H&start_date=2026-06-01&end_date=2026-06-30'
+
+# Override a threshold (omitted ones fall back to the GER40 defaults, not CAC40's)
+curl 'http://localhost:8000/api/backtest/run?definition=G9H&start_date=2026-06-01&end_date=2026-06-30&stop_loss_points=120'
+```
+
+## What to verify (maps to Success Criteria)
+
+- **SC-G01**: a single `G9H` day returns within a few seconds with a correct result (no data / no trade / one or more two-lot positions).
+- **SC-G02** (hand-verified, ≥6 GER40.I days): for each of — both-lots stop-out (`points = 2·(stop−entry)`, `stop_loss`), +50 break-even (net ≈ 0, `break_even`), TP1-then-break-even (net-positive, `break_even`), TP1-then-TP2 full winner (`points = (TP1−entry)+(TP2−entry)`, `take_profit`), end-of-day, and a multi-position day — the reported entry, per-lot exits, net points, and exit reason match manual calc.
+- **SC-G03**: a multi-week range summary (days, trades one-per-position, wins/losses/BE by net sign, avg win, avg loss, final result) matches a manual computation from the per-day net points.
+- **SC-G04**: the day detail view shows the H1 high/low, the 5-minute candles, and each position's entry/exit against the chart.
+- **SC-G05**: running the same range on `B9H` (CAC40) is byte-for-byte unaffected — confirm CAC40 still uses 50/10/20/20, entry-relative stop, single-lot trades.
+
+## Backend test entry points
+
+```bash
+poetry run pytest tests/api/services/test_backtest_service.py -k ger40 -q
+poetry run pytest tests/api/routers/test_backtest.py -k g9h -q
+poetry run black . && poetry run isort . && poetry run flake8 && poetry run mypy .
+```
+
+## Key rules (cheat sheet)
+
+- Instrument `GER40.I`; same 9:00–10:00 Paris-local H1 window and 17:30 session close as CAC40 (Xetra ≈ Euronext hours).
+- Long: entry off the H1 low reversal; **TP1 = H1 midpoint `(high+low)/2`** (lot A), **TP2 = H1 high − 10** (runner), **stop = H1 low − 150** (both lots), **break-even trigger = +50**, **max entry distance = 40** from the H1 low. Short = mirror around the H1 high.
+- Two lots per entry; when **TP1 fills, the runner's stop → entry** (break-even); "SL is x2" = both lots exit the shared stop.
+- One aggregated `Trade` per position; `points` = sum of both lots; summary counts by net-points sign.

--- a/specs/025-ger40-bougie-9h/research.md
+++ b/specs/025-ger40-bougie-9h/research.md
@@ -1,0 +1,47 @@
+# Research: Hardcoded "GER40 Bougie de 9h" Backtest (double take-profit)
+
+Phase 0 for spec 025. This feature is a thin extension of spec 021 ("CAC40 Bougie de 9h"), so most of the underlying research (Paris-local windows, Saxo historical-candle limits, one-position-at-a-time engine, ephemeral results) is inherited from `specs/021-backtest-menu-hardcoded/research.md` and not repeated. The items below resolve only what is new or different for GER40.
+
+## §1 — GER40.I trading session and reference window
+
+- **Decision**: Reuse the existing `EUMarket()` + `Europe/Paris` (DST-aware) logic in `api/services/backtest_service.py` verbatim for GER40.I. The 9:00–10:00 reference window, the after-10:00 evaluation start, and the session-end (17:30 local) all apply unchanged.
+- **Rationale**: GER40.I (the DAX / German 40 index) trades on Xetra 09:00–17:30 Central European Time; Euronext Paris (FRA40.I) trades 09:00–17:30 CET as well. Both `Europe/Paris` and `Europe/Berlin` share the same UTC offset and DST rules, so `EUMarket` (open 9, close 17, end_minute 30) and `paris_reference_window_utc`/`paris_session_end_utc` produce the correct GER40 bounds without a new market type or timezone.
+- **Alternatives considered**: (a) A dedicated `DEMarket`/`Europe/Berlin` variant — rejected: identical offset and DST to `Europe/Paris`, so it would only duplicate code. (b) A separate reference window — rejected: the strategy is explicitly "the same as CAC40 Bougie de 9h" on the 9:00–10:00 candle.
+- **Evidence**: `GER40.I` already used elsewhere in the codebase (`saxo_order/commands/snapshot.py`, `shortcuts.py`, `api/services/watchlist_service.py` — "DAX") as a Saxo index instrument; the H1 and 5-minute historical fetches (`CandlesService.get_candles_in_window`) are instrument-agnostic.
+
+## §2 — Two-lot / double take-profit representation
+
+- **Decision**: Model a position's two lots **inside** the existing `_OpenPosition`, tracked as `first_target_level` (TP1 = H1 midpoint), `first_target_taken` (bool), and `banked_points` (lot-A P&L). Surface the closed position as **one aggregated `Trade`** whose `points` is the sum of both lots (FR-G07), constructed via a dedicated close helper because `points ≠ exit_price − entry_price` when the two lots exit at different prices or both stop out (the "SL is x2" case).
+- **Rationale**: The owner chose a single aggregated trade over two rows (Clarifications 2026-07-23). Keeping the two lots as internal position state avoids a second engine and preserves the existing `Trade`/`DayResult`/response shapes (FR-G10 — no new response model, no frontend response change). The aggregated `exit_reason`/`exit_price`/`exit_time` reflect the **runner's** final exit (TP1 is a partial scale-out, not the position's close).
+- **Alternatives considered**: (a) Two separate `Trade` rows per position — rejected by the owner (would double trade counts and complicate the summary). (b) A new `Position` entity wrapping N `Trade` lots — rejected as over-engineering for a fixed 2-lot strategy (Constitution II); the summary and outputs only need the aggregate. (c) Encoding the split into `exit_price` so `points` still equals the price difference — impossible when both lots stop at one level (net is 2× the per-lot loss), so points must be carried explicitly.
+
+## §3 — Stop-loss reference: from entry vs. from the H1 level
+
+- **Decision**: Add a `stop_from_reference_level: bool` property to `BacktestDefinition`. When `True` (GER40 only), the initial stop is `stop_loss_points` **beyond the H1 reference level** (H1 low − 150 for a long, H1 high + 150 for a short); when `False` (CAC40/`B9H`/`B9HTC`), the stop stays `stop_loss_points` from **entry**, exactly as today.
+- **Rationale**: The user rule is "SL 150 points below the lower" (the H1 low), which is a level-based stop, materially different from CAC40's entry-relative stop. A per-definition flag isolates the new behavior so `B9H`/`B9HTC` are provably unchanged (their flag is `False`). Both lots share this one stop level while both are open; after TP1 the runner's stop moves to entry (break-even).
+- **Alternatives considered**: (a) Reinterpret CAC40's stop as level-based too — rejected: would silently change `B9H` results. (b) A new `stop_reference` enum with more modes — rejected as speculative (only two modes exist); a bool is sufficient and honest. (c) Making the reference choice a per-run `BacktestParameter` — rejected: it is a fixed property of the strategy, not a knob (FR-G09).
+- **Flagged for validation**: This is the one genuine fork from CAC40; recorded in spec Clarifications so the owner confirms "below the lower" means the H1 low, not entry, before merge.
+
+## §4 — TP1 = 50% of the H1 candle
+
+- **Decision**: TP1 is the arithmetic midpoint of the H1 range, `(h1_high + h1_low) / 2`, the same absolute level for both long and short. It is a fixed derived level, not a tunable parameter (FR-G09).
+- **Rationale**: The owner confirmed "50% of the h1 candle" = the midpoint of the high–low range (Clarifications 2026-07-23), not the body midpoint and not a fraction of the entry-to-TP2 distance. Deriving it from the H1 high/low (already computed for every day) needs no new input.
+- **Alternatives considered**: body midpoint `(open+close)/2` and `entry + 0.5·(TP2 − entry)` — both explicitly rejected by the owner's answer.
+
+## §5 — Per-definition default thresholds
+
+- **Decision**: Attach a `default_parameters: BacktestParameters` to each `BacktestDefinition` (CAC40 → 50/10/20/20; GER40 → 150/10/50/40). Change the router's threshold dependency to return **optional overrides**, then resolve them against the selected definition's `default_parameters` (omitted field ⇒ that definition's default). Expose `default_parameters` on `BacktestDefinitionResponse` so the frontend pre-fills the correct defaults per selected definition.
+- **Rationale**: Today `BacktestParameters()` carries a single global default set (the CAC40 values), and the frontend hardcodes those same numbers in `PARAM_FIELDS`. GER40 needs different defaults (150/10/50/40). Per-definition defaults on the definition object keep one source of truth and let the frontend display the right placeholders without hardcoding a second set. Positivity validation (`> 0`, FR-G09 / spec 021 FR-027) is unchanged and still rejected at the API boundary with 422.
+- **Alternatives considered**: (a) A second global default set keyed by definition code inside the router — rejected: scatters the numbers. (b) Leaving the frontend defaults hardcoded and only fixing the backend — rejected: the GER40 inputs would show CAC40 numbers, misleading the trader. (c) Keeping `BacktestParameters` dataclass defaults as the fallback and ignoring per-definition defaults — rejected: GER40 would silently run with a 50-pt stop.
+
+## §6 — Summary classification of a double-TP position (FR-G08)
+
+- **Decision**: For a double-TP definition, classify each aggregated position by the **sign of its net points**: net > 0 → winning, net < 0 → losing, net == 0 → break-even bucket. For non-double-TP definitions keep the existing mechanism-based classification (`exit_reason == BREAK_EVEN` ⇒ BE). Branch on `definition.double_take_profit` inside `_build_summary`.
+- **Rationale**: A TP1-then-break-even runner closes with `exit_reason == BREAK_EVEN` but a **net-positive** result (the banked TP1). Mechanism-based bucketing would miscount it as BE; the owner's model treats it as a win. Sign-based classification (the same approach the time-cut variant already uses for its non-BE exits) matches reality, and the zero bucket still captures genuinely-flat positions (both lots at break-even, no TP filled). Branching on the definition keeps `B9H` counts identical.
+- **Alternatives considered**: (a) Change classification globally to sign-based — rejected: would reclassify `B9H`'s rare gap-through BE trades and change spec-021 behavior. (b) A dedicated exit reason for "TP1 then BE" — rejected as unnecessary; the aggregated exit reason already reflects the runner's close and the summary reads the net sign.
+
+## §7 — Testing approach
+
+- **Decision**: Extend `tests/api/services/test_backtest_service.py` with hand-built 5-minute candle sequences (the existing pattern) covering every SC-G02 outcome: both-lots stop-out (net = 2× loss), +50 break-even with no TP, TP1-then-break-even (net-positive), TP1-then-TP2 full winner, end-of-day, a multi-position day, no-trade, and no-data. Add router tests to `tests/api/routers/test_backtest.py` for the `G9H` definition listing (with GER40 defaults), `/run` and `/day` against `G9H`, per-definition default resolution, and the unchanged `422` positivity rejection.
+- **Rationale**: Mirrors the spec's acceptance scenarios and the existing mocked-`CandlesService` convention; no live Saxo calls. "DON'T test mock" (CLAUDE.md) — tests assert engine outcomes (entry, per-lot exits, net points, exit reason, summary counts), not that mocks were called.
+- **Alternatives considered**: Recording real GER40.I days as fixtures — deferred to the hand-verification in SC-G02 (manual), not automated, to keep the suite deterministic and offline.

--- a/specs/025-ger40-bougie-9h/spec.md
+++ b/specs/025-ger40-bougie-9h/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Hardcoded "GER40 Bougie de 9h" Backtest (double take-profit)
+
+**Feature Branch**: `claude/ger40-backtest-spec-025-k9togf`
+**Created**: 2026-07-23
+**Status**: Draft
+**Input**: User description: "Let's create a new backtest (need a new spec 025). It's the same strategy as «CAC 40 bougie de 9h» but for the GER40.I index. Rules are: TP 10 points below the higher; SL 150 points below the lower; BE +50 pts; Max distance 40 pts. I want a double take profit: 50% of the h1 candle then 10 pts below the high. It means a position is 2 products, so SL is x2. When we take TP1, the rest is BE."
+
+## Context
+
+This backtest reuses, verbatim, the base strategy of "CAC40 Bougie de 9h" (spec 021): the 9:00–10:00 H1 reference range, the after-10:00 5-minute breakout/reversal detection on both directions, one-position-at-a-time, the gap-fill convention on price-level exits, the end-of-day fallback, and the range-run aggregate summary. It differs from "CAC40 Bougie de 9h" in exactly four ways:
+
+1. **Instrument**: `GER40.I` (the DAX / German 40 index) instead of `FRA40.I`. GER40 trades the same 9:00–17:30 Central-European session as FRA40 (Xetra ≈ Euronext Paris), so the existing Paris-local reference window and session-end handling apply unchanged.
+2. **Different default thresholds** (in points): take-profit offset **10**, break-even trigger **50**, max entry distance **40**, and a stop-loss of **150 measured from the H1 reference level** (see §Stop-loss placement below and FR-G05).
+3. **Double take-profit / two-lot position**: every entry opens **two products (lots)** on the same signal. The first lot targets the 50% level of the H1 candle (its midpoint); the second lot targets the full take-profit (H1 high − 10 for a long / H1 low + 10 for a short). See FR-G02–FR-G04.
+4. **Take-first-then-break-even**: once the first lot's take-profit (TP1) fills, the remaining lot's stop is immediately moved to break-even (entry), independently of the +50-point break-even trigger.
+
+Everything else — breakout/reversal detection, entry validity, exit ordering (stop before take-profit within a candle), the gap-fill convention, the one-position-at-a-time rule across both directions, and the range/day/CSV outputs — is identical to "CAC40 Bougie de 9h" and is not re-specified here; the requirements below reference the spec 021 requirement they mirror.
+
+## Clarifications
+
+### Session 2026-07-23
+
+- Q: What does "TP1 = 50% of the h1 candle" mean? → A: The midpoint of the H1 high–low range: `(h1_high + h1_low) / 2`. For a long the first lot exits at that midpoint; the short is the mirror. It is not tied to the entry price, the candle body, or the distance to TP2.
+- Q: A position is "2 products". How should a position appear in the day result and the aggregate summary? → A: As **one aggregated trade** whose points result is the **sum of both lots'** points. The two lots are not listed as two separate trades. "SL is x2" falls out of this: if both lots stop out before any take-profit, the position's points is twice a single lot's loss.
+- Q: Where is the stop-loss placed — 150 points below the entry (as CAC40 does with its 50-point stop) or 150 points below the H1 low? → A: Below the **H1 reference level** — 150 points below the H1 low for a long, 150 points above the H1 high for a short ("150 points below the lower"). This is a **deliberate difference** from "CAC40 Bougie de 9h", whose stop is measured from the entry price. Both lots share this same stop level.
+- Q: "When we take TP1, the rest is BE" — does the runner's stop move to entry as soon as TP1 fills, even if price never reached the +50 break-even trigger? → A: Yes. TP1 filling is an independent trigger that arms break-even on the remaining lot; the +50-point favorable-move trigger (FR-G06) is the other, whichever happens first.
+- Q: Are the double-take-profit fraction (50%) and the two-lot count tunable per run like the four numeric thresholds? → A: No. The 50% first-target fraction and the two-lot structure are fixed properties of this hardcoded backtest, like the time-cut variant's 30-minute / 5-point settings. The four numeric thresholds (stop-loss, take-profit offset, break-even trigger, max entry distance) remain tunable per run, with the GER40 defaults above.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run the "GER40 Bougie de 9h" double-TP backtest for a single day (Priority: P1)
+
+A trader selects the Backtest menu, picks the hardcoded "GER40 Bougie de 9h" backtest, chooses a past trading day, and sees whether the strategy would have entered, and for each entry: where the two lots entered, where each lot exited (first lot at the 50% level, runner at the full target / break-even / stop / end of day), and the position's net points result.
+
+**Why this priority**: This is the core capability — a correct single-day, two-lot, double-take-profit result. Without it the feature delivers nothing.
+
+**Independent Test**: Run the backtest against a known historical GER40.I day where the 9:00–10:00 H1 candle and the subsequent 5-minute candles are known, and verify the reported entry, per-lot exits, and net points match a manual calculation using the rules below.
+
+**Acceptance Scenarios**:
+
+1. **Given** a GER40.I day where, after 10:00, price breaks below the H1 low, a 5-minute candle closes back above it, and a later candle's high confirms the breakout (mirroring CAC40 FR-006/FR-006b/FR-007), **When** the backtest runs, **Then** the system reports a long position of **two lots** entered at the same confirmed entry price.
+2. **Given** the open two-lot long from Scenario 1, **When** price rises to reach the **50% level of the H1 candle** (`(h1_high + h1_low) / 2`) before the stop, **Then** the **first lot** is closed at that level (TP1, take-profit), the **remaining lot's stop is moved to entry** (break-even), and the second lot stays open.
+3. **Given** the runner from Scenario 2, **When** price then rises to reach **H1 high − 10 points** before its break-even stop or end of day, **Then** the runner is closed at that take-profit level (TP2), and the position's net points is `(TP1 − entry) + (TP2 − entry)`.
+4. **Given** the runner from Scenario 2, **When** price instead falls back to the entry price before reaching TP2, **Then** the runner is closed at break-even (≈0 points, gap-fill per CAC40 FR-010 applying to the exact fill), and the position's net points is `(TP1 − entry) + ≈0`.
+5. **Given** the open two-lot long from Scenario 1 **before** TP1 has filled, **When** price falls to the stop-loss level (**H1 low − 150 points**) before reaching the 50% level, **Then** **both lots** are closed at that stop level and the position's net points is twice a single lot's loss (`2 × (stop − entry)`, a negative number).
+6. **Given** the open two-lot long from Scenario 1 **before** TP1 has filled, **When** a candle's high reaches **entry + 50 points** (the break-even trigger) without TP1 having filled, **Then** the shared stop of **both** still-open lots is moved to entry (break-even) from the next candle onward — the standard CAC40 FR-008a arming, at the GER40 default of 50 points.
+7. **Given** an open two-lot long that reaches neither a take-profit nor its stop, **When** the session ends, **Then** every lot still open is closed at the last 5-minute candle's close (end-of-day), and the position's net points sums whatever each lot realised.
+8. **Given** the mirror-image setup off the H1 high, **When** a valid short breakdown confirms, **Then** a two-lot **short** is entered, with TP1 at the same 50% midpoint level, TP2 at **H1 low + 10**, the shared stop at **H1 high + 150**, and the +50-point break-even trigger and take-first-then-break-even rules mirrored — exactly the CAC40 short-side mirror (FR-020–FR-023) with the GER40 thresholds and the double-TP overlay.
+9. **Given** a day with no 9:00–10:00 H1 candle for GER40.I (holiday, missing data), **When** the backtest runs, **Then** the day is reported as "no data" without failing the run (CAC40 FR-004).
+
+---
+
+### User Story 2 - Run the double-TP backtest over a date range and see aggregate results (Priority: P2)
+
+A trader enters a start and end date, runs "GER40 Bougie de 9h" across every trading day in the range, and sees the same aggregate summary the other backtests produce (number of days, number of trades, winning/losing/BE positions, average win, average loss, final result), where each **position** (not each lot) counts as one trade and contributes its net points.
+
+**Why this priority**: A single day has little statistical value; the range summary is what lets a trader judge the strategy. It builds on User Story 1.
+
+**Independent Test**: Run a known multi-week range with a mix of outcomes and verify the summary figures match a manual computation from the per-day net-points results, counting each two-lot position once.
+
+**Acceptance Scenarios**:
+
+1. **Given** a start and end date, **When** the backtest runs, **Then** the system displays one summary with number of days, number of trades (one per position), number of winning positions, number of losing positions, number of BE positions, average win, average loss, and final result — computed on each position's **net** points (both lots summed), consistent with CAC40 FR-013.
+2. **Given** a position where TP1 filled and the runner returned to break-even, **When** the summary is computed, **Then** the position is classified by the **sign of its net points** — a net gain from the banked TP1 makes it a winning position (see §Summary classification and FR-G08).
+3. **Given** a range with non-trading days or missing-data days, **When** the backtest runs, **Then** those days are excluded from "number of days" and every other figure and the run completes without error (CAC40 FR-013 scenario 2).
+4. **Given** a completed range run, **When** the trader exports CSV, **Then** the download has one row per day (date, status, trade count, points) exactly as CAC40 FR-017, where a two-lot position counts as one trade and contributes its net points.
+
+---
+
+### User Story 3 - Inspect a day's reference levels, candles and trades (Priority: P3)
+
+A trader opens a day's detail view and sees the H1 high/low, the 5-minute candles, and where each position entered and exited, so they can audit the two-lot result against the chart.
+
+**Why this priority**: Builds trust in the hardcoded logic; the strategy is usable without it.
+
+**Independent Test**: Open the detail view for a day with a two-lot position and confirm the H1 levels, 5-minute candles, and the position's entry/exit(s) are consistent with the summary and the underlying chart.
+
+**Acceptance Scenarios**:
+
+1. **Given** a backtested day with a position, **When** the trader opens the detail view, **Then** the system shows the H1 high/low, the 5-minute candles from 10:00 onward, and the position's entry and exit marked against that data (CAC40 FR-015).
+2. **Given** a day's detail view, **When** the trader exports CSV, **Then** the download contains the H1 high/low, the 5-minute candle sequence, and the day's trades (CAC40 FR-018).
+
+---
+
+### Edge Cases
+
+- **All CAC40 edge cases carry over**: breach-without-reversal, reversal-without-confirmation, candidate roll-forward, candidate discarded by a fresh close past the H1 level, repeat entry after a closed position, same-candle stop-vs-take-profit priority, break-even arm/breach timing, gap-through exits, confirmed-breakout-too-far-from-the-level, the short-side mirror, and one-position-at-a-time across both directions — all apply here with the GER40 thresholds. Read them from spec 021; only the double-TP-specific additions are listed below.
+- **TP1 and the stop breached in the same pre-TP1 candle**: while both lots are still open, if a single candle would reach both the stop (H1 low − 150 for a long) and the 50% level, the **stop wins** for **both lots** (the conservative CAC40 FR-009 rule, applied to the whole position before any scale-out).
+- **TP1 and TP2 in the same candle**: if a single candle reaches both the 50% level and the full target (H1 high − 10) while both lots are open, the first lot fills at TP1 and the runner fills at TP2 on that same candle (both are favorable price-level exits; the runner's break-even arming from the TP1 fill is moot because TP2 is reached). Net points is `(TP1 − entry) + (TP2 − entry)`.
+- **Break-even trigger and TP1 on the same candle**: if a candle's high both reaches entry + 50 and reaches the 50% level, TP1 fills (a take-profit) and the runner's stop is at break-even either way; the two triggers agree on the outcome.
+- **Runner stops at break-even after TP1, with a gap**: if the candle that takes the runner out at break-even opens beyond the entry price, the runner fills at that open (CAC40 FR-010 gap-fill), so the runner's points can be a small non-zero value; the position is still net-positive by the banked TP1.
+- **Entry validity uses the full target (TP2)**: a confirmed breakout is a valid entry only if it is within the max entry distance (40 points) of the H1 reference level **and** strictly below the full take-profit level (H1 high − 10 for a long) — the CAC40 FR-006a/FR-020a rule, judged against TP2, so an entry always leaves room for both lots to work. The 50% level (TP1) is always between the H1 low and TP2, so a valid entry is always below TP1 as well.
+- **50% level at or below the entry (degenerate)**: for a valid long entry within 40 points of the H1 low, the midpoint `(h1_high + h1_low)/2` is above the entry as long as the H1 range exceeds twice the entry-above-low distance; on an unusually narrow H1 range where the midpoint is at or below the entry, TP1 is reached on the entry candle's first favorable tick after entry (treated like any immediately-reachable take-profit), and the runner is armed to break-even at once. This is a rare boundary case, resolved the same conservative way as CAC40's "already at/past take-profit" handling.
+- **"SL is x2" is an accounting consequence, not a second stop**: there is one stop **level** shared by both lots; the doubled loss simply reflects that two lots exit at it. Once TP1 has filled, only the runner remains, so a subsequent stop (now at break-even) affects one lot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+Requirements below are numbered FR-G## and are additive/override requirements on top of "CAC40 Bougie de 9h" (spec 021, FR-001–FR-031). Every spec 021 requirement not overridden here applies unchanged, with the GER40 instrument and default thresholds substituted.
+
+- **FR-G01**: System MUST provide a third hardcoded backtest, **"GER40 Bougie de 9h"**, selectable from the Backtest menu alongside "CAC40 Bougie de 9h" and its time-cut variant (extends CAC40 FR-001/FR-002). It runs on the **GER40.I** instrument and applies the base "CAC40 Bougie de 9h" rule set (reference range, both-direction breakout/reversal detection, entry validity, exit ordering, one-position-at-a-time, gap-fill, end-of-day, range/day/CSV outputs) with the GER40 defaults (FR-G05) and the double-take-profit overlay (FR-G02–FR-G04, FR-G07). Adding it does not make the menu a generic engine — it is a third fixed strategy.
+- **FR-G02**: Every valid entry (long or short, per the base FR-006a/FR-020a validity check judged against the full take-profit level of FR-G03) MUST open a position of **two lots** at the confirmed entry price and time. The two lots are managed together while both are open and share one stop level (FR-G05).
+- **FR-G03**: The position MUST have two take-profit targets:
+  - **TP1 (first lot)** — the **50% level of the H1 candle**: `(h1_high + h1_low) / 2`, the same level for a long and a short. When price reaches TP1, the **first lot only** is closed at TP1 (a take-profit exit, gap-fill per CAC40 FR-010).
+  - **TP2 (runner)** — the **full take-profit level**: H1 high − take-profit offset for a long, H1 low + take-profit offset for a short (offset default 10, CAC40 FR-008/FR-022). When price reaches TP2, the runner is closed at TP2.
+- **FR-G04**: When **TP1 fills** (FR-G03), the remaining (runner) lot's stop MUST be moved to the entry price (**break-even**) immediately, from the next candle onward, independently of whether the +50-point break-even trigger (FR-G06) has fired. This is a second, TP1-driven path to arming break-even, in addition to the favorable-move trigger.
+- **FR-G05**: The stop-loss for the position MUST be placed **150 points beyond the H1 reference level** — **150 points below the H1 low for a long**, **150 points above the H1 high for a short** — and is **shared by both lots** while both are open. This is a deliberate difference from "CAC40 Bougie de 9h", whose stop is measured from the entry price; here the 150-point default is measured from the H1 reference level. While both lots are open, a stop hit closes **both** lots at that level; after TP1 has filled and moved the runner to break-even (FR-G04), only the runner remains and its stop is the entry price.
+- **FR-G06**: While a lot's stop has not yet been moved, the base break-even arming (CAC40 FR-008a/FR-022) applies at the GER40 default of **50 points**: the moment a candle's high reaches entry + 50 (long) / low reaches entry − 50 (short), the still-open lots' shared stop moves to the entry price, at most once, from the next candle onward. FR-G04 (TP1-driven) and FR-G06 (favorable-move-driven) are the two ways the runner reaches break-even, whichever occurs first.
+- **FR-G07**: A position MUST be reported to the day result and the aggregate summary as **one aggregated trade**, whose **points result is the sum of both lots'** realised points. The two lots MUST NOT be listed as two separate trades. The aggregated trade's exit reason reflects how the **position finally closed** (the runner's exit): take-profit when the runner reached TP2, break-even when the runner closed at its moved (entry) stop, stop-loss when both lots stopped out before any take-profit, or end-of-day. A position where the first lot took TP1 and the runner then stopped at break-even is a take-first-then-break-even outcome recorded as a break-even exit with a net-positive points result (the banked TP1).
+- **FR-G08**: In the aggregate summary (CAC40 FR-013), a two-lot position MUST be counted as **one trade** and classified by the **sign of its net points** (both lots summed): net > 0 is a winning position, net < 0 is a losing position, and a position that closed flat with no take-profit filled (both lots at break-even or a net of exactly 0) counts toward "number of BE". Average win and average loss use each position's net points; break-even positions are excluded from both, consistent with CAC40 FR-013. (This mirrors how the time-cut variant classifies by points sign rather than forcing a mechanism-only bucket.)
+- **FR-G09**: The four numeric thresholds MUST remain **tunable per run** exactly as in CAC40 FR-025–FR-027 (validated strictly greater than 0, per-run only, not persisted), with these **GER40 defaults**: stop-loss **150** (measured from the H1 level, FR-G05), take-profit offset **10**, break-even trigger **50**, max entry distance **40**. The **50% first-target fraction** and the **two-lot** structure are **fixed properties** of this backtest, NOT tunable parameters (like the time-cut variant's 30-minute / 5-point settings, CAC40 FR-031).
+- **FR-G10**: The per-day detail (CAC40 FR-015), the day/summary responses, and the CSV exports (CAC40 FR-017/FR-018) MUST include this backtest's positions using the existing trade fields (direction, entry time/price, exit time/price, exit reason, points), where a position is one aggregated trade (FR-G07). No new response shape is required beyond the existing Trade representation; the double-TP detail is summarised into the single aggregated trade.
+
+### Key Entities
+
+- **Backtest Definition** (extends spec 021): "GER40 Bougie de 9h" is a third instance — instrument `GER40.I`, the base "CAC40 Bougie de 9h" rule set, plus the fixed double-take-profit properties (two lots, 50% first-target fraction) and the GER40 default thresholds. The data model must continue not to assume a single definition.
+- **Backtest Parameters** (unchanged shape): the four tunable thresholds (stop-loss distance, take-profit offset, break-even trigger, max entry distance), here defaulting to the GER40 values (FR-G09). The stop-loss distance is reinterpreted for this definition as a distance from the H1 reference level rather than from entry (FR-G05).
+- **Position (two lots)**: an entry opens two lots at one price/time, sharing one stop level; the first lot targets the 50% midpoint (TP1), the runner targets the full take-profit (TP2) with a stop moved to break-even once TP1 fills. Surfaced to all outputs as **one aggregated Trade** whose points is the sum of both lots (FR-G07).
+
+## Success Criteria *(mandatory)*
+
+- **SC-G01**: A trader can select the Backtest menu, run "GER40 Bougie de 9h" for a single past day, and within a few seconds see a correct result (no data / no trade / one or more two-lot positions, each with entry, per-position net points, and exit reason).
+- **SC-G02**: On a hand-verified set of at least 6 historical GER40.I days covering all outcome types (no data, no trade, both-lots stop-out, +50 break-even, TP1-then-break-even, TP1-then-TP2 full winner, end-of-day, and a day with more than one position), the reported entry, per-lot exits, net points, and exit reason match manual calculation exactly.
+- **SC-G03**: A trader can run a multi-week range and receive a summary (days, trades counted one-per-position, winning/losing/BE positions, average win, average loss, final result) that matches a manual computation from the per-day net-points results.
+- **SC-G04**: A trader can open a day's detail view and confirm the H1 levels and the position's entry/exit against the underlying 5-minute candles.
+- **SC-G05**: Running the same range on "GER40 Bougie de 9h" versus "CAC40 Bougie de 9h" (on their respective instruments) shows the GER40 backtest using the GER40 defaults and the double-take-profit two-lot behavior, while "CAC40 Bougie de 9h" is entirely unaffected by this feature.
+
+## Assumptions
+
+- "Points" is the raw index price difference on GER40.I; no position sizing or currency P&L is in scope. "Two lots" is a **unit** count for points accounting (net = sum of both lots), not a monetary position size.
+- GER40.I H1 and 5-minute candle history for past, fully-closed days is obtainable through the existing Saxo historical-candle capability, the same as FRA40.I; no new market-data source is required. GER40 trades the same 9:00–17:30 Central-European session, so the existing Paris-local (Europe/Paris, DST-aware) reference-window and session-end handling apply unchanged.
+- The backtest operates only on already-closed historical days (CAC40 assumption), computed on demand and returned synchronously; nothing is persisted.
+- The **stop-loss is measured from the H1 reference level** (150 points beyond it), a deliberate difference from "CAC40 Bougie de 9h" — surfaced explicitly for validation (Clarifications, 2026-07-23). The other three thresholds (take-profit offset, break-even trigger, max entry distance) keep the CAC40 entry-/level-relative meaning.
+- **TP1 is the H1 midpoint** `(h1_high + h1_low)/2`, the same level for both directions (Clarifications, 2026-07-23). The 50% fraction and the two-lot count are fixed strategy properties, not tunable parameters.
+- A position is surfaced as **one aggregated trade** (net points = both lots summed); the two lots are an internal mechanic, not two separate trades in any output (Clarifications, 2026-07-23). Its exit reason reflects the runner's final exit; its summary classification is by net-points sign (FR-G08).
+- "CAC40 Bougie de 9h" and its time-cut variant are unchanged by this feature; the Backtest menu now lists three hardcoded backtests. No generic backtest-authoring capability is being built.

--- a/specs/025-ger40-bougie-9h/tasks.md
+++ b/specs/025-ger40-bougie-9h/tasks.md
@@ -1,0 +1,188 @@
+---
+description: "Task list for GER40 Bougie de 9h double take-profit backtest"
+---
+
+# Tasks: Hardcoded "GER40 Bougie de 9h" Backtest (double take-profit)
+
+**Input**: Design documents from `/specs/025-ger40-bougie-9h/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/backtest-api.md, quickstart.md
+
+**Tests**: INCLUDED — the repo's constitution (Testing Standards) and the existing `tests/api/services/test_backtest_service.py` / `tests/api/routers/test_backtest.py` establish a test-first convention for the backtest engine; SC-G02/SC-G03 require verified outcomes.
+
+**Organization**: Tasks are grouped by user story. This feature extends the existing spec-021 backtest modules — most work is backend engine, and the GER40 definition auto-appears in the frontend menu once registered.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (setup/foundational/polish carry no story label)
+
+## Path Conventions
+
+Existing flat layout (plan.md Structure Decision): backend packages `model/`, `services/`, `api/` at repo root; `frontend/src/`; tests in `tests/` mirroring source.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-good baseline before touching shared engine code.
+
+- [ ] T001 Confirm the existing backtest suite is green before changes: run `poetry run pytest tests/api/services/test_backtest_service.py tests/api/routers/test_backtest.py -q` and record the pass count (regression baseline for B9H/B9HTC unchanged behavior, SC-G05).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Register the GER40 definition, its per-definition default thresholds, and the double-TP properties so every user story can reach it. No engine behavior yet.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 [P] Add `G9H = "Bougie de 9h GER40"` to the `Strategy` enum in `model/enum.py` (Constitution II — no hardcoded strategy string; data-model.md §New enum member).
+- [ ] T003 [P] Extend `BacktestDefinition` in `model/backtest.py` with the fields `default_parameters: BacktestParameters = field(default_factory=BacktestParameters)`, `double_take_profit: bool = False`, `first_target_fraction: Optional[float] = None`, `stop_from_reference_level: bool = False` (all defaulting to current CAC40 behavior; data-model.md §Extended entity). Leave `BacktestParameters` shape/defaults unchanged.
+- [ ] T004 Register the `G9H` `BacktestDefinition` in `BACKTEST_DEFINITIONS` in `api/services/backtest_service.py` — `instrument="GER40.I"`, `name=Strategy.G9H.value`, `display_name="GER40 Bougie de 9h"`, `default_parameters=BacktestParameters(stop_loss_points=150, take_profit_offset_points=10, break_even_trigger_points=50, max_entry_distance_points=40)`, `double_take_profit=True`, `first_target_fraction=0.5`, `stop_from_reference_level=True` (data-model.md exact snippet). Depends on T002, T003.
+- [ ] T005 Add a `resolve_parameters(definition, overrides) -> BacktestParameters` helper in `api/services/backtest_service.py` that fills each omitted override from `definition.default_parameters` (research §5 / contracts §Threshold parameters). Depends on T003.
+- [ ] T006 Rework `_params` in `api/routers/backtest.py` to return the four thresholds as optional overrides, and resolve them against the looked-up definition's defaults inside each endpoint (after `_resolve_definition`, before `evaluate_day`/`run_range`), keeping the `Query(gt=0)` positivity validation and 422 behavior (contracts §Threshold parameters; unknown definition still 400). Depends on T004, T005.
+- [ ] T007 Extend `BacktestDefinitionResponse` and `backtest_definition_to_response` in `api/models/backtest.py` with `double_take_profit: bool` and `default_parameters` (a four-float model echoing the definition's defaults); leave `TradeResponse`/`DayDetailResponse`/`BacktestRunResponse` unchanged (FR-G10; contracts §definitions). Depends on T003.
+- [ ] T008 [P] Extend the `BacktestDefinition` TS interface in `frontend/src/services/api.ts` with `double_take_profit: boolean` and `default_parameters: Required<BacktestParameters>` (contracts §Frontend service mapping). Depends on T007.
+- [ ] T009 In `frontend/src/pages/Backtest.tsx`, seed the threshold inputs from `selectedDefinition.default_parameters` instead of the hardcoded `PARAM_FIELDS` defaults, re-seeding when the selected definition changes (so GER40 shows 150/10/50/40 and CAC40 still shows 50/10/20/20). Depends on T008.
+
+**Checkpoint**: `GET /api/backtest/definitions` lists `G9H` with GER40 defaults; the menu shows "GER40 Bougie de 9h"; a run against `G9H` currently executes as if single-lot (no double-TP yet). B9H/B9HTC unchanged.
+
+---
+
+## Phase 3: User Story 1 - Single-day double-TP backtest (Priority: P1) 🎯 MVP
+
+**Goal**: A `G9H` single day produces correct two-lot / double-take-profit positions — TP1 at the H1 midpoint, runner to TP2 or break-even, both lots on a reference-level stop (x2 loss), take-first-then-break-even — surfaced as one aggregated `Trade`.
+
+**Independent Test**: Run `/api/backtest/day?definition=G9H&date=…` against hand-built candle days and verify entry, per-lot exits, net points, and exit reason match manual calc for every SC-G02 outcome type.
+
+### Tests for User Story 1 (write first, expect FAIL)
+
+- [ ] T010 [P] [US1] Add double-TP engine tests to `tests/api/services/test_backtest_service.py` covering: both-lots stop-out before TP1 (`points = 2·(stop−entry)`, `stop_loss`, stop = H1 low − 150); TP1 fills then runner hits TP2 (`points = (TP1−entry)+(TP2−entry)`, `take_profit`); TP1 then runner returns to break-even (net-positive, `break_even`); +50 break-even armed before TP1 then flat stop-out (net ≈ 0); end-of-day with both lots open and with runner only; the short mirror off the H1 high (TP2 = H1 low + 10, stop = H1 high + 150); no-trade; no-data. Assert on outcomes, not mocks (CLAUDE.md). Uses the existing hand-built 5-minute candle pattern.
+- [ ] T011 [P] [US1] Add a `/api/backtest/day` test for `G9H` to `tests/api/routers/test_backtest.py` asserting a traded day returns each position as one aggregated `TradeResponse` (shared `entry_price`, runner's `exit_price`/`exit_reason`, net `points`), response shape unchanged from B9H.
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Extend `_OpenPosition` in `api/services/backtest_service.py` with `double`, `first_target_level`, `first_target_taken`, `banked_points`, `initial_stop_price`; update the `stop_level` property to branch: `be_armed` → entry, else `stop_from_reference_level` → `initial_stop_price`, else `entry ± stop_loss_points` (unchanged CAC40 path). (data-model.md §Engine state). Depends on T004.
+- [ ] T013 [US1] Add the double-TP exit handling in `_resolve_exit` (or a `_resolve_exit_double` branch selected when `position.double`) in `api/services/backtest_service.py`: while both lots open — stop beats TP1 on a same-candle collision (both lots close, `points = 2·(stop−entry)`); TP1 hit → bank `TP1−entry`, set `first_target_taken`, arm runner break-even (FR-G04), handle same-candle TP1+TP2; +50 trigger arms shared stop (FR-G06). Runner only — break-even stop at entry, TP2, gap-fill (FR-010). Depends on T012.
+- [ ] T014 [US1] Add a `_close_double_trade` helper in `api/services/backtest_service.py` that builds the aggregated `Trade` with explicit net `points` (`banked_points` + runner leg, or `2·` leg for both-lots exits), the runner's `exit_price`/`exit_time`/`exit_reason`, raising an explicit exception (no `assert`, Constitution II.5) on any invariant violation. Depends on T012.
+- [ ] T015 [US1] Wire double-TP into `_evaluate_trades`/`evaluate_day` in `api/services/backtest_service.py`: compute `first_target_level = (h1_high + h1_low)/2` and the reference-based `initial_stop_price` per direction, construct `_OpenPosition` with the definition's double-TP props, and route open positions through the double-TP exit path and end-of-day close. Entry detection/validity (`_DirectionSearch`, validity judged against TP2) unchanged. Depends on T012, T013, T014.
+
+**Checkpoint**: T010/T011 pass; a `G9H` single day returns correct aggregated two-lot positions. MVP deliverable — CAC40 still green (rerun T001 suite).
+
+---
+
+## Phase 4: User Story 2 - Range summary with per-position classification (Priority: P2)
+
+**Goal**: A `G9H` range run counts each two-lot position once and classifies it by net-points sign (a TP1-then-break-even winner counts as a win, not BE).
+
+**Independent Test**: Run `/api/backtest/run?definition=G9H&…` over a mixed range and verify days/trades/wins/losses/BE/avg-win/avg-loss/final match a manual computation from per-day net points; a TP1-then-BE position lands in wins.
+
+### Tests for User Story 2 (write first, expect FAIL)
+
+- [ ] T016 [P] [US2] Add summary-classification tests to `tests/api/services/test_backtest_service.py`: for `G9H`, a net-positive TP1-then-break-even position counts as winning (not BE); a genuinely-flat position (both lots at break-even, no TP) counts as BE; `average_win`/`average_loss` use net points. Assert B9H classification is unchanged (regression).
+
+### Implementation for User Story 2
+
+- [ ] T017 [US2] In `_build_summary` in `api/services/backtest_service.py`, branch on `definition.double_take_profit`: classify by net-points sign (net > 0 win, net < 0 loss, net == 0 BE) for double-TP definitions; keep the existing mechanism-based (`exit_reason == BREAK_EVEN`) classification for B9H/B9HTC (FR-G08 / research §6). Depends on US1 (T015).
+- [ ] T018 [US2] Add a `/api/backtest/run` and `/api/backtest/run/csv` test for `G9H` to `tests/api/routers/test_backtest.py` asserting one row/trade per position (net points) and that the CSV parameters block echoes the resolved GER40 defaults (150/10/50/40). Depends on T017.
+
+**Checkpoint**: `G9H` range summary and CSV correct; B9H summary/CSV unchanged.
+
+---
+
+## Phase 5: User Story 3 - Inspect a day's levels, candles and trades (Priority: P3)
+
+**Goal**: The day detail view and its CSV show the H1 levels, 5-minute candles, and each aggregated `G9H` position's entry/exit — reusing the existing detail component and export (no response-shape change, FR-G10).
+
+**Independent Test**: Open the day detail for a `G9H` day with a position and confirm H1 levels, candles, and the position's entry/exit render consistently with the summary; export the day CSV.
+
+### Tests for User Story 3 (write first, expect FAIL)
+
+- [ ] T019 [P] [US3] Add a `/api/backtest/day/csv` test for `G9H` to `tests/api/routers/test_backtest.py` asserting the three-block CSV (H1 levels, candles, trades) renders the aggregated position row with net points and the resolved-parameters block.
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Verify `frontend/src/components/BacktestDayDetail.tsx` renders a `G9H` day (H1 levels, candle series, entry/exit markers) using the unchanged `DayDetailResponse`; make only the minimal adjustment needed if a two-lot position's single aggregated trade surfaces any label gap (e.g. it may read "long"/"short" as today). No new response field is introduced.
+
+**Checkpoint**: All three stories independently functional for GER40; CAC40 unaffected.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T021 Run `poetry run black . && poetry run isort . && poetry run flake8 && poetry run mypy .` and fix any violations in the changed backend files (Constitution Quality Gates; 79-char lines).
+- [ ] T022 Run `cd frontend && npm run lint && npm run build` and fix any TypeScript/ESLint issues in `api.ts` / `Backtest.tsx` (Constitution Frontend Quality Gates).
+- [ ] T023 Run the full backend suite `poetry run pytest -q` and confirm B9H/B9HTC results are byte-for-byte unchanged vs the T001 baseline (SC-G05 regression guard).
+- [ ] T024 Execute `specs/025-ger40-bougie-9h/quickstart.md` end-to-end (definitions list, single-day, range, CSV, threshold override) and confirm SC-G01…SC-G05.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: after Setup — BLOCKS all user stories (registers the definition, defaults, response fields, frontend plumbing).
+- **User Stories (Phase 3–5)**: all depend on Foundational. US2 depends on US1's engine (aggregated trades exist before they can be classified). US3 depends only on Foundational for the response but is naturally validated after US1 produces trades.
+- **Polish (Phase 6)**: after the desired stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after Foundational. The MVP — delivers the double-TP engine.
+- **US2 (P2)**: after US1 (classifies the positions US1 produces).
+- **US3 (P3)**: after Foundational; independent of US1/US2 in code (reuses existing detail/CSV), verified after US1.
+
+### Within Each User Story
+
+- Tests written first and expected to FAIL, then implementation (constitution test-first convention).
+- Model/state (`_OpenPosition`) before exit logic before wiring.
+
+### Parallel Opportunities
+
+- T002 and T003 (different model files) run in parallel.
+- T008 is parallel-safe once T007 lands (different file).
+- T010 and T011 (service vs router test files) run in parallel; T016 and T019 likewise.
+- US3 (T019/T020) can be built in parallel with US2 by a second contributor once US1 lands.
+
+---
+
+## Parallel Example: Foundational + User Story 1
+
+```bash
+# Foundational model changes in parallel:
+Task: "Add Strategy.G9H to model/enum.py"                # T002
+Task: "Extend BacktestDefinition fields in model/backtest.py"  # T003
+
+# User Story 1 tests in parallel (write first, expect FAIL):
+Task: "Double-TP engine tests in tests/api/services/test_backtest_service.py"  # T010
+Task: "G9H /day aggregated-trade test in tests/api/routers/test_backtest.py"    # T011
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup (T001 baseline).
+2. Phase 2 Foundational (T002–T009) — definition + defaults + plumbing.
+3. Phase 3 US1 (T010–T015) — the double-TP engine.
+4. **STOP and VALIDATE**: single-day `G9H` outcomes match manual calc (SC-G02); B9H still green.
+
+### Incremental Delivery
+
+1. Foundational → GER40 menu entry live (single-lot placeholder).
+2. + US1 → correct two-lot double-TP single-day results (MVP).
+3. + US2 → range summary with net-sign classification.
+4. + US3 → day detail/CSV inspection.
+5. Polish → lint/type/build/regression/quickstart.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependency.
+- Every user-story task carries its `[US#]` label; setup/foundational/polish do not.
+- No `assert` in production code — raise explicit exceptions (Constitution II.5 / v1.3.0).
+- B9H/B9HTC must stay byte-for-byte unchanged — all new behavior is gated behind `double_take_profit` / `stop_from_reference_level` per-definition flags.
+- Commit after each task or logical group; conventional commit prefixes (`feat:`/`test:`/`docs:`).


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016TJ6vDqK7ZrXkvaTePtXxx