### PR TITLE
feat: add 9h open and overnight gap columns to backtest range CSV

### DIFF
--- a/api/models/backtest.py
+++ b/api/models/backtest.py
@@ -61,6 +61,8 @@ class DayResultSummaryResponse(BaseModel):
     h1_low: Optional[float] = None
     mm50_slope: Optional[float] = None
     adx14: Optional[float] = None
+    h1_open: Optional[float] = None
+    overnight_gap: Optional[float] = None
 
 
 class BacktestSummaryResponse(BaseModel):
@@ -137,6 +139,8 @@ def _day_result_summary_to_response(
         h1_low=summary.h1_low,
         mm50_slope=summary.mm50_slope,
         adx14=summary.adx14,
+        h1_open=summary.h1_open,
+        overnight_gap=summary.overnight_gap,
     )
 
 
@@ -203,6 +207,8 @@ def backtest_run_result_to_csv(
             "h1_range",
             "mm50_slope",
             "adx14",
+            "h1_open",
+            "overnight_gap",
         ]
     )
     for day in run_result.days:
@@ -222,6 +228,8 @@ def backtest_run_result_to_csv(
                 h1_range,
                 day.mm50_slope,
                 day.adx14,
+                day.h1_open,
+                day.overnight_gap,
             ]
         )
     return output.getvalue()

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -387,6 +387,7 @@ class BacktestService:
             status=status,
             h1_high=h1_high,
             h1_low=h1_low,
+            h1_open=h1_candle.open,
             candles=chronological,
             trades=trades,
         )
@@ -432,6 +433,12 @@ class BacktestService:
                             daily_candles, day_result.date
                         ),
                         adx14=self._adx_before(daily_candles, day_result.date),
+                        h1_open=day_result.h1_open,
+                        overnight_gap=self._overnight_gap(
+                            daily_candles,
+                            day_result.date,
+                            day_result.h1_open,
+                        ),
                     )
                 )
                 all_trades.extend(day_result.trades)
@@ -604,6 +611,29 @@ class BacktestService:
             return None
         prior.sort(key=_candle_date, reverse=True)
         return adx(prior, ADX_PERIOD)
