### PR TITLE
feat: add daily ADX(14) regime column to backtest range CSV

### DIFF
--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -60,6 +60,7 @@ class DayResultSummaryResponse(BaseModel):
     h1_high: Optional[float] = None
     h1_low: Optional[float] = None
     mm50_slope: Optional[float] = None
+    adx14: Optional[float] = None
 
 
 class BacktestSummaryResponse(BaseModel):
@@ -135,6 +136,7 @@ def _day_result_summary_to_response(
         h1_high=summary.h1_high,
         h1_low=summary.h1_low,
         mm50_slope=summary.mm50_slope,
+        adx14=summary.adx14,
     )
 
 
@@ -200,6 +202,7 @@ def backtest_run_result_to_csv(
             "h1_low",
             "h1_range",
             "mm50_slope",
+            "adx14",
         ]
     )
     for day in run_result.days:
@@ -218,6 +221,7 @@ def backtest_run_result_to_csv(
                 day.h1_low,
                 h1_range,
                 day.mm50_slope,
+                day.adx14,
             ]
         )
     return output.getvalue()

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -18,7 +18,11 @@ from model import (
 )
 from model.enum import DayStatus, Direction, ExitReason
 from services.candles_service import CandlesService
-from services.indicator_service import mobile_average, slope_percentage
+from services.indicator_service import (
+    adx,
+    mobile_average,
+    slope_percentage,
+)
 from utils.exception import SaxoException
 from utils.helper import market_in_utc
 from utils.logger import Logger
@@ -30,6 +34,11 @@ PARIS_TZ = ZoneInfo("Europe/Paris")
 # candles are required before a day can be scored.
 MM50_MIN_DAILY_CANDLES = 60
 MM50_SLOPE_LOOKBACK = 10
+
+# Daily ADX regime measure: Wilder's double smoothing needs period * 3
+# prior daily candles (matches services.indicator_service.adx).
+ADX_PERIOD = 14
+ADX_MIN_DAILY_CANDLES = ADX_PERIOD * 3
 
 BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
     BacktestDefinition(
@@ -422,6 +431,7 @@ class BacktestService:
                         mm50_slope=self._mm50_slope_before(
                             daily_candles, day_result.date
                         ),
+                        adx14=self._adx_before(daily_candles, day_result.date),
                     )
                 )
                 all_trades.extend(day_result.trades)
@@ -576,6 +586,24 @@ class BacktestService:
         ma50_last = mobile_average(prior, 50)
         ma50_first = mobile_average(prior[MM50_SLOPE_LOOKBACK:], 50)
         return slope_percentage(0, ma50_first, MM50_SLOPE_LOOKBACK, ma50_last)
