### PR TITLE
feat: add daily MA50 slope (regime) column to backtest range CSV

### DIFF
--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -59,6 +59,7 @@ class DayResultSummaryResponse(BaseModel):
     points: float
     h1_high: Optional[float] = None
     h1_low: Optional[float] = None
+    mm50_slope: Optional[float] = None
 
 
 class BacktestSummaryResponse(BaseModel):
@@ -133,6 +134,7 @@ def _day_result_summary_to_response(
         points=summary.points,
         h1_high=summary.h1_high,
         h1_low=summary.h1_low,
+        mm50_slope=summary.mm50_slope,
     )
 
 
@@ -197,6 +199,7 @@ def backtest_run_result_to_csv(
             "h1_high",
             "h1_low",
             "h1_range",
+            "mm50_slope",
         ]
     )
     for day in run_result.days:
@@ -214,6 +217,7 @@ def backtest_run_result_to_csv(
                 day.h1_high,
                 day.h1_low,
                 h1_range,
+                day.mm50_slope,
             ]
         )
     return output.getvalue()

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -532,12 +532,17 @@ class BacktestService:
         enough lead-in to compute a 50-day MA slope on the first day.
         Fetched once per run_range. A failure degrades to an empty series
         (blank mm50_slope column) rather than aborting the whole export."""
-        weekdays = sum(
-            1
-            for n in range((end_date - start_date).days + 1)
-            if (start_date + datetime.timedelta(days=n)).weekday() < 5
+        # Daily candles are fetched counting backward from end_date, so
+        # count must reach ~60 trading days before start_date for the
+        # first day's MA50 slope. Calendar days is a safe upper bound on
+        # the range's trading days (build_candles caps at available data),
+        # so no need to exclude weekends/holidays precisely.
+        count = (
+            (end_date - start_date).days
+            + MM50_MIN_DAILY_CANDLES
+            + MM50_SLOPE_LOOKBACK
+            + 5
         )
-        count = weekdays + MM50_MIN_DAILY_CANDLES + MM50_SLOPE_LOOKBACK + 5
         reference = datetime.datetime(
             end_date.year, end_date.month, end_date.day, tzinfo=PARIS_TZ
         )

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -18,11 +18,18 @@ from model import (
 )
 from model.enum import DayStatus, Direction, ExitReason
 from services.candles_service import CandlesService
+from services.indicator_service import mobile_average, slope_percentage
 from utils.exception import SaxoException
 from utils.helper import market_in_utc
 from utils.logger import Logger
 
 PARIS_TZ = ZoneInfo("Europe/Paris")
+
+# Daily MA50 slope regime measure: MA50 needs 50 daily closes and the
+# slope is taken over a 10-candle lookback, so at least 60 prior daily
+# candles are required before a day can be scored.
+MM50_MIN_DAILY_CANDLES = 60
+MM50_SLOPE_LOOKBACK = 10
 
 BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
     BacktestDefinition(
@@ -387,6 +394,10 @@ class BacktestService:
         day_summaries: List[DayResultSummary] = []
         all_trades: List[Trade] = []
 
+        daily_candles = self._fetch_daily_candles(
+            definition.instrument, start_date, end_date
+        )
+
         current = start_date
         while current <= end_date:
             if current.weekday() >= 5:
@@ -408,6 +419,9 @@ class BacktestService:
                         points=day_points,
                         h1_high=day_result.h1_high,
                         h1_low=day_result.h1_low,
+                        mm50_slope=self._mm50_slope_before(
+                            daily_candles, day_result.date
+                        ),
                     )
                 )
                 all_trades.extend(day_result.trades)
@@ -507,6 +521,56 @@ class BacktestService:
                 f"{start_utc} and {end_utc}: {e}"
             )
             return []
+
+    def _fetch_daily_candles(
+        self,
+        instrument: str,
+        start_date: datetime.date,
+        end_date: datetime.date,
+    ) -> List[Candle]:
+        """Daily (newest-first) candle series covering the run range plus
+        enough lead-in to compute a 50-day MA slope on the first day.
+        Fetched once per run_range. A failure degrades to an empty series
+        (blank mm50_slope column) rather than aborting the whole export."""
+        weekdays = sum(
+            1
+            for n in range((end_date - start_date).days + 1)
+            if (start_date + datetime.timedelta(days=n)).weekday() < 5
+        )
+        count = weekdays + MM50_MIN_DAILY_CANDLES + MM50_SLOPE_LOOKBACK + 5
+        reference = datetime.datetime(
+            end_date.year, end_date.month, end_date.day, tzinfo=PARIS_TZ
+        )
+        try:
+            return self.candles_service.build_candles(
+                instrument, UnitTime.D, EUMarket(), count, reference
+            )
+        except SaxoException as e:
+            self.logger.warning(
+                f"No daily candles for {instrument} regime measure: {e}"
+            )
+            return []
+
+    @staticmethod
+    def _mm50_slope_before(
+        daily_candles: List[Candle], trading_date: datetime.date
+    ) -> Optional[float]:
+        """Daily MA50 slope (%) as of the last close strictly before
+        trading_date (lookahead-safe: today's daily candle is never in the
+        window). Mirrors the MA50 slope used by the MM50 alert (spec 019).
+        Returns None when fewer than MM50_MIN_DAILY_CANDLES prior daily
+        candles are available."""
+        prior = [
+            candle
+            for candle in daily_candles
+            if candle.date is not None and candle.date.date() < trading_date
+        ]
+        if len(prior) < MM50_MIN_DAILY_CANDLES:
+            return None
+        prior.sort(key=_candle_date, reverse=True)
+        ma50_last = mobile_average(prior, 50)
+        ma50_first = mobile_average(prior[MM50_SLOPE_LOOKBACK:], 50)
+        return slope_percentage(0, ma50_first, MM50_SLOPE_LOOKBACK, ma50_last)
 
     def _evaluate_trades(
         self,

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -67,6 +67,10 @@ class DayResultSummary:
     # days, which run_range excludes from the summary anyway.
     h1_high: Optional[float] = None
     h1_low: Optional[float] = None
+    # Daily MA50 slope (%) as of the close strictly before this day - a
+    # trend/chop regime measure, lookahead-safe and config-independent.
+    # None when fewer than 60 prior daily candles are available.
+    mm50_slope: Optional[float] = None
 
 
 @dataclass

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -367,6 +367,7 @@ class TestGetBacktestRunCsv:
                     points=30.0,
                     h1_high=8050.0,
                     h1_low=8000.0,
+                    mm50_slope=1.2345,
                 )
             ],
         )
@@ -389,8 +390,11 @@ class TestGetBacktestRunCsv:
         body = response.text
         assert "parameter,value" in body
         assert "stop_loss_points,50" in body
-        assert "date,status,trade_count,points,h1_high,h1_low,h1_range" in body
-        assert "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0" in body
+        assert (
+            "date,status,trade_count,points,h1_high,h1_low,h1_range,"
+            "mm50_slope" in body
+        )
+        assert "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0,1.2345" in body
 
     def test_end_before_start_returns_400(self, mock_backtest_service):
         mock_backtest_service.get_definition.return_value = MagicMock(

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -1188,3 +1188,83 @@ class TestBacktestParameters:
         result = service.evaluate_day(DEFINITION, TRADING_DATE, params)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
+
+
+def daily_candle(day: datetime.date, close: float) -> Candle:
+    return Candle(
+        lower=close - 5,
+        higher=close + 5,
+        open=close,
+        close=close,
+        ut=UnitTime.D,
+        date=datetime.datetime(day.year, day.month, day.day, 0, 0),
+    )
+
+
+def uptrend_daily_series(end_before: datetime.date, count: int) -> list:
+    """`count` daily candles ending the day before `end_before`, close
+    rising toward the most recent day (an uptrend). Returned oldest-first
+    to prove _mm50_slope_before does not rely on input ordering."""
+    series = []
+    for offset in range(1, count + 1):
+        day = end_before - datetime.timedelta(days=offset)
+        series.append(daily_candle(day, close=8000 + (count - offset)))
+    return list(reversed(series))  # oldest-first
+
+
+class TestMm50SlopeBefore:
+    TRADING_DATE = datetime.date(2026, 6, 2)
+
+    def test_none_when_fewer_than_60_prior_candles(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 59)
+        assert (
+            BacktestService._mm50_slope_before(series, self.TRADING_DATE)
+            is None
+        )
+
+    def test_positive_slope_for_uptrend(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        slope = BacktestService._mm50_slope_before(series, self.TRADING_DATE)
+        assert slope is not None and slope > 0
+
+    def test_ignores_today_and_future_candles(self):
+        """A candle dated on the trading day (or later) must not affect
+        the result - the gate is computed only from strictly-prior
+        closes."""
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        baseline = BacktestService._mm50_slope_before(
+            series, self.TRADING_DATE
+        )
+        polluted = series + [
+            daily_candle(self.TRADING_DATE, close=0.0),
+            daily_candle(
+                self.TRADING_DATE + datetime.timedelta(days=1), close=99999.0
+            ),
+        ]
+        assert (
+            BacktestService._mm50_slope_before(polluted, self.TRADING_DATE)
+            == baseline
+        )
+
+    def test_skips_dateless_candles(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        dateless = daily_candle(self.TRADING_DATE, close=0.0)
+        dateless.date = None
+        assert BacktestService._mm50_slope_before(
+            [dateless] + series, self.TRADING_DATE
+        ) == BacktestService._mm50_slope_before(series, self.TRADING_DATE)
+
+
+class TestRunRangeThreadsRegime:
+    def test_mm50_slope_populated_on_summary(self):
+        trading_date = datetime.date(2026, 6, 2)
+        service = make_service(
+            [h1_candle()], TestBacktestParameters.STOP_LOSS_CANDLES
+        )
+        service.candles_service.build_candles.return_value = (
+            uptrend_daily_series(trading_date, 70)
+        )
+        result = service.run_range(DEFINITION, trading_date, trading_date)
+        assert len(result.days) == 1
+        assert result.days[0].mm50_slope is not None
+        assert result.days[0].mm50_slope > 0


### PR DESCRIPTION
## What

Adds a `mm50_slope` column to the `/api/backtest/run/csv` day rows: the daily **MA50 slope (%)** as of the close **strictly before** each trading day. `run_range` fetches the daily (`UnitTime.D`) series once, and per day computes the slope from prior closes only, reusing `mobile_average` / `slope_percentage` (same formula as the MM50 alert, spec 019). Also surfaced on the JSON `/run` response.

Header now:
```
date,status,trade_count,points,h1_high,h1_low,h1_range,mm50_slope
```

## Why

Next step in the B9H regime-filter investigation (see `backtests/b9h-stop-loss-analysis.md`). The out-of-sample work showed the strategy's edge concentrates in trending months; the 9h-range proxy (`h1_range`, #656) was then tested and **rejected** as a standalone gate because it measures morning quality, not regime. The daily MA50 slope is the actual trend/chop measure that was missing. Exposing it as a column lets one export per window feed the regime analysis without another Saxo round-trip.

## Design notes

- **Lookahead-safe:** the slope window is built only from daily candles dated `< trading_date` — today's daily candle is never included, so the gate is tradeable (verified by a unit test that pollutes the series with a same-day and a future candle and asserts the result is unchanged).
- **Config-independent**, like `h1_range`: the slope depends only on prior daily closes, so it is identical across every SL/TP/time-cut run and joins to any parameter CSV by date.
- **Graceful degradation:** `None` (blank cell) when fewer than 60 prior daily candles exist; a daily-fetch `SaxoException` logs a warning and leaves the column blank rather than aborting the export.
- Signed slope is exported (analysis takes `|slope|`, since B9H is long+short) — the gate/threshold is deliberately **not** baked into the export.

## Tests

- `_mm50_slope_before`: insufficient-history → None; uptrend → positive slope; ignores today's and future candles; skips dateless candles.
- `run_range` threads `mm50_slope` onto the summary.
- Router CSV test asserts the new header and a populated value.
- Full suite green (463 passed, 10 skipped); black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)