### PR TITLE
feat: add 9h H1 range to backtest range CSV export

### DIFF
--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -57,6 +57,8 @@ class DayResultSummaryResponse(BaseModel):
     status: str
     trade_count: int
     points: float
+    h1_high: Optional[float] = None
+    h1_low: Optional[float] = None
 
 
 class BacktestSummaryResponse(BaseModel):
@@ -129,6 +131,8 @@ def _day_result_summary_to_response(
         status=summary.status.value,
         trade_count=summary.trade_count,
         points=summary.points,
+        h1_high=summary.h1_high,
+        h1_low=summary.h1_low,
     )
 
 
@@ -184,14 +188,32 @@ def backtest_run_result_to_csv(
     output = io.StringIO()
     writer = csv.writer(output)
     _write_parameters_block(writer, params)
-    writer.writerow(["date", "status", "trade_count", "points"])
+    writer.writerow(
+        [
+            "date",
+            "status",
+            "trade_count",
+            "points",
+            "h1_high",
+            "h1_low",
+            "h1_range",
+        ]
+    )
     for day in run_result.days:
+        h1_range = (
+            round(day.h1_high - day.h1_low, 4)
+            if day.h1_high is not None and day.h1_low is not None
+            else None
+        )
         writer.writerow(
             [
                 day.date.isoformat(),
                 day.status.value,
                 day.trade_count,
                 day.points,
+                day.h1_high,
+                day.h1_low,
+                h1_range,
             ]
         )
     return output.getvalue()

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -406,6 +406,8 @@ class BacktestService:
                         status=day_result.status,
                         trade_count=len(day_result.trades),
                         points=day_points,
+                        h1_high=day_result.h1_high,
+                        h1_low=day_result.h1_low,
                     )
                 )
                 all_trades.extend(day_result.trades)

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -61,6 +61,12 @@ class DayResultSummary:
     status: DayStatus
     trade_count: int
     points: float
+    # 9h reference candle levels for the day, carried through so a range
+    # export can expose the setup's H1 range (a regime/volatility proxy
+    # that is independent of the SL/TP parameters). None only on NO_DATA
+    # days, which run_range excludes from the summary anyway.
+    h1_high: Optional[float] = None
+    h1_low: Optional[float] = None
 
 
 @dataclass

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -365,6 +365,8 @@ class TestGetBacktestRunCsv:
                     status=DayStatus.TRADED,
                     trade_count=1,
                     points=30.0,
+                    h1_high=8050.0,
+                    h1_low=8000.0,
                 )
             ],
         )
@@ -387,8 +389,8 @@ class TestGetBacktestRunCsv:
         body = response.text
         assert "parameter,value" in body
         assert "stop_loss_points,50" in body
-        assert "date,status,trade_count,points" in body
-        assert "2026-06-02,traded,1,30.0" in body
+        assert "date,status,trade_count,points,h1_high,h1_low,h1_range" in body
+        assert "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0" in body
 
     def test_end_before_start_returns_400(self, mock_backtest_service):
         mock_backtest_service.get_definition.return_value = MagicMock(


### PR DESCRIPTION
## What

Adds three per-day columns to the `/api/backtest/run/csv` export: `h1_high`, `h1_low`, and a computed `h1_range` (= `h1_high - h1_low`). The values are threaded from the day's 9h reference candle through `DayResultSummary` → `run_range` → the CSV builder, and are also surfaced on the JSON `/run` response for consistency.

Header changes from:
```
date,status,trade_count,points
```
to:
```
date,status,trade_count,points,h1_high,h1_low,h1_range
```

## Why

The 9h reference-candle range is a setup/volatility (regime) proxy for the "Bougie de 9h" strategy, and — crucially — it is **independent of the SL/TP/time-cut parameters** (it's just the reference candle). Exposing it in the range export lets a single export per period be joined against any parameter run for regime analysis, without re-fetching Saxo data.

This unblocks the regime-filter investigation from the B9H stop-loss analysis: out-of-sample testing showed the strategy's edge concentrates in trending months, so the next step is to test whether a trend/chop gate (of which H1 range is the leading candidate) separates winning from losing days.

## Notes

- `h1_range` is blank on `NO_DATA` days, which `run_range` already excludes from the summary anyway; `h1_high`/`h1_low` are populated for all `TRADED` and `NO_TRADE` rows.
- No behavior change to the strategy or existing columns — purely additive.

## Test

- `tests/api/routers/test_backtest.py` updated to assert the new header and a populated `h1_range` row.
- Full backtest suites green (95 passed); black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)