+
+    @staticmethod
+    def _adx_before(
+        daily_candles: List[Candle], trading_date: datetime.date
+    ) -> Optional[float]:
+        """Daily ADX(14) as of the last close strictly before trading_date
+        (lookahead-safe, same window discipline as _mm50_slope_before).
+        Returns None when fewer than ADX_MIN_DAILY_CANDLES prior daily
+        candles are available."""
+        prior = [
+            candle
+            for candle in daily_candles
+            if candle.date is not None and candle.date.date() < trading_date
+        ]
+        if len(prior) < ADX_MIN_DAILY_CANDLES:
+            return None
+        prior.sort(key=_candle_date, reverse=True)
+        return adx(prior, ADX_PERIOD)
 
     def _evaluate_trades(
         self,

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -71,6 +71,10 @@ class DayResultSummary:
     # trend/chop regime measure, lookahead-safe and config-independent.
     # None when fewer than 60 prior daily candles are available.
     mm50_slope: Optional[float] = None
+    # Daily ADX(14) as of the close strictly before this day - a
+    # direction-agnostic trend/chop strength measure, lookahead-safe and
+    # config-independent. None when fewer than 42 prior daily candles exist.
+    adx14: Optional[float] = None
 
 
 @dataclass

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -435,6 +435,72 @@ def true_range(candles: List[Candle]) -> float:
     return max(tr, tr2, tr3)
 
 
+def _directional_index(atr: float, plus_sm: float, minus_sm: float) -> float:
+    """DX from Wilder-smoothed TR/+DM/-DM sums (guards zero denominators)."""
+    if atr == 0:
+        return 0.0
+    plus_di = 100 * plus_sm / atr
+    minus_di = 100 * minus_sm / atr
+    denominator = plus_di + minus_di
+    if denominator == 0:
+        return 0.0
+    return 100 * abs(plus_di - minus_di) / denominator
+
+
+def adx(candles: List[Candle], period: int = 14) -> float:
+    """Wilder's Average Directional Index - a direction-agnostic trend/chop
+    strength measure (high = trending, low = chopping).
+
+    Candles are newest-first (index 0 is the most recent), matching the rest
+    of this module. Returns the latest ADX value. Needs period * 3 candles
+    for the double Wilder smoothing (the same minimum as average_true_range).
+    """
+    if len(candles) < period * 3:
+        Logger.get_logger("adx").error(
+            f"Missing candles to calculate an adx {len(candles)},"
+            f" needed {period * 3}"
+        )
+        raise SaxoException("Missing candles")
+    true_ranges: List[float] = []
+    plus_dms: List[float] = []
+    minus_dms: List[float] = []
+    for i in range(0, len(candles) - 1):
+        current = candles[i]
+        previous = candles[i + 1]
+        up_move = current.higher - previous.higher
+        down_move = previous.lower - current.lower
+        plus_dms.append(
+            up_move if up_move > down_move and up_move > 0 else 0.0
+        )
+        minus_dms.append(
+            down_move if down_move > up_move and down_move > 0 else 0.0
+        )
+        true_ranges.append(true_range(candles[i:]))
+    # reverse to chronological (oldest-first) for forward Wilder smoothing
+    true_ranges.reverse()
+    plus_dms.reverse()
+    minus_dms.reverse()
+
+    atr = sum(true_ranges[:period])
+    plus_sm = sum(plus_dms[:period])
+    minus_sm = sum(minus_dms[:period])
+    directional_indices: List[float] = [
+        _directional_index(atr, plus_sm, minus_sm)
+    ]
+    for i in range(period, len(true_ranges)):
+        atr = atr - atr / period + true_ranges[i]
+        plus_sm = plus_sm - plus_sm / period + plus_dms[i]
+        minus_sm = minus_sm - minus_sm / period + minus_dms[i]
+        directional_indices.append(_directional_index(atr, plus_sm, minus_sm))
+
+    adx_value = sum(directional_indices[:period]) / period
+    for i in range(period, len(directional_indices)):
+        adx_value = (
+            adx_value * (period - 1) + directional_indices[i]
+        ) / period
+    return round(adx_value, 5)
+
+
 def inside_bar(candles: List[Candle]) -> bool:
     if len(candles) < 2:
         Logger.get_logger("inside_bar").error(

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -368,6 +368,7 @@ class TestGetBacktestRunCsv:
                     h1_high=8050.0,
                     h1_low=8000.0,
                     mm50_slope=1.2345,
+                    adx14=27.5,
                 )
             ],
         )
@@ -392,9 +393,11 @@ class TestGetBacktestRunCsv:
         assert "stop_loss_points,50" in body
         assert (
             "date,status,trade_count,points,h1_high,h1_low,h1_range,"
-            "mm50_slope" in body
+            "mm50_slope,adx14" in body
         )
