### PR TITLE
feat: report Ouinex trades under the Binance identity (spec 024 phase 6 / US4)

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -7,6 +7,7 @@ from fastapi import Depends, HTTPException, Request
 from api.services.asset_details_service import AssetDetailsService
 from api.services.backtest_service import BacktestService
 from api.services.binance_report_service import BinanceReportService
+from api.services.ouinex_report_service import OuinexReportService
 from api.services.report_service import ReportService
 from api.services.trade_republic_service import TradeRepublicService
 from client.aws_client import AwsClient, DynamoDBClient
@@ -117,6 +118,13 @@ def get_binance_report_service() -> BinanceReportService:
     binance_client = get_binance_client()
     config = get_configuration()
     return BinanceReportService(binance_client, config)
+
+
+@lru_cache()
+def get_ouinex_report_service() -> OuinexReportService:
+    ouinex_client = get_ouinex_client()
+    config = get_configuration()
+    return OuinexReportService(ouinex_client, config)
 
 
 @lru_cache()

--- a/api/routers/report.py
+++ b/api/routers/report.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.dependencies import (
     get_binance_report_service,
+    get_ouinex_report_service,
     get_report_service,
 )
 from api.models.report import (
@@ -14,6 +15,7 @@ from api.models.report import (
     UpdateGSheetOrderRequest,
 )
 from api.services.binance_report_service import BinanceReportService
+from api.services.ouinex_report_service import OuinexReportService
 from api.services.report_service import ReportService
 from model import Signal, Strategy
 from utils.exception import SaxoException
@@ -40,6 +42,9 @@ async def get_report_orders(
     binance_report_service: BinanceReportService = Depends(
         get_binance_report_service
     ),
+    ouinex_report_service: OuinexReportService = Depends(
+        get_ouinex_report_service
+    ),
 ):
     """
     Get trading report orders for a specific account from a given date.
@@ -51,9 +56,13 @@ async def get_report_orders(
     summary data.
     """
     try:
-        report_service: Union[BinanceReportService, ReportService]
+        report_service: Union[
+            BinanceReportService, OuinexReportService, ReportService
+        ]
         if account_id.startswith("binance_"):
             report_service = binance_report_service
+        elif account_id.startswith("ouinex_"):
+            report_service = ouinex_report_service
         else:
             report_service = saxo_report_service
 
@@ -99,6 +108,9 @@ async def get_report_summary(
     binance_report_service: BinanceReportService = Depends(
         get_binance_report_service
     ),
+    ouinex_report_service: OuinexReportService = Depends(
+        get_ouinex_report_service
+    ),
 ):
     """
     Get summary statistics for trading report.
@@ -108,9 +120,13 @@ async def get_report_summary(
     Returns aggregated data like total orders, volume, fees, etc.
     """
     try:
-        report_service: Union[BinanceReportService, ReportService]
+        report_service: Union[
+            BinanceReportService, OuinexReportService, ReportService
+        ]
         if account_id.startswith("binance_"):
             report_service = binance_report_service
+        elif account_id.startswith("ouinex_"):
+            report_service = ouinex_report_service
         else:
             report_service = saxo_report_service
 
@@ -137,6 +153,9 @@ async def create_gsheet_order(
     binance_report_service: BinanceReportService = Depends(
         get_binance_report_service
     ),
+    ouinex_report_service: OuinexReportService = Depends(
+        get_ouinex_report_service
+    ),
 ):
     """
     Create a new order entry in Google Sheets.
@@ -146,9 +165,13 @@ async def create_gsheet_order(
     This opens a new position with stop loss, target, and strategy tracking.
     """
     try:
-        report_service: Union[BinanceReportService, ReportService]
+        report_service: Union[
+            BinanceReportService, OuinexReportService, ReportService
+        ]
         if request.account_id.startswith("binance_"):
             report_service = binance_report_service
+        elif request.account_id.startswith("ouinex_"):
+            report_service = ouinex_report_service
         else:
             report_service = saxo_report_service
 
@@ -193,6 +216,9 @@ async def update_gsheet_order(
     binance_report_service: BinanceReportService = Depends(
         get_binance_report_service
     ),
+    ouinex_report_service: OuinexReportService = Depends(
+        get_ouinex_report_service
+    ),
 ):
     """
     Update an existing order entry in Google Sheets.
@@ -202,9 +228,13 @@ async def update_gsheet_order(
     This can either update an open position or close it.
     """
     try:
-        report_service: Union[BinanceReportService, ReportService]
+        report_service: Union[
+            BinanceReportService, OuinexReportService, ReportService
+        ]
         if request.account_id.startswith("binance_"):
             report_service = binance_report_service
+        elif request.account_id.startswith("ouinex_"):
+            report_service = ouinex_report_service
         else:
             report_service = saxo_report_service
 

--- a/api/services/ouinex_report_service.py
+++ b/api/services/ouinex_report_service.py
@@ -1,0 +1,243 @@
+from operator import attrgetter
+from typing import Dict, List, Optional
+
+from cachetools import TTLCache, cachedmethod
+
+from client.gsheet_client import GSheetClient
+from client.ouinex_client import OuinexClient
+from model import (
+    Account,
+    Currency,
+    Direction,
+    ReportOrder,
+    Signal,
+    Strategy,
+    crypto_account,
+)
+from saxo_order.service import calculate_currency, calculate_taxes
+from utils.configuration import Configuration
+from utils.logger import Logger
+
+logger = Logger.get_logger("ouinex_report_service")
+
+
+class OuinexReportService:
+    """Service for handling Ouinex trading report operations.
+
+    Mirrors BinanceReportService. Journal writes reuse the shared crypto
+    pseudo-account so Ouinex rows are indistinguishable from Binance rows
+    ("map as binance").
+    """
+
+    def __init__(self, client: OuinexClient, configuration: Configuration):
+        self.client = client
+        self.configuration = configuration
+        self.currencies_rate = configuration.currencies_rate
+        self.gsheet_client = GSheetClient(
+            key_path=configuration.gsheet_creds_path,
+            spreadsheet_id=configuration.spreadsheet_id,
+        )
+        # Cache for report data with 5 min TTL
+        self._report_cache: TTLCache[str, List[ReportOrder]] = TTLCache(
+            maxsize=128, ttl=300
+        )
+
+    def _get_ouinex_account(self) -> Account:
+        """
+        Return the shared crypto pseudo-account (the "map as binance"
+        identity).
+        """
+        return crypto_account()
+
+    @cachedmethod(cache=attrgetter("_report_cache"))
+    def get_orders_report(
+        self, account_id: str, from_date: str
+    ) -> List[ReportOrder]:
+        """
+        Get orders report for Ouinex from a given date.
+
+        Args:
+            account_id: Ouinex account ID (should be "ouinex_main")
+            from_date: Start date in YYYY-MM-DD format
+
+        Returns:
+            List of ReportOrder objects
+        """
+        logger.debug(
+            f"Cache MISS for get_orders_report({account_id}, {from_date}) "
+            f"- fetching from Ouinex API"
+        )
+        orders = self.client.get_report_all(
+            from_date, self.currencies_rate["usdeur"]
+        )
+
+        return orders
+
+    def convert_order_to_eur(
+        self, order: ReportOrder
+    ) -> tuple[float, float, Optional[float], Optional[float]]:
+        """
+        Convert order prices to EUR if needed.
+
+        Returns:
+            Tuple of (price_eur, total_eur, price_original, total_original)
+        """
+        if order.currency == Currency.EURO:
+            return (
+                order.price,
+                order.price * order.quantity,
+                None,
+                None,
+            )
+
+        # Convert to EUR
+        converted_order = calculate_currency(order, self.currencies_rate)
+        return (
+            converted_order.price,
+            converted_order.price * order.quantity,
+            order.price,
+            order.price * order.quantity,
+        )
+
+    def calculate_summary(self, orders: List[ReportOrder]) -> Dict:
+        """
+        Calculate summary statistics for orders.
+
+        Args:
+            orders: List of ReportOrder objects
+
+        Returns:
+            Dictionary with summary statistics
+        """
+        total_orders = len(orders)
+        total_volume_eur = 0.0
+        total_fees_eur = 0.0
+        buy_orders = 0
+        buy_volume_eur = 0.0
+        sell_orders = 0
+        sell_volume_eur = 0.0
+
+        for order in orders:
+            # Convert to EUR
+            price_eur, total_eur, _, _ = self.convert_order_to_eur(order)
+            total_volume_eur += total_eur
+
+            taxes = calculate_taxes(order)
+            total_fees_eur += taxes.cost + taxes.taxes
+
+            # Count by direction
+            if order.direction and order.direction == Direction.BUY:
+                buy_orders += 1
+                buy_volume_eur += total_eur
+            else:
+                sell_orders += 1
+                sell_volume_eur += total_eur
+
+        return {
+            "total_orders": total_orders,
+            "total_volume_eur": round(total_volume_eur, 2),
+            "total_fees_eur": round(total_fees_eur, 2),
+            "buy_orders": buy_orders,
+            "buy_volume_eur": round(buy_volume_eur, 2),
+            "sell_orders": sell_orders,
+            "sell_volume_eur": round(sell_volume_eur, 2),
+        }
+
+    def create_gsheet_order(
+        self,
+        account_id: str,
+        order: ReportOrder,
+        stop: Optional[float] = None,
+        objective: Optional[float] = None,
+        strategy: Strategy = None,  # type: ignore
+        signal: Signal = None,  # type: ignore
+        comment: Optional[str] = None,
+    ):
+        """
+        Create a new order entry in Google Sheets under the crypto identity.
+
+        Raises:
+            ValueError: If strategy or signal is not provided
+        """
+        if not strategy:
+            raise ValueError(
+                "Strategy is required when creating a new position"
+            )
+        if not signal:
+            raise ValueError("Signal is required when creating a new position")
+
+        account = self._get_ouinex_account()
+
+        # Update order with user inputs
+        order.stop = stop
+        order.objective = objective
+        order.strategy = strategy.value  # type: ignore
+        order.signal = signal.value  # type: ignore
+        order.comment = comment
+        order.open_position = True
+
+        # Calculate taxes
+        order.taxes = calculate_taxes(order)
+
+        # Convert to EUR if needed
+        report_order = calculate_currency(order, self.currencies_rate)
+        if not isinstance(report_order, ReportOrder):
+            raise TypeError(
+                "calculate_currency must return a ReportOrder for a "
+                "ReportOrder input"
+            )
+
+        # Create in Google Sheets
+        self.gsheet_client.create_order(
+            account=account, order=report_order, original_order=order
+        )
+
+    def update_gsheet_order(
+        self,
+        account_id: str,
+        order: ReportOrder,
+        line_number: int,
+        close: bool = False,
+        stopped: bool = False,
+        be_stopped: bool = False,
+        stop: Optional[float] = None,
+        objective: Optional[float] = None,
+        strategy: Optional[Strategy] = None,
+        signal: Optional[Signal] = None,
+        comment: Optional[str] = None,
+    ):
+        """
+        Update an existing order entry in Google Sheets.
+        """
+        # Update order with user inputs
+        if stop is not None:
+            order.stop = stop
+        if objective is not None:
+            order.objective = objective
+        if strategy is not None:
+            order.strategy = strategy.value  # type: ignore
+        if signal is not None:
+            order.signal = signal.value  # type: ignore
+        if comment is not None:
+            order.comment = comment
+
+        # Position is closed if close=True, regardless of stopped/be_stopped
+        order.open_position = not close
+        order.stopped = stopped
+        order.be_stopped = be_stopped
+        order.taxes = calculate_taxes(order)
+
+        # Convert to EUR if needed
+        report_order = calculate_currency(order, self.currencies_rate)
+        if not isinstance(report_order, ReportOrder):
+            raise TypeError(
+                "calculate_currency must return a ReportOrder for a "
+                "ReportOrder input"
+            )
+
+        # Update in Google Sheets
+        self.gsheet_client.update_order(
+            order=report_order,
+            original_order=order,
+            line_to_update=line_number,
+        )

--- a/client/ouinex_client.py
+++ b/client/ouinex_client.py
@@ -197,12 +197,15 @@ class OuinexClient:
             return
 
         fee_currency = trade.get("feeCurrency", "")
-        if order.direction == Direction.BUY and fee_currency == order.name:
-            order.quantity -= fee
-            order.taxes = Taxes(
-                cost=fee * (order.price * usdeur_rate), taxes=0
-            )
+        if fee_currency == order.name:
+            # Fee charged in the base asset (e.g. 0.539 XRP on an XRP buy):
+            # it reduces the quantity actually received and is valued in EUR
+            # at the trade price.
+            if order.direction == Direction.BUY:
+                order.quantity -= fee
+            order.taxes = Taxes(cost=fee * order.price * usdeur_rate, taxes=0)
         else:
+            # Fee charged in the quote/cash currency: already a cash amount.
             order.taxes = Taxes(cost=fee * usdeur_rate, taxes=0)
 
     def _map_trade_to_order(

--- a/client/ouinex_client.py
+++ b/client/ouinex_client.py
@@ -1,9 +1,11 @@
 import logging
 import time
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import requests
 
+from model import Currency, Direction, ReportOrder, Taxes
 from model.asset import Asset
 from model.enum import AssetType, Exchange
 from utils.exception import OuinexException
@@ -26,6 +28,22 @@ query Instruments {
     symbol
     baseCurrency
     quoteCurrency
+  }
+}
+"""
+
+CLOSED_ORDERS_QUERY = """
+query ClosedOrders($fromDate: String!) {
+  closedOrders(fromDate: $fromDate) {
+    symbol
+    baseCurrency
+    quoteCurrency
+    side
+    price
+    quantity
+    fee
+    feeCurrency
+    executedAt
   }
 }
 """
@@ -164,3 +182,83 @@ class OuinexClient:
                 results.append(self._map_instrument_to_asset(instrument))
 
         return results
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(value / 1000)
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+    def _apply_commission(
+        self, trade: Dict[str, Any], order: ReportOrder, usdeur_rate: float
+    ) -> None:
+        fee = float(trade.get("fee") or 0)
+        if fee <= 0:
+            order.taxes = Taxes(cost=0, taxes=0)
+            return
+
+        fee_currency = trade.get("feeCurrency", "")
+        if order.direction == Direction.BUY and fee_currency == order.name:
+            order.quantity -= fee
+            order.taxes = Taxes(
+                cost=fee * (order.price * usdeur_rate), taxes=0
+            )
+        else:
+            order.taxes = Taxes(cost=fee * usdeur_rate, taxes=0)
+
+    def _map_trade_to_order(
+        self, trade: Dict[str, Any], usdeur_rate: float
+    ) -> ReportOrder:
+        base = trade.get("baseCurrency", "")
+        side = (trade.get("side") or "").upper()
+        direction = Direction.BUY if side == "BUY" else Direction.SELL
+        order = ReportOrder(
+            code=base,
+            name=base,
+            price=float(trade["price"]),
+            quantity=float(trade["quantity"]),
+            direction=direction,
+            asset_type=AssetType.CRYPTO,
+            date=self._parse_timestamp(trade["executedAt"]),
+            currency=Currency.USD,
+        )
+        self._apply_commission(trade, order, usdeur_rate)
+        return order
+
+    def get_report_all(
+        self, date: str, usdeur_rate: float
+    ) -> List[ReportOrder]:
+        """
+        Get all closed Ouinex orders since `date`, mapped to ReportOrder.
+
+        Args:
+            date: Start date (as accepted by the Ouinex `closedOrders` query)
+            usdeur_rate: USD→EUR rate used for commission conversion
+
+        Returns:
+            List of ReportOrder objects (asset_type=CRYPTO, currency=USD)
+        """
+        data = self._execute(CLOSED_ORDERS_QUERY, {"fromDate": date})
+        return [
+            self._map_trade_to_order(trade, usdeur_rate)
+            for trade in data.get("closedOrders", [])
+        ]
+
+    def get_report(
+        self, symbol: str, date: str, usdeur_rate: float
+    ) -> List[ReportOrder]:
+        """
+        Get closed Ouinex orders for a single symbol since `date`.
+
+        Args:
+            symbol: Base currency code to filter on (e.g. "BTC")
+            date: Start date (as accepted by the Ouinex `closedOrders` query)
+            usdeur_rate: USD→EUR rate used for commission conversion
+
+        Returns:
+            List of ReportOrder objects for the given symbol
+        """
+        return [
+            order
+            for order in self.get_report_all(date, usdeur_rate)
+            if order.code == symbol
+        ]

--- a/saxo_order/commands/k_order.py
+++ b/saxo_order/commands/k_order.py
@@ -8,6 +8,7 @@ import saxo_order.commands.binance as binance_commands
 import saxo_order.commands.fundamental as get_score
 import saxo_order.commands.get_report as get_report
 import saxo_order.commands.internal as internal_command
+import saxo_order.commands.ouinex as ouinex_commands
 import saxo_order.commands.search as search
 import saxo_order.commands.set_oco_order as set_oco_order
 import saxo_order.commands.set_order as set_order
@@ -93,6 +94,12 @@ def binance(ctx: Context):
 
 @click.group()
 @click.pass_context
+def ouinex(ctx: Context):
+    pass
+
+
+@click.group()
+@click.pass_context
 def internal(ctx: Context):
     pass
 
@@ -100,6 +107,7 @@ def internal(ctx: Context):
 k_order.add_command(set)
 k_order.add_command(shortcut)
 k_order.add_command(binance)
+k_order.add_command(ouinex)
 k_order.add_command(internal)
 k_order.add_command(workflow)
 
@@ -127,6 +135,8 @@ shortcut.add_command(shortcurts.nikkei)
 
 binance.add_command(binance_commands.get_report)
 binance.add_command(binance_commands.get_stacking_report)
+
+ouinex.add_command(ouinex_commands.get_report)
 
 internal.add_command(internal_command.refresh_stocks_list)
 internal.add_command(internal_command.technical)

--- a/saxo_order/commands/ouinex.py
+++ b/saxo_order/commands/ouinex.py
@@ -1,0 +1,107 @@
+import click
+from click.core import Context
+
+from api.services.ouinex_report_service import OuinexReportService
+from client.ouinex_client import OuinexClient
+from saxo_order.commands import catch_exception
+from saxo_order.commands.binance import show_report
+from saxo_order.commands.input_helper import update_order
+from utils.configuration import Configuration
+from utils.exception import SaxoException
+from utils.logger import Logger
+
+logger = Logger.get_logger("ouinex")
+
+
+@click.command
+@click.option(
+    "--from-date",
+    type=str,
+    required=True,
+    help="What is the start date",
+    prompt="What is the start date ? (YYYY/MM/DD)",
+)
+@click.option(
+    "--update-gsheet",
+    type=bool,
+    required=True,
+    help="Do you want to update the gsheet ?",
+    prompt="Do you want to update the gsheet ?",
+)
+@click.pass_context
+@catch_exception(handle=SaxoException)
+def get_report(ctx: Context, from_date: str, update_gsheet: bool):
+    configuration = Configuration(ctx.obj["config"])
+    client = OuinexClient(
+        configuration.ouinex_keys[0],
+        configuration.ouinex_keys[1],
+        configuration.ouinex_graphql_url,
+    )
+
+    report_service = OuinexReportService(client, configuration)
+    orders = report_service.get_orders_report("ouinex_main", from_date)
+
+    if len(orders) == 0:
+        print("No order to report")
+        exit(0)
+    show_report(orders, configuration.currencies_rate)
+    if update_gsheet:
+        while True:
+            index = click.prompt("Which row to manage (0 = exit) ? ", type=int)
+            if index == 0:
+                return
+            create_or_update = click.prompt(
+                "Create or update ?", type=click.Choice(["c", "u"])
+            )
+            order = orders[index - 1]
+            if create_or_update == "c":
+                update_order(
+                    order=order, conditional_order=None, validate_input=False
+                )
+                report_service.create_gsheet_order(
+                    account_id="ouinex_main",
+                    order=order,
+                    stop=order.stop,
+                    objective=order.objective,
+                    strategy=order.strategy,
+                    signal=order.signal,
+                    comment=order.comment,
+                )
+            else:
+                line_to_update = click.prompt(
+                    "Which line needs to be updated ?", type=int
+                )
+                order.open_position = click.prompt(
+                    "This update open a position ?", type=bool, default=False
+                )
+                if order.open_position:
+                    update_order(
+                        order=order,
+                        conditional_order=None,
+                        validate_input=False,
+                    )
+                else:
+                    order.stopped = click.prompt(
+                        "Has the order been stopped ?",
+                        type=bool,
+                        default=False,
+                    )
+                    order.be_stopped = click.prompt(
+                        "Has the order been BE stopped ?",
+                        type=bool,
+                        default=False,
+                    )
+                report_service.update_gsheet_order(
+                    account_id="ouinex_main",
+                    order=order,
+                    line_number=line_to_update,
+                    close=not order.open_position,
+                    stopped=order.stopped,
+                    be_stopped=order.be_stopped,
+                    stop=order.stop,
+                    objective=order.objective,
+                    strategy=order.strategy,
+                    signal=order.signal,
+                    comment=order.comment,
+                )
+            show_report(orders, configuration.currencies_rate)

--- a/tests/api/routers/test_report.py
+++ b/tests/api/routers/test_report.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import (
+    get_binance_report_service,
+    get_ouinex_report_service,
+    get_report_service,
+)
+from api.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_report_services():
+    """Override the three report services with mocks returning no orders."""
+    saxo = MagicMock()
+    saxo.get_orders_report.return_value = []
+    binance = MagicMock()
+    binance.get_orders_report.return_value = []
+    ouinex = MagicMock()
+    ouinex.get_orders_report.return_value = []
+
+    app.dependency_overrides[get_report_service] = lambda: saxo
+    app.dependency_overrides[get_binance_report_service] = lambda: binance
+    app.dependency_overrides[get_ouinex_report_service] = lambda: ouinex
+    yield saxo, binance, ouinex
+    app.dependency_overrides.clear()
+
+
+class TestReportRouting:
+    def test_ouinex_account_selects_ouinex_service(self, mock_report_services):
+        saxo, binance, ouinex = mock_report_services
+
+        response = client.get(
+            "/api/report/orders",
+            params={"account_id": "ouinex_main", "from_date": "2024-01-01"},
+        )
+
+        assert response.status_code == 200
+        ouinex.get_orders_report.assert_called_once_with(
+            "ouinex_main", "2024-01-01"
+        )
+        binance.get_orders_report.assert_not_called()
+        saxo.get_orders_report.assert_not_called()
+
+    def test_binance_account_selects_binance_service(
+        self, mock_report_services
+    ):
+        saxo, binance, ouinex = mock_report_services
+
+        response = client.get(
+            "/api/report/orders",
+            params={"account_id": "binance_main", "from_date": "2024-01-01"},
+        )
+
+        assert response.status_code == 200
+        binance.get_orders_report.assert_called_once_with(
+            "binance_main", "2024-01-01"
+        )
+        ouinex.get_orders_report.assert_not_called()
+        saxo.get_orders_report.assert_not_called()
+
+    def test_saxo_account_selects_saxo_service(self, mock_report_services):
+        saxo, binance, ouinex = mock_report_services
+
+        response = client.get(
+            "/api/report/orders",
+            params={"account_id": "12345", "from_date": "2024-01-01"},
+        )
+
+        assert response.status_code == 200
+        saxo.get_orders_report.assert_called_once_with("12345", "2024-01-01")
+        binance.get_orders_report.assert_not_called()
+        ouinex.get_orders_report.assert_not_called()

--- a/tests/api/services/test_ouinex_report_service.py
+++ b/tests/api/services/test_ouinex_report_service.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from api.services.ouinex_report_service import OuinexReportService
+from model import (
+    AssetType,
+    Currency,
+    Direction,
+    ReportOrder,
+    Signal,
+    Strategy,
+    crypto_account,
+)
+
+
+def _make_service() -> OuinexReportService:
+    configuration = MagicMock()
+    configuration.currencies_rate = {"usdeur": 0.5}
+    configuration.gsheet_creds_path = "creds.json"
+    configuration.spreadsheet_id = "sheet-id"
+
+    with patch("api.services.ouinex_report_service.GSheetClient"):
+        service = OuinexReportService(MagicMock(), configuration)
+    service.gsheet_client = MagicMock()
+    return service
+
+
+def _make_order() -> ReportOrder:
+    return ReportOrder(
+        code="BTC",
+        name="BTC",
+        price=50000,
+        quantity=0.1,
+        direction=Direction.BUY,
+        asset_type=AssetType.CRYPTO,
+        date=datetime(2023, 1, 1),
+        currency=Currency.USD,
+    )
+
+
+class TestOuinexReportServiceMapAsBinance:
+    def test_create_gsheet_order_uses_binance_identity(self):
+        service = _make_service()
+        order = _make_order()
+
+        service.create_gsheet_order(
+            account_id="ouinex_main",
+            order=order,
+            strategy=Strategy.YOLO,
+            signal=Signal.NONE,
+        )
+
+        service.gsheet_client.create_order.assert_called_once()
+        account = service.gsheet_client.create_order.call_args.kwargs[
+            "account"
+        ]
+        assert account == crypto_account()
+        assert account.name == "Coinbase"
+        assert account.key == "binance"

--- a/tests/client/test_ouinex_client.py
+++ b/tests/client/test_ouinex_client.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from client.ouinex_client import OuinexClient
-from model.enum import AssetType, Exchange
+from model.enum import AssetType, Currency, Direction, Exchange
 from utils.exception import OuinexException
 
 
@@ -207,3 +207,78 @@ class TestOuinexClientSearch:
 
         assert {asset.symbol for asset in results} == {"BTCUSD", "ETHUSD"}
         assert all(asset.exchange == Exchange.OUINEX for asset in results)
+
+
+CLOSED_ORDERS_OK = {
+    "data": {
+        "closedOrders": [
+            {
+                "symbol": "BTCUSD",
+                "baseCurrency": "BTC",
+                "quoteCurrency": "USD",
+                "side": "BUY",
+                "price": 50000,
+                "quantity": 0.1,
+                "fee": 0.001,
+                "feeCurrency": "BTC",
+                "executedAt": 1700000000000,
+            },
+            {
+                "symbol": "ETHUSD",
+                "baseCurrency": "ETH",
+                "quoteCurrency": "USD",
+                "side": "SELL",
+                "price": 3000,
+                "quantity": 2,
+                "fee": 1.5,
+                "feeCurrency": "USD",
+                "executedAt": 1700000000000,
+            },
+        ]
+    }
+}
+
+
+class TestOuinexClientReport:
+    def test_get_report_all_maps_trades(
+        self, client_and_session: Tuple[OuinexClient, MagicMock]
+    ):
+        client, session = client_and_session
+        session.post.side_effect = [
+            make_response(200, SIGN_IN_OK),
+            make_response(200, CLOSED_ORDERS_OK),
+        ]
+
+        orders = client.get_report_all("2023/01/01", usdeur_rate=0.5)
+
+        assert len(orders) == 2
+
+        buy = orders[0]
+        assert buy.code == "BTC"
+        assert buy.direction == Direction.BUY
+        assert buy.asset_type == AssetType.CRYPTO
+        assert buy.currency == Currency.USD
+        # Buy fee paid in base asset reduces quantity
+        assert buy.quantity == pytest.approx(0.099)
+        assert buy.taxes is not None
+        assert buy.taxes.cost == pytest.approx(0.001 * (50000 * 0.5))
+
+        sell = orders[1]
+        assert sell.direction == Direction.SELL
+        # Sell fee paid in quote currency -> EUR cost
+        assert sell.taxes is not None
+        assert sell.taxes.cost == pytest.approx(1.5 * 0.5)
+
+    def test_get_report_filters_by_symbol(
+        self, client_and_session: Tuple[OuinexClient, MagicMock]
+    ):
+        client, session = client_and_session
+        session.post.side_effect = [
+            make_response(200, SIGN_IN_OK),
+            make_response(200, CLOSED_ORDERS_OK),
+        ]
+
+        orders = client.get_report("ETH", "2023/01/01", usdeur_rate=0.5)
+
+        assert len(orders) == 1
+        assert orders[0].code == "ETH"

--- a/tests/client/test_ouinex_client.py
+++ b/tests/client/test_ouinex_client.py
@@ -269,6 +269,42 @@ class TestOuinexClientReport:
         assert sell.taxes is not None
         assert sell.taxes.cost == pytest.approx(1.5 * 0.5)
 
+    def test_buy_fee_in_base_asset_reduces_quantity_and_costs_eur(
+        self, client_and_session: Tuple[OuinexClient, MagicMock]
+    ):
+        # Real example: buy 550 XRP @ 1.1430 USDC, fee 0.5390 XRP.
+        # Final quantity received is 550 - 0.539 = 549.461 XRP and the fee
+        # is reported in EUR at the trade price.
+        client, session = client_and_session
+        xrp_trade = {
+            "data": {
+                "closedOrders": [
+                    {
+                        "symbol": "XRP/USDC",
+                        "baseCurrency": "XRP",
+                        "quoteCurrency": "USDC",
+                        "side": "BUY",
+                        "price": 1.1430,
+                        "quantity": 550,
+                        "fee": 0.5390,
+                        "feeCurrency": "XRP",
+                        "executedAt": 1700000000000,
+                    }
+                ]
+            }
+        }
+        session.post.side_effect = [
+            make_response(200, SIGN_IN_OK),
+            make_response(200, xrp_trade),
+        ]
+
+        orders = client.get_report_all("2023/01/01", usdeur_rate=0.9)
+
+        order = orders[0]
+        assert order.quantity == pytest.approx(549.461)
+        assert order.taxes is not None
+        assert order.taxes.cost == pytest.approx(0.5390 * 1.1430 * 0.9)
+
     def test_get_report_filters_by_symbol(
         self, client_and_session: Tuple[OuinexClient, MagicMock]
     ):


### PR DESCRIPTION
## Summary

Implements **phase 6** of spec [024-ouinex-provider](specs/024-ouinex-provider/) — **User Story 4**: report Ouinex trading activity into the Google Sheet journal under the existing Binance identity ("map as binance"). Independent of US3 (indicators) — it only needs the foundational `OuinexClient` and the shared `crypto_account()` factory, both already on `main`.

## Changes

- **`client/ouinex_client.py`** — `get_report(symbol, date, usdeur_rate)` and `get_report_all(date, usdeur_rate)`: fetch closed Ouinex orders via the `closedOrders` GraphQL query and map each to `ReportOrder` (`asset_type=CRYPTO`, `currency=USD`, direction, commission). Commission handling mirrors Binance: a buy fee paid in the base asset reduces quantity and is costed in EUR; a quote-currency fee is costed directly. Timestamp/commission/mapping isolated in private helpers.
- **`api/services/ouinex_report_service.py`** (new) — mirrors `BinanceReportService` (TTLCache 128/300s; `get_orders_report`, `convert_order_to_eur`, `calculate_summary`, `create_gsheet_order`, `update_gsheet_order`) and writes every journal row using the shared `crypto_account()` factory — so Ouinex rows are byte-for-byte indistinguishable from Binance rows.
- **`api/dependencies.py`** — cached `get_ouinex_report_service()`.
- **`api/routers/report.py`** — route `account_id` starting with `"ouinex_"` → `OuinexReportService` in all four handlers (orders, summary, gsheet create, gsheet update); `binance_`/Saxo routing unchanged.
- **`saxo_order/commands/ouinex.py`** (new) + registration — `k-order ouinex get-report` CLI mirroring the Binance command (reuses its `show_report`).

## Tests
- `tests/client/test_ouinex_client.py` — `get_report_all`/`get_report` map trades to `ReportOrder` with correct direction, currency, quantity-after-fee, and commission cost; `get_report` filters by symbol.
- `tests/api/services/test_ouinex_report_service.py` — the core "map as binance" guarantee: `create_gsheet_order` passes an `Account` equal to `crypto_account()` (`name="Coinbase"`, `key="binance"`) to `GSheetClient.create_order`.
- `tests/api/routers/test_report.py` — `account_id="ouinex_main"` selects `OuinexReportService`; `binance_main` still selects `BinanceReportService`; numeric Saxo ids select the Saxo service.

## Verification
- Full suite: **474 passed, 10 skipped**
- `black`, `isort`, `flake8` clean; full-repo `mypy` clean (165 files) — run as CI does

## Notes
- The `closedOrders` GraphQL field shapes (side, price, quantity, fee, feeCurrency, executedAt, base/quote currency) remain a VERIFY item (research R3) — implemented to the documented assumption and isolated in `_map_trade_to_order` / `_apply_commission` for easy adjustment once the real schema is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ST1dwao7yrcydK61shAquo)_