+
+    @staticmethod
+    def _overnight_gap(
+        daily_candles: List[Candle],
+        trading_date: datetime.date,
+        h1_open: Optional[float],
+    ) -> Optional[float]:
+        """Overnight gap = 9h open - the prior daily close. A same-day,
+        pre-trade shock signal (the 9h open is known at 09:00, before any
+        entry). Lookahead-safe: the prior close is the latest daily candle
+        strictly before trading_date. None when the 9h open or a prior
+        daily candle is missing."""
+        if h1_open is None:
+            return None
+        prior = [
+            candle
+            for candle in daily_candles
+            if candle.date is not None and candle.date.date() < trading_date
+        ]
+        if not prior:
+            return None
+        prior_close = max(prior, key=_candle_date).close
+        return round(h1_open - prior_close, 4)
 
     def _evaluate_trades(
         self,

--- a/backtests/b9h-stop-loss-analysis.md
+++ b/backtests/b9h-stop-loss-analysis.md
@@ -249,25 +249,81 @@ The MM50 failure is diagnostic: stop testing slow trailing trend, and try a
 measure that (a) reacts on a shorter horizon and (b) captures a *different*
 property than a moving-average level.
 
-## Next step (spec): ADX(14) daily gate column
+## Regime filter #3: daily ADX(14) — tested, rejected (same inversion + no shared band)
 
-The next measure to test, chosen against *why* MM50 failed:
+The direction-agnostic trend/chop classifier (`adx14` column, PR #661),
+computed lookahead-safe from daily bars strictly before each day. Gate
+tested at the pre-committed ADX ∈ {20, 25, 30}, vs unfiltered
+(H2 +41, H1 +416):
 
-- **Measure:** ADX(14) on the daily close (direction-agnostic trend/chop
-  classifier). Rationale: (a) ~2–3 week horizon fixes the MM50 lag; (b) it
-  measures directional *persistence*, a different property than the MA-slope
-  level and the 9h raw range already rejected; (c) it is the textbook
-  trend/chop indicator. Needs new Wilder-smoothing code (DI+/DI−/ADX).
-  Alternatives, ranked lower: MM20/MM7 slope (cheap, isolates the lag
-  variable only), daily ATR/range-expansion (risks re-testing the 9h-range
-  volatility axis).
-- **Lookahead safety (critical):** compute strictly from daily bars *before*
-  the trading day, exactly as `mm50_slope` does.
-- **Where:** additive export column `adx14`, mirroring how `mm50_slope` is
-  fetched in `run_range` and threaded through `DayResultSummary` → CSV.
-- **Acceptance bar (unchanged):** lock the threshold on one window, test the
-  other; ≤3 conventional thresholds (ADX 20/25/30); require improvement in
-  **both** windows on total P&L. Helps-one-hurts-the-other is rejected.
+| T | 2025 H2 | 2026 H1 |
+|---|---|---|
+| 20 | 0.0 (drops all 126) | −37 |
+| 25 | 0.0 (drops all 126) | −49 |
+| 30 | 0.0 (drops all 126) | +70 |
+
+Improves **neither** window at any threshold. Rejected. Two structural
+problems:
+
+1. **The windows occupy different ADX bands.** ADX range is 8–34 (median
+   14.7), and **2025 H2 never reaches ADX 20**. So an absolute "trend gate"
+   doesn't filter H2 — it deletes the entire window (net → 0, worse than the
+   +41 it started at). Absolute thresholds are meaningless when one window
+   never enters the gated band. General warning for any fixed-cutoff gate on
+   only two windows.
+2. **Same sign-inversion as MM50.** Expectancy by ADX tercile:
+
+   | | low ADX | mid | high ADX |
+   |---|---|---|---|
+   | 2025 H2 | −0.33/d | −0.66/d | +1.97/d |
+   | 2026 H1 | +9.96/d | +6.96/d | −4.02/d |
+
+   In 2026 H1, *more* trend strength is *worse* (high-ADX loses −4/day,
+   low-ADX makes +10/day); in 2025 H2 the opposite. The trend-strength →
+   P&L relationship flips sign between windows.
+
+## The strategy is anti-trend (three measures agree)
+
+This is the load-bearing finding of the regime work. Three independent
+trend/strength measures now agree on the same thing in the profitable
+window (2026 H1):
+
+- MM50 slope: **flat** slope was the best bucket (+11.4/day).
+- ADX(14): **low** ADX was the best bucket (+10.0/day); high ADX *lost*.
+
+**Trend strength is negatively correlated with B9H returns in the window
+where it makes money.** The "profits come from trending months" story we
+started with is contradicted by two independent trend indicators. B9H is
+not a trend strategy — it appears to profit in quiet, low-directional-
+strength tape and get run over on strong directional days (the big trend
+days blow through the 9h breakout levels straight to the far stop).
+
+This reframes the search but does **not** hand us a gate: the sign still
+flips between windows, and H2 has no ADX range to exploit. A consistent
+narrative-buster, not a usable filter.
+
+## Next step (spec): intraday overnight-gap column
+
+Three daily trend measures have now failed the same way, so the axis that
+matters is almost certainly **same-day**, not multi-day. Next measure:
+
+- **Measure:** overnight gap = 9h open − prior daily close, a same-day
+  shock/impulse signal known at 09:00 (before any trade → lookahead-safe).
+  It is orthogonal to everything tested (a shock measure, not a trailing
+  trend or the morning's own range). Hypothesis, from the anti-trend
+  finding: **large-|gap| ("shock open") days are the bleed regime; small-gap
+  (quiet open) days are where the edge lives.**
+- **Normalize, don't use a raw cutoff.** The ADX result showed absolute
+  thresholds fail when the two windows sit in different bands. Express the
+  gap as a within-window-relative quantity (percentile or z-score vs recent
+  gaps, or gap ÷ ATR) so a threshold means the same thing in both windows.
+- **Where:** export `h1_open` (we already have high/low) and compute the gap
+  against the daily series already fetched for `mm50_slope`/`adx14`.
+- **Acceptance bar (unchanged):** must improve **both** windows on total P&L.
+- **Honest caveat:** four measures have now been tested on the same 12
+  months — each new one raises false-positive risk, and the gap may invert
+  between windows like the trend measures did. This is pre-registered as the
+  intraday test; a pass on 12 months is suggestive, not validated.
 
 ## The 12 clean single-trade `-50.0` days (baseline SL 50)
 
@@ -345,9 +401,9 @@ weaker claim than "viable.")
 
 ## Not yet investigated
 
-- **ADX(14) daily gate** (highest priority): see the "Next step (spec)"
-  section above. The 9h-range and MM50-slope proxies have both been tested
-  and rejected; ADX is the next measure, chosen against why MM50 failed.
+- **Intraday overnight-gap gate** (highest priority): see the "Next step
+  (spec)" section above. Three daily measures (9h range, MM50 slope, ADX)
+  are now tested and rejected; the intraday same-day axis is next.
 - A time-cut with **no re-entry after cut**, to isolate the early-exit
   benefit from the churn cost.
 - The 5 exactly-0.0-point days.

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -51,6 +51,7 @@ class DayResult:
     status: DayStatus
     h1_high: Optional[float] = None
     h1_low: Optional[float] = None
+    h1_open: Optional[float] = None
     candles: List[Candle] = field(default_factory=list)
     trades: List[Trade] = field(default_factory=list)
 
@@ -75,6 +76,12 @@ class DayResultSummary:
     # direction-agnostic trend/chop strength measure, lookahead-safe and
     # config-independent. None when fewer than 42 prior daily candles exist.
     adx14: Optional[float] = None
+    # 9h reference candle open, and the overnight gap (9h open - the prior
+    # daily close). A same-day, pre-trade shock/impulse signal, lookahead-
+    # safe and config-independent. overnight_gap is None when there is no
+    # prior daily candle to measure against.
+    h1_open: Optional[float] = None
+    overnight_gap: Optional[float] = None
 
 
 @dataclass

--- a/tests/api/routers/test_backtest.py
+++ b/tests/api/routers/test_backtest.py
@@ -369,6 +369,8 @@ class TestGetBacktestRunCsv:
                     h1_low=8000.0,
                     mm50_slope=1.2345,
                     adx14=27.5,
+                    h1_open=8020.0,
+                    overnight_gap=-12.5,
                 )
             ],
         )