-        assert "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0,1.2345" in body
+        assert (
+            "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0,1.2345,27.5" in body
+        )
 
     def test_end_before_start_returns_400(self, mock_backtest_service):
         mock_backtest_service.get_definition.return_value = MagicMock(

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -1268,3 +1268,32 @@ class TestRunRangeThreadsRegime:
         assert len(result.days) == 1
         assert result.days[0].mm50_slope is not None
         assert result.days[0].mm50_slope > 0
+        assert result.days[0].adx14 is not None
+        assert result.days[0].adx14 > 0
+
+
+class TestAdxBefore:
+    TRADING_DATE = datetime.date(2026, 6, 2)
+
+    def test_none_when_fewer_than_42_prior_candles(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 41)
+        assert BacktestService._adx_before(series, self.TRADING_DATE) is None
+
+    def test_high_adx_for_uptrend(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 60)
+        value = BacktestService._adx_before(series, self.TRADING_DATE)
+        assert value is not None and value > 40
+
+    def test_ignores_today_and_future_candles(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 60)
+        baseline = BacktestService._adx_before(series, self.TRADING_DATE)
+        polluted = series + [
+            daily_candle(self.TRADING_DATE, close=0.0),
+            daily_candle(
+                self.TRADING_DATE + datetime.timedelta(days=1), close=99999.0
+            ),
+        ]
+        assert (
+            BacktestService._adx_before(polluted, self.TRADING_DATE)
+            == baseline
+        )

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -12,6 +12,7 @@ from model import (
     UnitTime,
 )
 from services.indicator_service import (
+    adx,
     apply_linear_function,
     average_true_range,
     bollinger_bands,
@@ -26,6 +27,7 @@ from services.indicator_service import (
     number_of_day_between_dates,
     slope_percentage,
 )
+from utils.exception import SaxoException
 
 
 def _make_candles(closes: List[float]) -> List[Candle]:
@@ -683,3 +685,60 @@ class TestIndicatorService:
     def test_mm50_touch_returns_none_when_fewer_than_sixty_candles(self):
         candles = _make_candles([100.0] * 59)
         assert mm50_touch(candles) is None
+
+
+def _trending_daily(count: int, step: float = 5.0) -> List[Candle]:
+    """Newest-first steady uptrend: the more recent the bar (smaller
+    index), the higher its price."""
+    base = datetime.datetime(2026, 1, 1)
+    candles = []
+    for i in range(count):
+        close = 8000 + step * (count - i)
+        candles.append(
+            Candle(
+                lower=close - 2,
+                higher=close + 2,
+                open=close,
+                close=close,
+                ut=UnitTime.D,
+                date=base - datetime.timedelta(days=i),
+            )
+        )
+    return candles
+
+
+def _choppy_daily(count: int) -> List[Candle]:
+    """Newest-first sideways chop: close alternates around a flat mean, so
+    +DM and -DM roughly cancel and ADX stays low."""
+    base = datetime.datetime(2026, 1, 1)
+    candles = []
+    for i in range(count):
+        close = 8000 + (3 if i % 2 == 0 else -3)
+        candles.append(
+            Candle(
+                lower=close - 2,
+                higher=close + 2,
+                open=close,
+                close=close,
+                ut=UnitTime.D,
+                date=base - datetime.timedelta(days=i),
+            )
+        )
+    return candles
+
+
+class TestAdx:
+    def test_high_for_strong_uptrend(self):
+        # a one-directional trend drives DX toward 100
+        assert adx(_trending_daily(60)) > 40
+
+    def test_low_for_chop(self):
+        assert adx(_choppy_daily(60)) < 25
+
+    def test_trend_scores_higher_than_chop(self):
+        assert adx(_trending_daily(60)) > adx(_choppy_daily(60))
+
+    def test_raises_when_insufficient_candles(self):
+        # period * 3 = 42 required; 41 is one short
+        with pytest.raises(SaxoException):
+            adx(_trending_daily(41))


### PR DESCRIPTION
## What

Adds an `adx14` column to the `/api/backtest/run/csv` day rows: Wilder's **ADX(14)** on the daily close, as of the close **strictly before** each trading day. New `adx()` in `services/indicator_service.py` (reuses `true_range`, matches the newest-first / `period*3` conventions of `average_true_range`); `run_range` computes it per day and threads it through `DayResultSummary` into the CSV and the JSON `/run` response.

Header now:
```
date,status,trade_count,points,h1_high,h1_low,h1_range,mm50_slope,adx14
```

## Why

Next measure in the B9H regime-filter investigation (`backtests/b9h-stop-loss-analysis.md`). The MM50-slope gate (#657) was rejected — it not only failed the both-windows bar but **inverted sign** between windows (flat 50-day slope was the worst bucket in 2025 H2 and the best in 2026 H1). ADX is chosen specifically against *why* MM50 failed:

- **~14-day horizon** instead of the laggy 50-day MA.
- **Different property:** directional *persistence* (trend strength), not an MA-slope level and not the raw 9h range already rejected.
- It is the textbook direction-agnostic trend/chop classifier (fits B9H being long+short).

## Design notes

- **Lookahead-safe:** the ADX window uses only daily bars dated `< trading_date`, identical discipline to `mm50_slope` (a test pollutes the series with same-day and future candles and asserts the value is unchanged).
- **Config-independent**, like `h1_range`/`mm50_slope` — one export per window feeds any parameter run's analysis.
- **Graceful degradation:** `None` when fewer than `14*3 = 42` prior daily candles exist (the existing daily fetch already provides a 60+ day lead-in).
- Raw ADX exported; the threshold/gate stays in analysis (planned bar: ADX 20/25/30, must improve both windows).

## Tests

- `adx()`: high on a strong uptrend, low on chop, trend > chop, and raises on insufficient candles.
- `_adx_before`: None below 42 prior candles; lookahead safety.
- `run_range` threads `adx14` onto the summary.
- Router CSV header + value.
- Full suite green (475 passed, 10 skipped); black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)