### PR TITLE
docs(spec-021): plan + tasks for wide-range structural-stop variant (US1d)

### DIFF
--- a/specs/021-backtest-menu-hardcoded/plan.md
+++ b/specs/021-backtest-menu-hardcoded/plan.md
@@ -107,3 +107,36 @@ tests/
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |---|---|---|
 | ~~Strategy thresholds (50pt stop, 10pt take-profit offset, 20pt break-even trigger, 9:00–10:00 window) hardcoded in `api/services/backtest_service.py` rather than `config.yml`~~ **Resolved 2026-07-21** | Originally justified by FR-002 ("I don't want to create a back test engine"). Superseded: the three numeric thresholds plus max-entry-distance became per-run parameters (`BacktestParameters`, FR-025), defaulting to the original constants; they are analysis inputs, not deployment configuration, so this is no longer a Configuration-Driven Design exception. The instrument and 9:00–10:00 window remain hardcoded per FR-002. | N/A — no longer a violation |
+
+---
+
+## Increment (2026-07-24): User Story 1d — Wide-range structural-stop variant
+
+Adds a third hardcoded backtest, **"CAC40 Bougie de 9h (wide-range structural stop)"** (US1d, FR-032–FR-035). Reuses the base strategy end-to-end and changes exactly two things: a 9h-range entry filter and the stop-loss mechanism. No new API endpoints, no new CSV columns, no frontend logic changes — the variant surfaces automatically through the definition-driven menu (FR-001) and exports with the existing columns.
+
+### Technical Context (delta only)
+
+- **Language/stack**: unchanged (Python 3.11 backend; FastAPI; existing `BacktestService`).
+- **New dependencies**: none.
+- **Storage / API / frontend**: no changes — `list_definitions()` already drives the menu and CSV/JSON responses handle any definition generically.
+- **Data model**: `BacktestDefinition` gains two optional, variant-scoped fields (`min_h1_range_points`, `structural_stop`), mirroring how the time-cut added `time_cut_*`. The base and time-cut definitions leave them unset/false, so their behaviour is unchanged.
+
+### Design
+
+1. **Range filter (FR-033)** — enforced in `evaluate_day`, before any candidate search: if `definition.min_h1_range_points` is set and `h1_high − h1_low ≤ 40`, return a `NO_TRADE` day (H1 levels/open present, no trades). Days with range > 40 fall through to the unchanged `_evaluate_trades`.
+2. **Structural stop (FR-034/FR-035)** — localized to the *break-even-unarmed* branch of the exit path. The open position carries `h1_low`/`h1_high` and the `structural_stop` flag. While unarmed and structural:
+   - take-profit is resolved first (it is reached intrabar, i.e. before the candle's close);
+   - otherwise, if the candle **closes** beyond the H1 level on the losing side (below H1 low for a long, above H1 high for a short), the trade exits at that candle's **close** with the `STOP_LOSS` reason (no FR-010 gap-fill — it is a market/close exit);
+   - break-even still arms at +20 favorable. Once armed, the stop becomes the entry price and control falls through to the **existing** base logic (entry-level break-even, base FR-009 stop-before-take-profit ordering). The structural stop no longer applies once armed.
+   The tunable stop-loss distance (default 50) is unused by this variant; the other three thresholds apply unchanged.
+
+### Files touched
+
+- `model/enum.py` — new `Strategy.B9HWS` value.
+- `model/backtest.py` — two new optional `BacktestDefinition` fields.
+- `api/services/backtest_service.py` — register the third definition; range filter in `evaluate_day`; structural-stop branch in `_OpenPosition`/`_resolve_exit`.
+- `tests/api/services/test_backtest_service.py` — variant tests.
+
+### Quality gates
+
+Same as Phase 6: black/isort/flake8/mypy clean, `poetry run pytest` green, and SC-007 hand-verified on a real wide-range FRA40.I day.

--- a/specs/021-backtest-menu-hardcoded/tasks.md
+++ b/specs/021-backtest-menu-hardcoded/tasks.md
@@ -193,3 +193,34 @@ Task: "Style the single-day result view in frontend/src/pages/Backtest.css"
 - [US1]/[US2]/[US3] labels map every story-phase task back to spec.md's priorities for traceability
 - FR-002's "no generic engine" constraint keeps the strategy *logic*, instrument, and 9–10 window fixed in code; the four numeric thresholds became per-run parameters (`BacktestParameters`, FR-025, added 2026-07-21), defaulting to 50/10/20/20 — see plan.md's Complexity Tracking (resolved) and the "Parametrized thresholds" requirements
 - Commit after each task or logical group; stop at any checkpoint to validate a story independently before continuing
+
+---
+
+## Increment (2026-07-24) — Phase 7: User Story 1d — Wide-range structural stop (Priority: P2)
+
+**Goal**: A third hardcoded backtest that trades only days whose 9h H1 range exceeds 40 points and replaces the fixed 50-point stop with a structural stop (a 5-minute candle closing back beyond the H1 level while break-even is unarmed); break-even and take-profit are unchanged.
+
+**Independent Test**: Run the variant over a range — days with H1 range ≤ 40 report "no trade"; on a wide-range day a pre-break-even 5-minute close below the H1 low exits at that close with a stop-loss reason, where the base backtest instead runs to its entry-minus-50 stop (SC-007).
+
+### Foundational (model + enum)
+
+- [ ] T034 [US1d] Add `B9HWS = "Bougie de 9h (wide-range structural stop)"` to the `Strategy` enum in `model/enum.py`.
+- [ ] T035 [US1d] Add `min_h1_range_points: Optional[float] = None` and `structural_stop: bool = False` fields to `BacktestDefinition` in `model/backtest.py` (keep the existing time-cut fields; the data model must not assume a single variant).
+
+### Tests (write before/with implementation)
+
+- [ ] T036 [P] [US1d] Service tests in `tests/api/services/test_backtest_service.py`: (a) H1 range ≤ 40 → `NO_TRADE`, zero trades, no candidate search; (b) H1 range > 40 → trades evaluated as in base; (c) unarmed long, a 5-minute candle closes below H1 low → exit at that candle's close, `STOP_LOSS`; (d) mirror short closes above H1 high → `STOP_LOSS` at close; (e) break-even armed (+20) then pullback to entry → `BREAK_EVEN` (structural stop no longer applies); (f) unarmed candle whose high reaches take-profit and whose close is below H1 low → `TAKE_PROFIT` wins; (g) a plain take-profit still exits normally.
+- [ ] T037 [P] [US1d] Definition-list test: `list_definitions()` returns three definitions including `B9HWS`, with `min_h1_range_points == 40.0` and `structural_stop is True`.
+
+### Implementation
+
+- [ ] T038 [US1d] Register the third definition in `BACKTEST_DEFINITIONS` (`api/services/backtest_service.py`): code `B9HWS`, name `Strategy.B9HWS.value`, display `CAC40 Bougie de 9h (wide-range structural stop)`, instrument `FRA40.I`, `min_h1_range_points=40.0`, `structural_stop=True`.
+- [ ] T039 [US1d] Range filter in `evaluate_day` (FR-033): when `definition.min_h1_range_points` is set and `h1_high - h1_low <= definition.min_h1_range_points`, return a `NO_TRADE` `DayResult` carrying the H1 levels/open but performing no candidate search and holding no trades.
+- [ ] T040 [US1d] Structural stop (FR-034/FR-035) in `_OpenPosition` + `_resolve_exit`: carry `h1_low`/`h1_high`/`structural_stop` on the open position; while break-even is unarmed and `structural_stop` is set, resolve take-profit first (intrabar), then a structural stop when `candle.close` is beyond the H1 level (below H1 low for a long, above H1 high for a short), exiting at `candle.close` with `STOP_LOSS` (no FR-010 gap-fill); once break-even arms, fall through to the existing entry-level break-even logic and base FR-009 ordering.
+
+### Checkpoint & polish
+
+- [ ] T041 [US1d] Confirm the variant appears in the Backtest menu (the frontend list is definition-driven — no code change expected) and exports with the existing CSV columns; note any missing wiring.
+- [ ] T042 [P] [US1d] Run black/isort/flake8/mypy and `poetry run pytest` on the changed backend files; hand-verify SC-007 on a real wide-range FRA40.I day per `quickstart.md`.
+
+**Checkpoint**: The wide-range structural-stop variant is selectable, its two rule changes are covered by tests, and the original two backtests are unaffected.


### PR DESCRIPTION
## What

Adds the **implementation plan** and **task breakdown** for the wide-range structural-stop variant (US1d), stacked on the spec PR #666.

- `plan.md` — an "Increment (2026-07-24)" section: technical-context delta (no new deps/endpoints/CSV columns/frontend logic), the design for both rule changes, files touched, and quality gates.
- `tasks.md` — "Phase 7" with dependency-ordered tasks **T034–T042**: enum + `BacktestDefinition` fields, tests-first, the range filter in `evaluate_day`, the structural-stop branch in `_resolve_exit`, and the polish/SC-007 checkpoint.

> ⚠️ **Stacked on #666** (base = `spec/021-wide-range-structural-stop`), so this PR's diff is only the plan/tasks. Merge #666 first, then retarget/merge this to `main`.

## Note on approach

I intentionally **appended** to the feature-wide `plan.md`/`tasks.md` rather than running `speckit.plan`'s setup script: that script `cp`s the plan template over `plan.md` (destroying the existing feature-wide plan) and rejects the non-`NNN` branch name. The time-cut increment set the precedent of not regenerating these. The appended sections are clearly dated and scoped to US1d.

## Implementation summary (what the tasks will build)

Two changes to the base strategy, both localized:
1. **Range filter** in `evaluate_day` — H1 range ≤ 40 → `NO_TRADE` before any candidate search.
2. **Structural stop** in the break-even-unarmed exit branch — take-profit resolved first (intrabar), else exit at the candle **close** when it closes beyond the H1 level (`STOP_LOSS`); break-even supersedes once armed.

No new API/CSV/frontend surface — the variant appears via the definition-driven menu and exports with the existing regime columns, so it can be regime-tested immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)