@@ -393,10 +395,11 @@ class TestGetBacktestRunCsv:
         assert "stop_loss_points,50" in body
         assert (
             "date,status,trade_count,points,h1_high,h1_low,h1_range,"
-            "mm50_slope,adx14" in body
+            "mm50_slope,adx14,h1_open,overnight_gap" in body
         )
         assert (
-            "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0,1.2345,27.5" in body
+            "2026-06-02,traded,1,30.0,8050.0,8000.0,50.0,1.2345,27.5,"
+            "8020.0,-12.5" in body
         )
 
     def test_end_before_start_returns_400(self, mock_backtest_service):

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -1270,6 +1270,58 @@ class TestRunRangeThreadsRegime:
         assert result.days[0].mm50_slope > 0
         assert result.days[0].adx14 is not None
         assert result.days[0].adx14 > 0
+        # h1_candle() opens at 8020; latest prior daily close is 8069
+        assert result.days[0].h1_open == 8020.0
+        assert result.days[0].overnight_gap == round(8020.0 - 8069.0, 4)
+
+
+class TestOvernightGap:
+    TRADING_DATE = datetime.date(2026, 6, 2)
+
+    def test_gap_is_open_minus_prior_daily_close(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        # latest prior daily close in the series is 8069
+        gap = BacktestService._overnight_gap(
+            series, self.TRADING_DATE, h1_open=8100.0
+        )
+        assert gap == 31.0
+
+    def test_none_when_no_prior_candle(self):
+        assert (
+            BacktestService._overnight_gap(
+                [], self.TRADING_DATE, h1_open=8100.0
+            )
+            is None
+        )
+
+    def test_none_when_h1_open_missing(self):
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        assert (
+            BacktestService._overnight_gap(
+                series, self.TRADING_DATE, h1_open=None
+            )
+            is None
+        )
+
+    def test_ignores_today_and_future_candles(self):
+        """The gap is measured against the prior close only; a candle dated
+        on the trading day or later must not become the reference."""
+        series = uptrend_daily_series(self.TRADING_DATE, 70)
+        baseline = BacktestService._overnight_gap(
+            series, self.TRADING_DATE, h1_open=8100.0
+        )
+        polluted = series + [
+            daily_candle(self.TRADING_DATE, close=0.0),
+            daily_candle(
+                self.TRADING_DATE + datetime.timedelta(days=1), close=99999.0
+            ),
+        ]
+        assert (
+            BacktestService._overnight_gap(
+                polluted, self.TRADING_DATE, h1_open=8100.0
+            )
+            == baseline
+        )
 
 
 class TestAdxBefore:


### PR DESCRIPTION
## What

Adds two columns to the `/api/backtest/run/csv` day rows:
- **`h1_open`** — the 9h reference candle's open (we already export high/low).
- **`overnight_gap`** — `9h open − prior daily close`, a same-day pre-trade shock/impulse signal known at 09:00.

Computed in `run_range` from the daily series already fetched for `mm50_slope`/`adx14`, threaded through `DayResult` / `DayResultSummary` into the CSV and the JSON `/run` response.

Header now:
```
date,status,trade_count,points,h1_high,h1_low,h1_range,mm50_slope,adx14,h1_open,overnight_gap
```

## Why

The intraday same-day measure for the B9H regime investigation. Three *daily* trend measures (9h range, MM50 slope, ADX) have now been rejected — all sign-inverted between windows, and the load-bearing finding is that the strategy is **anti-trend** (profits in quiet tape, bled on strong directional days). The overnight gap is the first *same-day, pre-trade* signal and a genuinely different axis (an overnight shock, not a trailing trend or the morning's own range).

**Pre-registered hypothesis:** large-`|gap|` ("shock open") days are the bleed regime; small-gap (quiet open) days are where the edge lives — and this must hold in **both** windows.

## Design notes

- **Lookahead-safe:** the 9h open is known at 09:00 (before any entry, which can only happen after the 10:00 close of the 9h window), and the prior close is the latest daily candle *strictly before* the day. A test pollutes the series with same-day and future candles and asserts the gap is unchanged.
- **Config-independent** (price-only), like the other regime columns — one export per window feeds any parameter run.
- **Normalization is deliberately left to analysis.** The ADX result showed absolute cutoffs fail when the two windows sit in different bands, so the gate will normalize the gap against its own recent distribution (z-score/percentile) at analysis time rather than baking a raw threshold into the export.
- `overnight_gap` is `None` when there is no prior daily candle; `h1_open` is populated for all TRADED/NO_TRADE rows.

## Tests

- `_overnight_gap`: value (`open − prior close`), None when no prior candle or missing open, and lookahead safety.
- `run_range` threads `h1_open` + `overnight_gap` onto the summary.
- Router CSV header + values.
- Full suite green (479 passed, 10 skipped); black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)