### PR TITLE
feat: add backtest candle caching with DynamoDB

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -74,6 +74,18 @@ def get_dynamodb_client_optional(request: Request) -> Optional[DynamoDBClient]:
     return None
 
 
+def get_dynamodb_client_best_effort(request: Request) -> DynamoDBClient:
+    """Always returns a DynamoDBClient, even outside an AWS context -
+    unlike get_dynamodb_client, it never raises, and unlike
+    get_dynamodb_client_optional, it's never None. Its underlying
+    resource may be unset (local/dev without AWS), in which case any
+    actual DynamoDB call raises RuntimeError; for a caller that treats
+    DynamoDB as a best-effort cache rather than a hard dependency (e.g.
+    BacktestService's candle cache), that's expected and caught there."""
+    dynamodb = getattr(request.app.state, "dynamodb", None)
+    return DynamoDBClient(dynamodb_resource=dynamodb)
+
+
 @lru_cache()
 def get_binance_client() -> BinanceClient:
     config = get_configuration()
@@ -126,9 +138,7 @@ def get_trade_republic_service() -> TradeRepublicService:
 
 
 def get_backtest_service(
-    dynamodb_client: Optional[DynamoDBClient] = Depends(
-        get_dynamodb_client_optional
-    ),
+    dynamodb_client: DynamoDBClient = Depends(get_dynamodb_client_best_effort),
 ) -> BacktestService:
     candles_service = get_candles_service()
     return BacktestService(candles_service, dynamodb_client)

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -125,10 +125,13 @@ def get_trade_republic_service() -> TradeRepublicService:
     return TradeRepublicService(gsheet_client)
 
 
-@lru_cache()
-def get_backtest_service() -> BacktestService:
+def get_backtest_service(
+    dynamodb_client: Optional[DynamoDBClient] = Depends(
+        get_dynamodb_client_optional
+    ),
+) -> BacktestService:
     candles_service = get_candles_service()
-    return BacktestService(candles_service)
+    return BacktestService(candles_service, dynamodb_client)
 
 
 def get_asset_details_service(

--- a/api/routers/backtest.py
+++ b/api/routers/backtest.py
@@ -95,7 +95,7 @@ async def get_backtest_day(
     """Run the backtest for a single day and return full trade detail."""
     backtest_definition = _resolve_definition(backtest_service, definition)
     trading_date = _parse_date(date)
-    day_result = backtest_service.evaluate_day(
+    day_result = await backtest_service.evaluate_day(
         backtest_definition, trading_date, params
     )
     return day_result_to_response(day_result)
@@ -113,7 +113,7 @@ async def get_backtest_run(
     summary plus a compact per-day list."""
     backtest_definition = _resolve_definition(backtest_service, definition)
     start, end = _parse_range(start_date, end_date)
-    run_result = backtest_service.run_range(
+    run_result = await backtest_service.run_range(
         backtest_definition, start, end, params
     )
     return backtest_run_result_to_response(run_result)
@@ -129,7 +129,7 @@ async def get_backtest_day_csv(
     """CSV export of a single day's detail (FR-018)."""
     backtest_definition = _resolve_definition(backtest_service, definition)
     trading_date = _parse_date(date)
-    day_result = backtest_service.evaluate_day(
+    day_result = await backtest_service.evaluate_day(
         backtest_definition, trading_date, params
     )
     return Response(
@@ -154,7 +154,7 @@ async def get_backtest_run_csv(
     """CSV export of a range run's day-by-day summary (FR-017)."""
     backtest_definition = _resolve_definition(backtest_service, definition)
     start, end = _parse_range(start_date, end_date)
-    run_result = backtest_service.run_range(
+    run_result = await backtest_service.run_range(
         backtest_definition, start, end, params
     )
     return Response(

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 from zoneinfo import ZoneInfo
 
 from client.aws_client import DynamoDBClient, DynamoDBOperationError
@@ -66,6 +66,23 @@ BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
         structural_stop=True,
     ),
 ]
+
+# Bump whenever a change to a BacktestDefinition's instrument, 9h
+# reference window, or session windows would change what candles are
+# fetched under the same code (e.g. re-pointing a definition at a
+# different instrument). Without this, an edited definition would
+# otherwise keep serving cache entries fetched under its old shape
+# forever - there is no TTL on the candle cache (FR-040).
+CACHE_SCHEMA_VERSION = 1
+
+
+def _cache_key(definition: BacktestDefinition) -> str:
+    """Cache key for the raw-candle cache (FR-036), covering not just
+    the definition's code but also its instrument and the schema
+    version, so a definition edit or a strategy-shape change can
+    invalidate old entries just by bumping CACHE_SCHEMA_VERSION."""
+    return f"{definition.code}:{definition.instrument}:v{CACHE_SCHEMA_VERSION}"
+
 
 # Candle horizons for the two Saxo fetches. Unlike the strategy
 # thresholds (now tunable via BacktestParameters), these describe the
@@ -393,14 +410,16 @@ class BacktestService:
         written to the cache, so it doesn't permanently poison later
         runs over the same day."""
         params = params or BacktestParameters()
-        cached = await self._get_cached_candles(definition.code, trading_date)
+        cached = await self._get_cached_candles(
+            _cache_key(definition), trading_date
+        )
 
         if cached is not None and cached.has_data and cached.h1_candle is None:
             # _get_cached_candles already guards against this, but a
             # cache problem must never break a backtest - fall through
             # to a fresh fetch instead of failing the request.
             self.logger.warning(
-                f"Cached backtest entry for {definition.code}/"
+                f"Cached backtest entry for {_cache_key(definition)}/"
                 f"{trading_date} has has_data=True but no h1_candle; "
                 "treating as a miss"
             )
@@ -432,7 +451,7 @@ class BacktestService:
             return DayResult(date=trading_date, status=DayStatus.NO_DATA)
         if fetched_h1_candle is None:
             await self._store_candles(
-                definition.code, trading_date, has_data=False
+                _cache_key(definition), trading_date, has_data=False
             )
             return DayResult(date=trading_date, status=DayStatus.NO_DATA)
 
@@ -443,7 +462,7 @@ class BacktestService:
             definition, fetched_h1_candle.higher, fetched_h1_candle.lower
         ):
             await self._store_candles(
-                definition.code,
+                _cache_key(definition),
                 trading_date,
                 has_data=True,
                 h1_candle=fetched_h1_candle,
@@ -466,7 +485,7 @@ class BacktestService:
             five_min_candles = []
         else:
             await self._store_candles(
-                definition.code,
+                _cache_key(definition),
                 trading_date,
                 has_data=True,
                 h1_candle=fetched_h1_candle,
@@ -474,7 +493,11 @@ class BacktestService:
             )
 
         return self._evaluate_from_candles(
-            definition, trading_date, params, fetched_h1_candle, five_min_candles
+            definition,
+            trading_date,
+            params,
+            fetched_h1_candle,
+            five_min_candles,
         )
 
     @staticmethod
@@ -1059,10 +1082,10 @@ class BacktestService:
         )
 
     async def _get_cached_candles(
-        self, definition_code: str, trading_date: datetime.date
+        self, cache_key: str, trading_date: datetime.date
     ) -> Optional[CachedDayCandles]:
-        """Look up the raw-candle cache for (definition_code,
-        trading_date) (FR-036). Returns None on a cache miss, or when no
+        """Look up the raw-candle cache for (cache_key, trading_date)
+        (FR-036). Returns None on a cache miss, or when no
         DynamoDBClient is available (local/test usage, or a DynamoDB
         failure) - in every such case the caller falls back to fetching
         from Saxo, so a cache outage never breaks a backtest run."""
@@ -1070,48 +1093,57 @@ class BacktestService:
             return None
         try:
             item = await self.dynamodb_client.get_cached_backtest_candles(
-                definition_code, trading_date.isoformat()
+                cache_key, trading_date.isoformat()
             )
         except DynamoDBOperationError as e:
             self.logger.warning(
                 f"Backtest candle cache lookup failed for "
-                f"{definition_code}/{trading_date}: {e}"
+                f"{cache_key}/{trading_date}: {e}"
             )
             return None
         if item is None:
             return None
 
-        has_data = bool(item["has_data"])
-        if not has_data:
-            return CachedDayCandles(has_data=False)
-        return CachedDayCandles(
-            has_data=True,
-            h1_candle=self._candle_from_cached_dict(item["h1_candle"]),
-            m5_candles=[
-                self._candle_from_cached_dict(c)
-                for c in item.get("m5_candles", [])
-            ],
-        )
+        try:
+            has_data = bool(item["has_data"])
+            if not has_data:
+                return CachedDayCandles(has_data=False)
+            return CachedDayCandles(
+                has_data=True,
+                h1_candle=Candle.from_dict(item["h1_candle"]),
+                m5_candles=[
+                    Candle.from_dict(c) for c in item.get("m5_candles", [])
+                ],
+            )
+        except (KeyError, ValueError, TypeError) as e:
+            # A cache problem must never break a backtest: an item
+            # written under an earlier schema (or otherwise malformed)
+            # is treated as a miss, the same as if nothing were cached.
+            self.logger.warning(
+                f"Malformed backtest cache item for "
+                f"{cache_key}/{trading_date}: {e}"
+            )
+            return None
 
     async def _store_candles(
         self,
-        definition_code: str,
+        cache_key: str,
         trading_date: datetime.date,
         has_data: bool,
         h1_candle: Optional[Candle] = None,
         m5_candles: Optional[List[Candle]] = None,
     ) -> None:
-        """Store the raw candles fetched for (definition_code,
-        trading_date) so a later request for the same pair is served
-        from the cache (FR-037/FR-038). A missing DynamoDBClient or a
-        DynamoDB failure degrades to "not cached this time" rather than
-        failing the backtest - caching is a cost optimization, not a
-        correctness requirement."""
+        """Store the raw candles fetched for (cache_key, trading_date)
+        so a later request for the same pair is served from the cache
+        (FR-037/FR-038). A missing DynamoDBClient or a DynamoDB failure
+        degrades to "not cached this time" rather than failing the
+        backtest - caching is a cost optimization, not a correctness
+        requirement."""
         if self.dynamodb_client is None:
             return
         try:
             await self.dynamodb_client.store_backtest_candles(
-                definition_code,
+                cache_key,
                 trading_date.isoformat(),
                 has_data,
                 h1_candle.to_dict() if h1_candle is not None else None,
@@ -1124,24 +1156,5 @@ class BacktestService:
         except DynamoDBOperationError as e:
             self.logger.warning(
                 f"Backtest candle cache store failed for "
-                f"{definition_code}/{trading_date}: {e}"
+                f"{cache_key}/{trading_date}: {e}"
             )
-
-    @staticmethod
-    def _candle_from_cached_dict(data: Dict[str, Any]) -> Candle:
-        """Rebuild a Candle from a cached item's field, converting the
-        Decimal prices DynamoDB returns back to float (this codebase's
-        convention for reading numeric DynamoDB fields back out, e.g.
-        AlertDigestService._to_triaged_asset)."""
-        return Candle(
-            lower=float(data["lower"]),
-            higher=float(data["higher"]),
-            open=float(data["open"]),
-            close=float(data["close"]),
-            ut=UnitTime(data["ut"]),
-            date=(
-                datetime.datetime.fromisoformat(data["date"])
-                if data.get("date")
-                else None
-            ),
-        )

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -377,7 +377,7 @@ class BacktestService:
     def __init__(
         self,
         candles_service: CandlesService,
-        dynamodb_client: Optional[DynamoDBClient] = None,
+        dynamodb_client: DynamoDBClient,
     ):
         self.logger = Logger.get_logger("backtest_service")
         self.candles_service = candles_service
@@ -1085,17 +1085,16 @@ class BacktestService:
         self, cache_key: str, trading_date: datetime.date
     ) -> Optional[CachedDayCandles]:
         """Look up the raw-candle cache for (cache_key, trading_date)
-        (FR-036). Returns None on a cache miss, or when no
-        DynamoDBClient is available (local/test usage, or a DynamoDB
-        failure) - in every such case the caller falls back to fetching
-        from Saxo, so a cache outage never breaks a backtest run."""
-        if self.dynamodb_client is None:
-            return None
+        (FR-036). Returns None on a cache miss, or on a DynamoDB failure
+        (including no active resource - local/dev without AWS, see
+        get_dynamodb_client_best_effort) - in every such case the caller
+        falls back to fetching from Saxo, so a cache outage never
+        breaks a backtest run."""
         try:
             item = await self.dynamodb_client.get_cached_backtest_candles(
                 cache_key, trading_date.isoformat()
             )
-        except DynamoDBOperationError as e:
+        except (DynamoDBOperationError, RuntimeError) as e:
             self.logger.warning(
                 f"Backtest candle cache lookup failed for "
                 f"{cache_key}/{trading_date}: {e}"
@@ -1135,12 +1134,10 @@ class BacktestService:
     ) -> None:
         """Store the raw candles fetched for (cache_key, trading_date)
         so a later request for the same pair is served from the cache
-        (FR-037/FR-038). A missing DynamoDBClient or a DynamoDB failure
-        degrades to "not cached this time" rather than failing the
-        backtest - caching is a cost optimization, not a correctness
-        requirement."""
-        if self.dynamodb_client is None:
-            return
+        (FR-037/FR-038). A DynamoDB failure (including no active
+        resource - local/dev without AWS) degrades to "not cached this
+        time" rather than failing the backtest - caching is a cost
+        optimization, not a correctness requirement."""
         try:
             await self.dynamodb_client.store_backtest_candles(
                 cache_key,
@@ -1153,7 +1150,7 @@ class BacktestService:
                     else None
                 ),
             )
-        except DynamoDBOperationError as e:
+        except (DynamoDBOperationError, RuntimeError) as e:
             self.logger.warning(
                 f"Backtest candle cache store failed for "
                 f"{cache_key}/{trading_date}: {e}"

--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -1,12 +1,14 @@
 import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 
+from client.aws_client import DynamoDBClient, DynamoDBOperationError
 from model import (
     BacktestDefinition,
     BacktestParameters,
     BacktestRunResult,
     BacktestSummary,
+    CachedDayCandles,
     Candle,
     DayResult,
     DayResultSummary,
@@ -355,9 +357,14 @@ class _DirectionSearch:
 class BacktestService:
     """Runs the hardcoded backtests exposed by the Backtest menu."""
 
-    def __init__(self, candles_service: CandlesService):
+    def __init__(
+        self,
+        candles_service: CandlesService,
+        dynamodb_client: Optional[DynamoDBClient] = None,
+    ):
         self.logger = Logger.get_logger("backtest_service")
         self.candles_service = candles_service
+        self.dynamodb_client = dynamodb_client
 
     def list_definitions(self) -> List[BacktestDefinition]:
         return BACKTEST_DEFINITIONS
@@ -368,31 +375,136 @@ class BacktestService:
                 return definition
         return None
 
-    def evaluate_day(
+    async def evaluate_day(
         self,
         definition: BacktestDefinition,
         trading_date: datetime.date,
         params: Optional[BacktestParameters] = None,
     ) -> DayResult:
-        """Run the "CAC40 Bougie de 9h" rules for a single trading day."""
+        """Run the "CAC40 Bougie de 9h" rules for a single trading day.
+
+        Before fetching from Saxo, checks the raw-candle cache for this
+        (definition, trading_date) pair (FR-036); on a miss, fetches as
+        before and stores the result under that key (FR-037/FR-038) so a
+        later request for the same pair skips Saxo entirely. The
+        strategy evaluation (_evaluate_from_candles) always runs fresh
+        against those candles, cached or not (FR-039). A transient Saxo
+        fetch failure (as opposed to a genuine "no data") is never
+        written to the cache, so it doesn't permanently poison later
+        runs over the same day."""
         params = params or BacktestParameters()
+        cached = await self._get_cached_candles(definition.code, trading_date)
+
+        if cached is not None and cached.has_data and cached.h1_candle is None:
+            # _get_cached_candles already guards against this, but a
+            # cache problem must never break a backtest - fall through
+            # to a fresh fetch instead of failing the request.
+            self.logger.warning(
+                f"Cached backtest entry for {definition.code}/"
+                f"{trading_date} has has_data=True but no h1_candle; "
+                "treating as a miss"
+            )
+            cached = None
+
+        if cached is not None:
+            if not cached.has_data:
+                return DayResult(date=trading_date, status=DayStatus.NO_DATA)
+            cached_h1_candle = cached.h1_candle
+            if cached_h1_candle is not None:
+                return self._evaluate_from_candles(
+                    definition,
+                    trading_date,
+                    params,
+                    cached_h1_candle,
+                    cached.m5_candles,
+                )
+
         h1_start_utc, h1_end_utc = paris_reference_window_utc(trading_date)
-        h1_candle = self._fetch_h1_reference_candle(
-            definition.instrument, h1_start_utc, h1_end_utc
-        )
-        if h1_candle is None:
+        try:
+            fetched_h1_candle = self._fetch_h1_reference_candle(
+                definition.instrument, h1_start_utc, h1_end_utc
+            )
+        except SaxoException as e:
+            self.logger.warning(
+                f"H1 fetch failed for {definition.instrument} on "
+                f"{trading_date}, not caching: {e}"
+            )
+            return DayResult(date=trading_date, status=DayStatus.NO_DATA)
+        if fetched_h1_candle is None:
+            await self._store_candles(
+                definition.code, trading_date, has_data=False
+            )
             return DayResult(date=trading_date, status=DayStatus.NO_DATA)
 
-        h1_high = h1_candle.higher
-        h1_low = h1_candle.lower
-        # Wide-range variant (FR-033): a day is only eligible for trades
-        # when its H1 range is strictly greater than the threshold. On a
-        # narrower day, take no trades and perform no candidate search - the
-        # H1 candle exists, so this is a NO_TRADE day, not NO_DATA.
-        if (
+        # Wide-range variant (FR-033): skip the 5-minute fetch entirely
+        # on a day whose H1 range doesn't clear the threshold - the day
+        # is a NO_TRADE regardless of what the 5-minute candles hold.
+        if self._is_below_min_range(
+            definition, fetched_h1_candle.higher, fetched_h1_candle.lower
+        ):
+            await self._store_candles(
+                definition.code,
+                trading_date,
+                has_data=True,
+                h1_candle=fetched_h1_candle,
+                m5_candles=[],
+            )
+            return self._evaluate_from_candles(
+                definition, trading_date, params, fetched_h1_candle, []
+            )
+
+        session_end_utc = paris_session_end_utc(trading_date)
+        try:
+            five_min_candles = self._fetch_five_minute_candles(
+                definition.instrument, h1_end_utc, session_end_utc
+            )
+        except SaxoException as e:
+            self.logger.warning(
+                f"5-minute fetch failed for {definition.instrument} on "
+                f"{trading_date}, not caching: {e}"
+            )
+            five_min_candles = []
+        else:
+            await self._store_candles(
+                definition.code,
+                trading_date,
+                has_data=True,
+                h1_candle=fetched_h1_candle,
+                m5_candles=five_min_candles,
+            )
+
+        return self._evaluate_from_candles(
+            definition, trading_date, params, fetched_h1_candle, five_min_candles
+        )
+
+    @staticmethod
+    def _is_below_min_range(
+        definition: BacktestDefinition, h1_high: float, h1_low: float
+    ) -> bool:
+        """Wide-range variant (FR-033): whether the day's H1 range fails
+        to clear the definition's threshold. Always False for
+        definitions without one (min_h1_range_points is None)."""
+        return (
             definition.min_h1_range_points is not None
             and h1_high - h1_low <= definition.min_h1_range_points
-        ):
+        )
+
+    def _evaluate_from_candles(
+        self,
+        definition: BacktestDefinition,
+        trading_date: datetime.date,
+        params: BacktestParameters,
+        h1_candle: Candle,
+        five_min_candles: List[Candle],
+    ) -> DayResult:
+        """Shared tail of evaluate_day once the day's H1/5-minute candles
+        are known, whether from the cache or a fresh Saxo fetch: applies
+        the wide-range filter (FR-033) then runs the strategy. Pure/no
+        I/O, so it's reused unchanged by both the cache-hit and
+        cache-miss paths."""
+        h1_high = h1_candle.higher
+        h1_low = h1_candle.lower
+        if self._is_below_min_range(definition, h1_high, h1_low):
             return DayResult(
                 date=trading_date,
                 status=DayStatus.NO_TRADE,
@@ -400,12 +512,8 @@ class BacktestService:
                 h1_low=h1_low,
                 h1_open=h1_candle.open,
             )
-        session_end_utc = paris_session_end_utc(trading_date)
-        five_min_candles = self._fetch_five_minute_candles(
-            definition.instrument, h1_end_utc, session_end_utc
-        )
-        chronological = sorted(five_min_candles, key=_candle_date)
 
+        chronological = sorted(five_min_candles, key=_candle_date)
         trades = self._evaluate_trades(
             chronological, h1_high, h1_low, params, definition
         )
@@ -421,7 +529,7 @@ class BacktestService:
             trades=trades,
         )
 
-    def run_range(
+    async def run_range(
         self,
         definition: BacktestDefinition,
         start_date: datetime.date,
@@ -445,7 +553,7 @@ class BacktestService:
                 # NO_DATA - avoids two wasted Saxo calls per weekend day.
                 current += datetime.timedelta(days=1)
                 continue
-            day_result = self.evaluate_day(definition, current, params)
+            day_result = await self.evaluate_day(definition, current, params)
             if day_result.status != DayStatus.NO_DATA:
                 day_points = round(
                     sum(trade.points for trade in day_result.trades), 4
@@ -529,20 +637,19 @@ class BacktestService:
         h1_start_utc: datetime.datetime,
         h1_end_utc: datetime.datetime,
     ) -> Optional[Candle]:
-        try:
-            candles = self.candles_service.get_candles_in_window(
-                instrument,
-                UnitTime.H1,
-                H1_HORIZON,
-                h1_start_utc,
-                h1_end_utc,
-            )
-        except SaxoException as e:
-            self.logger.warning(
-                f"No H1 reference candle for {instrument} on "
-                f"{h1_start_utc.date()}: {e}"
-            )
-            return None
+        """Returns None only when Saxo genuinely has no H1 candle for this
+        window (a real "no data" day, safe to cache as such). A
+        SaxoException (expired token, rate limit, network blip) is a
+        transient fetch failure, not "no data" - it propagates so the
+        caller never mistakes one for the other and caches it
+        permanently."""
+        candles = self.candles_service.get_candles_in_window(
+            instrument,
+            UnitTime.H1,
+            H1_HORIZON,
+            h1_start_utc,
+            h1_end_utc,
+        )
         if not candles:
             return None
         return sorted(candles, key=_candle_date)[0]
@@ -553,20 +660,16 @@ class BacktestService:
         start_utc: datetime.datetime,
         end_utc: datetime.datetime,
     ) -> List[Candle]:
-        try:
-            return self.candles_service.get_candles_in_window(
-                instrument,
-                UnitTime.M5,
-                FIVE_MINUTE_HORIZON,
-                start_utc,
-                end_utc,
-            )
-        except SaxoException as e:
-            self.logger.warning(
-                f"No 5-minute candles for {instrument} between "
-                f"{start_utc} and {end_utc}: {e}"
-            )
-            return []
+        """An empty result is a genuine (cacheable) "no candles"; a
+        SaxoException is a transient fetch failure and propagates - see
+        _fetch_h1_reference_candle."""
+        return self.candles_service.get_candles_in_window(
+            instrument,
+            UnitTime.M5,
+            FIVE_MINUTE_HORIZON,
+            start_utc,
+            end_utc,
+        )
 
     def _fetch_daily_candles(
         self,
@@ -953,4 +1056,92 @@ class BacktestService:
             exit_reason=exit_reason,
             direction=position.direction,
             points=round(points, 4),
+        )
+
+    async def _get_cached_candles(
+        self, definition_code: str, trading_date: datetime.date
+    ) -> Optional[CachedDayCandles]:
+        """Look up the raw-candle cache for (definition_code,
+        trading_date) (FR-036). Returns None on a cache miss, or when no
+        DynamoDBClient is available (local/test usage, or a DynamoDB
+        failure) - in every such case the caller falls back to fetching
+        from Saxo, so a cache outage never breaks a backtest run."""
+        if self.dynamodb_client is None:
+            return None
+        try:
+            item = await self.dynamodb_client.get_cached_backtest_candles(
+                definition_code, trading_date.isoformat()
+            )
+        except DynamoDBOperationError as e:
+            self.logger.warning(
+                f"Backtest candle cache lookup failed for "
+                f"{definition_code}/{trading_date}: {e}"
+            )
+            return None
+        if item is None:
+            return None
+
+        has_data = bool(item["has_data"])
+        if not has_data:
+            return CachedDayCandles(has_data=False)
+        return CachedDayCandles(
+            has_data=True,
+            h1_candle=self._candle_from_cached_dict(item["h1_candle"]),
+            m5_candles=[
+                self._candle_from_cached_dict(c)
+                for c in item.get("m5_candles", [])
+            ],
+        )
+
+    async def _store_candles(
+        self,
+        definition_code: str,
+        trading_date: datetime.date,
+        has_data: bool,
+        h1_candle: Optional[Candle] = None,
+        m5_candles: Optional[List[Candle]] = None,
+    ) -> None:
+        """Store the raw candles fetched for (definition_code,
+        trading_date) so a later request for the same pair is served
+        from the cache (FR-037/FR-038). A missing DynamoDBClient or a
+        DynamoDB failure degrades to "not cached this time" rather than
+        failing the backtest - caching is a cost optimization, not a
+        correctness requirement."""
+        if self.dynamodb_client is None:
+            return
+        try:
+            await self.dynamodb_client.store_backtest_candles(
+                definition_code,
+                trading_date.isoformat(),
+                has_data,
+                h1_candle.to_dict() if h1_candle is not None else None,
+                (
+                    [c.to_dict() for c in m5_candles]
+                    if m5_candles is not None
+                    else None
+                ),
+            )
+        except DynamoDBOperationError as e:
+            self.logger.warning(
+                f"Backtest candle cache store failed for "
+                f"{definition_code}/{trading_date}: {e}"
+            )
+
+    @staticmethod
+    def _candle_from_cached_dict(data: Dict[str, Any]) -> Candle:
+        """Rebuild a Candle from a cached item's field, converting the
+        Decimal prices DynamoDB returns back to float (this codebase's
+        convention for reading numeric DynamoDB fields back out, e.g.
+        AlertDigestService._to_triaged_asset)."""
+        return Candle(
+            lower=float(data["lower"]),
+            higher=float(data["higher"]),
+            open=float(data["open"]),
+            close=float(data["close"]),
+            ut=UnitTime(data["ut"]),
+            date=(
+                datetime.datetime.fromisoformat(data["date"])
+                if data.get("date")
+                else None
+            ),
         )

--- a/client/aws_client.py
+++ b/client/aws_client.py
@@ -969,3 +969,49 @@ class DynamoDBClient(AwsClient):
 
         items = response.get("Items", [])
         return items[0] if items else None
+
+    @_dynamo_operation
+    async def get_cached_backtest_candles(
+        self, definition_code: str, trading_date: str
+    ) -> Optional[Dict[str, Any]]:
+        table = await self._get_table("backtest_candle_cache")
+        response = await table.get_item(
+            Key={
+                "definition_code": definition_code,
+                "trading_date": trading_date,
+            }
+        )
+
+        if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+            self.logger.error(f"DynamoDB get_item error: {response}")
+            return None
+
+        return response.get("Item")
+
+    @_dynamo_operation
+    async def store_backtest_candles(
+        self,
+        definition_code: str,
+        trading_date: str,
+        has_data: bool,
+        h1_candle: Optional[Dict[str, Any]] = None,
+        m5_candles: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "definition_code": definition_code,
+            "trading_date": trading_date,
+            "has_data": has_data,
+            "cached_at": int(time.time()),
+        }
+        if has_data:
+            item["h1_candle"] = h1_candle
+            item["m5_candles"] = m5_candles or []
+        item = self._convert_floats_to_decimal(item)
+
+        table = await self._get_table("backtest_candle_cache")
+        response = await table.put_item(Item=item)
+
+        if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
+            self.logger.error(f"DynamoDB put_item error: {response}")
+
+        return response

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -7,6 +7,7 @@ from model.backtest import (  # noqa: F401
     BacktestParameters,
     BacktestRunResult,
     BacktestSummary,
+    CachedDayCandles,
     DayResult,
     DayResultSummary,
     Trade,

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -111,3 +111,15 @@ class BacktestSummary:
 class BacktestRunResult:
     summary: BacktestSummary
     days: List[DayResultSummary] = field(default_factory=list)
+
+
+@dataclass
+class CachedDayCandles:
+    """Raw Saxo candle data cached for one (backtest definition, trading
+    date) pair (FR-036-FR-040). Never holds a computed Trade/DayResult -
+    only the H1 reference candle and 5-minute session candles a day's
+    strategy evaluation is run against."""
+
+    has_data: bool
+    h1_candle: Optional[Candle] = None
+    m5_candles: List[Candle] = field(default_factory=list)

--- a/model/workflow.py
+++ b/model/workflow.py
@@ -204,11 +204,13 @@ class Candle:
 
     @staticmethod
     def from_dict(data: Dict) -> "Candle":
+        # float() coerces DynamoDB's Decimal (or any numeric type) back
+        # to a plain float; a no-op for values already stored as float.
         return Candle(
-            lower=data["lower"],
-            higher=data["higher"],
-            open=data["open"],
-            close=data["close"],
+            lower=float(data["lower"]),
+            higher=float(data["higher"]),
+            open=float(data["open"]),
+            close=float(data["close"]),
             ut=UnitTime(data["ut"]),
             date=(
                 datetime.datetime.fromisoformat(data["date"])

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -21,6 +21,7 @@ alerts_table = dynamodb.alerts_table()
 workflows_table = dynamodb.workflows_table()
 workflow_orders_table = dynamodb.workflow_orders_table()
 alert_digests_table = dynamodb.alert_digests_table()
+backtest_candle_cache_table = dynamodb.backtest_candle_cache_table()
 refresh_token_lambda = ecr_repository.repository_url.apply(
     lambda repository_url: lambda_.resfreh_token_lambda(
         repository_url, lambda_role.arn
@@ -51,6 +52,7 @@ iam.dynamodb_policy(
         workflows_table,
         workflow_orders_table,
         alert_digests_table,
+        backtest_candle_cache_table,
     ],
     lambda_role,
 )
@@ -63,6 +65,7 @@ iam.user_dynamodb_policy(
         workflows_table,
         workflow_orders_table,
         alert_digests_table,
+        backtest_candle_cache_table,
     ],
     user,
 )
@@ -138,3 +141,6 @@ pulumi.export("alerts_table_name", alerts_table.name)
 pulumi.export("workflows_table_name", workflows_table.name)
 pulumi.export("workflow_orders_table_name", workflow_orders_table.name)
 pulumi.export("alert_digests_table_name", alert_digests_table.name)
+pulumi.export(
+    "backtest_candle_cache_table_name", backtest_candle_cache_table.name
+)

--- a/pulumi/dynamodb.py
+++ b/pulumi/dynamodb.py
@@ -105,3 +105,21 @@ def alert_digests_table() -> aws.dynamodb.Table:
         stream_enabled=True,
         stream_view_type="NEW_AND_OLD_IMAGES",
     )
+
+
+def backtest_candle_cache_table() -> aws.dynamodb.Table:
+    return aws.dynamodb.Table(
+        "backtest_candle_cache",
+        attributes=[
+            aws.dynamodb.TableAttributeArgs(name="definition_code", type="S"),
+            aws.dynamodb.TableAttributeArgs(name="trading_date", type="S"),
+        ],
+        hash_key="definition_code",
+        range_key="trading_date",
+        name="backtest_candle_cache",
+        billing_mode="PAY_PER_REQUEST",
+        stream_enabled=True,
+        stream_view_type="NEW_AND_OLD_IMAGES",
+        # No TTL (FR-040): a closed historical trading day's candles
+        # never change once cached.
+    )

--- a/pulumi/dynamodb.py
+++ b/pulumi/dynamodb.py
@@ -118,8 +118,8 @@ def backtest_candle_cache_table() -> aws.dynamodb.Table:
         range_key="trading_date",
         name="backtest_candle_cache",
         billing_mode="PAY_PER_REQUEST",
-        stream_enabled=True,
-        stream_view_type="NEW_AND_OLD_IMAGES",
+        # No stream: nothing consumes one, and it's a paid feature on a
+        # table whose entire purpose is cost reduction.
         # No TTL (FR-040): a closed historical trading day's candles
         # never change once cached.
     )

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -14,6 +14,7 @@ from api.services.backtest_service import (
     paris_reference_window_utc,
     paris_session_end_utc,
 )
+from client.aws_client import DynamoDBClient, DynamoDBOperationError
 from model import (
     BacktestDefinition,
     BacktestParameters,
@@ -154,25 +155,25 @@ class TestCandleDate:
 
 
 class TestEvaluateDayNoData:
-    def test_missing_h1_candle_returns_no_data(self):
+    async def test_missing_h1_candle_returns_no_data(self):
         service = make_service(h1_candles=[], m5_candles=[])
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_DATA
         assert result.trades == []
         assert result.h1_high is None
         assert result.h1_low is None
 
-    def test_h1_fetch_raising_returns_no_data(self):
+    async def test_h1_fetch_raising_returns_no_data(self):
         service = make_service(h1_candles=[], m5_candles=[], raise_on_h1=True)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_DATA
 
-    def test_m5_fetch_raising_returns_no_trade(self):
+    async def test_m5_fetch_raising_returns_no_trade(self):
         """If the H1 reference is available but the 5-minute fetch
         fails, the day is a NO_TRADE (not NO_DATA, which is reserved
         for a missing H1 reference per FR-004)."""
         service = make_service([h1_candle()], m5_candles=[], raise_on_m5=True)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.h1_high == H1_HIGH
         assert result.h1_low == H1_LOW
@@ -209,31 +210,31 @@ class TestListAndGetDefinition:
 
 
 class TestEvaluateDayNoTrade:
-    def test_no_breakout_below_h1_low(self):
+    async def test_no_breakout_below_h1_low(self):
         candles = [
             m5_candle(0, 8010, 8020, 8005, 8015),
             m5_candle(1, 8015, 8025, 8010, 8020),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
         assert result.h1_high == H1_HIGH
         assert result.h1_low == H1_LOW
 
-    def test_breakdown_without_confirmed_reversal(self):
+    async def test_breakdown_without_confirmed_reversal(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),  # breach, no close-back
             m5_candle(1, 7995, 8000, 7985, 7990),  # still below h1_low
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
 
 class TestEvaluateDayCandleOrdering:
-    def test_day_result_candles_are_chronological_even_if_fetched_reversed(
+    async def test_day_result_candles_chronological_even_if_fetched_reversed(
         self,
     ):
         """The real SaxoClient returns candles newest-first (repo-wide
@@ -249,14 +250,14 @@ class TestEvaluateDayCandleOrdering:
         ]
         newest_first = list(reversed(chronological_candles))
         service = make_service([h1_candle()], newest_first)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert [c.date for c in result.candles] == [
             c.date for c in chronological_candles
         ]
 
 
 class TestEvaluateDayExits:
-    def test_stop_loss_exit(self):
+    async def test_stop_loss_exit(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),  # breach
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -264,7 +265,7 @@ class TestEvaluateDayExits:
             m5_candle(3, 8000, 8005, 7950, 7955),  # SL: low<=7965, no gap
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         assert len(result.trades) == 1
         trade = result.trades[0]
@@ -273,7 +274,7 @@ class TestEvaluateDayExits:
         assert trade.exit_price == 7965
         assert trade.points == -50
 
-    def test_stop_loss_exit_with_gap(self):
+    async def test_stop_loss_exit_with_gap(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -281,13 +282,13 @@ class TestEvaluateDayExits:
             m5_candle(3, 7900, 7910, 7850, 7880),  # gap below 7965
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 7900
         assert trade.points == -115
 
-    def test_take_profit_exit(self):
+    async def test_take_profit_exit(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -295,13 +296,13 @@ class TestEvaluateDayExits:
             m5_candle(3, 8020, 8045, 8015, 8035),  # TP: high>=8040, no gap
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8040
         assert trade.points == 25
 
-    def test_end_of_day_exit(self):
+    async def test_end_of_day_exit(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -309,13 +310,13 @@ class TestEvaluateDayExits:
             m5_candle(3, 8012, 8020, 8005, 8018),  # last candle of the day
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.END_OF_DAY
         assert trade.exit_price == 8018
         assert trade.points == 3
 
-    def test_entry_on_last_candle_produces_zero_point_end_of_day(self):
+    async def test_entry_on_last_candle_produces_zero_point_end_of_day(self):
         """A breakout that only confirms on the session's final
         5-minute candle opens and immediately closes (end of day) on
         that same candle, since there is no further candle to
@@ -327,7 +328,7 @@ class TestEvaluateDayExits:
             m5_candle(2, 8010, 8020, 8005, 8015),  # breakout, also last
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.entry_price == 8015
@@ -335,7 +336,7 @@ class TestEvaluateDayExits:
         assert trade.exit_reason == ExitReason.END_OF_DAY
         assert trade.points == 0
 
-    def test_break_even_exit(self):
+    async def test_break_even_exit(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -344,14 +345,14 @@ class TestEvaluateDayExits:
             m5_candle(4, 8020, 8025, 8005, 8000),  # BE exit: low<=8015
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.BREAK_EVEN
         assert trade.exit_price == 8015
         assert trade.points == 0
 
-    def test_break_even_exit_with_gap_is_not_exactly_zero(self):
+    async def test_break_even_exit_with_gap_is_not_exactly_zero(self):
         """FR-010's gap-fill rule applies uniformly to all exit types,
         including break-even (resolved explicitly after PR review):
         a candle that opens below the (now break-even) stop records
@@ -365,14 +366,14 @@ class TestEvaluateDayExits:
             m5_candle(4, 8005, 8008, 7995, 8000),  # gap: open 8005 < 8015
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.BREAK_EVEN
         assert trade.exit_price == 8005
         assert trade.points == -10
 
-    def test_multi_trade_day_reentry(self):
+    async def test_multi_trade_day_reentry(self):
         candles = [
             # Trade 1: breach -> candidate -> breakout @8015 -> stop-loss
             m5_candle(0, 8005, 8010, 7990, 7995),
@@ -386,7 +387,7 @@ class TestEvaluateDayExits:
             m5_candle(7, 8010, 8020, 8000, 8015),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         assert len(result.trades) == 2
         assert result.trades[0].entry_price == 8015
@@ -403,18 +404,22 @@ class TestBreakoutConfirmation:
     candidate reversal candle - entry only fires once a later candle's
     high trades above that candidate's high."""
 
-    def test_reversal_without_breakout_confirmation_produces_no_trade(self):
+    async def test_reversal_without_breakout_confirmation_produces_no_trade(
+        self,
+    ):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),  # breach
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
             m5_candle(2, 8010, 8014, 8005, 8012),  # never exceeds 8015
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_candidate_rolls_forward_when_breakout_not_yet_confirmed(self):
+    async def test_candidate_rolls_forward_when_breakout_not_yet_confirmed(
+        self,
+    ):
         """A candle that stays above the H1 low but fails to beat the
         current candidate's high becomes the new candidate itself,
         rather than cancelling the signal."""
@@ -425,11 +430,11 @@ class TestBreakoutConfirmation:
             m5_candle(3, 8010, 8020, 8005, 8015),  # breaks 8014 -> entry
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].entry_price == 8014
 
-    def test_candidate_closing_back_below_h1_low_requires_a_fresh_breach(
+    async def test_candidate_closing_back_below_h1_low_requires_a_fresh_breach(
         self,
     ):
         """While waiting for a breakout, a candle that closes back
@@ -444,11 +449,11 @@ class TestBreakoutConfirmation:
             m5_candle(4, 8010, 8025, 8000, 8015),  # breaks 8020 -> entry
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].entry_price == 8020
 
-    def test_breakout_entry_gap_fill(self):
+    async def test_breakout_entry_gap_fill(self):
         """A candle that opens above the candidate's high (a gap)
         records the entry at that worse open price, not the exact
         breakout level - same gap-fill convention as the exits."""
@@ -458,13 +463,13 @@ class TestBreakoutConfirmation:
             m5_candle(2, 8020, 8030, 8015, 8025),  # gaps above 8015
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].entry_price == 8020
 
 
 class TestEvaluateDaySameCandleEdgeCases:
-    def test_stop_loss_priority_over_same_candle_be_arm(self):
+    async def test_stop_loss_priority_over_same_candle_be_arm(self):
         """A candle that would both breach the original stop-loss and
         reach the +20pt break-even-arm threshold resolves as a
         stop-loss using the pre-candle level, not a break-even arm."""
@@ -476,13 +481,13 @@ class TestEvaluateDaySameCandleEdgeCases:
             m5_candle(3, 8005, 8035, 7950, 8000),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 7965
 
-    def test_arm_and_breach_round_trip_does_not_exit_same_candle(self):
+    async def test_arm_and_breach_round_trip_does_not_exit_same_candle(self):
         """A candle whose high reaches the +20pt arm threshold and whose
         low would also breach the not-yet-armed break-even level (but
         not the original stop) must not itself produce a break-even
@@ -498,7 +503,7 @@ class TestEvaluateDaySameCandleEdgeCases:
             m5_candle(4, 8020, 8025, 8005, 8000),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.BREAK_EVEN
@@ -558,7 +563,7 @@ class TestIsValidShortEntry:
 
 
 class TestEvaluateDayEntryValidityRule:
-    def test_entry_too_far_above_h1_low_is_rejected(self):
+    async def test_entry_too_far_above_h1_low_is_rejected(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),  # breach
             m5_candle(1, 8015, 8026, 8005, 8020),  # candidate, higher=8026
@@ -566,11 +571,11 @@ class TestEvaluateDayEntryValidityRule:
             m5_candle(2, 8020, 8030, 8010, 8025),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_entry_at_or_above_take_profit_is_rejected(self):
+    async def test_entry_at_or_above_take_profit_is_rejected(self):
         h1 = h1_candle(higher=8025, lower=8005)  # take_profit_level = 8015
         candles = [
             m5_candle(0, 8010, 8015, 7995, 8000),  # breach
@@ -579,11 +584,11 @@ class TestEvaluateDayEntryValidityRule:
             m5_candle(2, 8012, 8020, 8005, 8015),
         ]
         service = make_service([h1], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_rejected_entry_still_allows_a_fresh_signal_afterwards(self):
+    async def test_rejected_entry_still_allows_a_fresh_signal_afterwards(self):
         """After an invalid entry, the search resets so a later,
         independent breach/candidate/breakout sequence can still
         produce a valid trade the same day."""
@@ -597,7 +602,7 @@ class TestEvaluateDayEntryValidityRule:
             m5_candle(6, 8012, 8020, 8005, 8018),  # end of day
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         assert len(result.trades) == 1
         trade = result.trades[0]
@@ -612,7 +617,9 @@ class TestBreachRequiresCloseOutsideRange:
     inside it does not arm a breach, so a subsequent reversal/breakout
     sequence produces no trade."""
 
-    def test_long_wick_below_low_that_closes_inside_is_not_a_breach(self):
+    async def test_long_wick_below_low_that_closes_inside_is_not_a_breach(
+        self,
+    ):
         candles = [
             # low 7990 dips below h1_low 8000 but close 8005 is inside
             m5_candle(0, 8005, 8010, 7990, 8005),
@@ -620,11 +627,13 @@ class TestBreachRequiresCloseOutsideRange:
             m5_candle(2, 8010, 8020, 8005, 8015),  # would-be breakout
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_short_wick_above_high_that_closes_inside_is_not_a_breach(self):
+    async def test_short_wick_above_high_that_closes_inside_is_not_a_breach(
+        self,
+    ):
         candles = [
             # high 8060 pierces h1_high 8050 but close 8045 is inside
             m5_candle(0, 8045, 8060, 8040, 8045),
@@ -632,7 +641,7 @@ class TestBreachRequiresCloseOutsideRange:
             m5_candle(2, 8040, 8045, 8030, 8035),  # would-be breakdown
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
@@ -642,7 +651,7 @@ class TestEvaluateDayShort:
     low=8000, so the short take-profit is 8010 (low + 10) and the short
     stop-loss sits 50 points above entry."""
 
-    def test_short_stop_loss_exit(self):
+    async def test_short_stop_loss_exit(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),  # breach above high
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -650,7 +659,7 @@ class TestEvaluateDayShort:
             m5_candle(3, 8080, 8090, 8075, 8085),  # SL: high>=8088, no gap
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         assert len(result.trades) == 1
         trade = result.trades[0]
@@ -660,7 +669,7 @@ class TestEvaluateDayShort:
         assert trade.exit_price == 8088
         assert trade.points == -50
 
-    def test_short_stop_loss_exit_with_gap(self):
+    async def test_short_stop_loss_exit_with_gap(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -668,14 +677,14 @@ class TestEvaluateDayShort:
             m5_candle(3, 8095, 8100, 8090, 8098),  # gap above 8088
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 8095
         assert trade.points == -57
 
-    def test_short_take_profit_exit(self):
+    async def test_short_take_profit_exit(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -683,14 +692,14 @@ class TestEvaluateDayShort:
             m5_candle(3, 8015, 8018, 8005, 8010),  # TP: low<=8010, no gap
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8010
         assert trade.points == 28
 
-    def test_short_end_of_day_exit(self):
+    async def test_short_end_of_day_exit(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -698,14 +707,14 @@ class TestEvaluateDayShort:
             m5_candle(3, 8036, 8040, 8030, 8035),  # last candle of the day
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
         assert trade.exit_reason == ExitReason.END_OF_DAY
         assert trade.exit_price == 8035
         assert trade.points == 3
 
-    def test_short_break_even_exit(self):
+    async def test_short_break_even_exit(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -714,7 +723,7 @@ class TestEvaluateDayShort:
             m5_candle(4, 8030, 8045, 8025, 8035),  # BE exit: high>=8038
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
@@ -722,18 +731,20 @@ class TestEvaluateDayShort:
         assert trade.exit_price == 8038
         assert trade.points == 0
 
-    def test_short_reversal_without_breakdown_confirmation_no_trade(self):
+    async def test_short_reversal_without_breakdown_confirmation_no_trade(
+        self,
+    ):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),  # breach above high
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
             m5_candle(2, 8042, 8048, 8041, 8045),  # never breaks below 8040
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_short_entry_too_far_below_h1_high_is_rejected(self):
+    async def test_short_entry_too_far_below_h1_high_is_rejected(self):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),  # breach above high
             m5_candle(1, 8050, 8055, 8025, 8045),  # candidate, lower=8025
@@ -741,11 +752,11 @@ class TestEvaluateDayShort:
             m5_candle(2, 8028, 8030, 8020, 8025),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
-    def test_short_breakdown_entry_gap_fill(self):
+    async def test_short_breakdown_entry_gap_fill(self):
         """Mirror of the long-side gap-fill entry: a confirming candle
         that opens below the candidate's low records the short entry at
         that worse open price, not the exact breakdown level."""
@@ -755,12 +766,12 @@ class TestEvaluateDayShort:
             m5_candle(2, 8035, 8038, 8025, 8030),  # gaps below 8040
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].direction == Direction.SELL
         assert result.trades[0].entry_price == 8035
 
-    def test_short_candidate_closing_back_above_h1_high_needs_fresh_breach(
+    async def test_short_candidate_closing_above_h1_high_needs_fresh_breach(
         self,
     ):
         """Mirror of the long-side discard rule: while waiting for a
@@ -775,12 +786,12 @@ class TestEvaluateDayShort:
             m5_candle(4, 8038, 8042, 8030, 8035),  # breaks 8035 -> entry
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].direction == Direction.SELL
         assert result.trades[0].entry_price == 8035
 
-    def test_short_candidate_rolls_forward_when_not_yet_confirmed(self):
+    async def test_short_candidate_rolls_forward_when_not_yet_confirmed(self):
         """Mirror of the long-side roll-forward: a candle that stays
         below the H1 high but fails to break the current candidate's
         low becomes the new candidate itself, rather than cancelling
@@ -792,14 +803,14 @@ class TestEvaluateDayShort:
             m5_candle(3, 8042, 8044, 8035, 8038),  # breaks 8041 -> entry
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         assert result.trades[0].direction == Direction.SELL
         assert result.trades[0].entry_price == 8041
 
 
 class TestBothDirectionsOnePositionAtATime:
-    def test_long_then_short_sequential_same_day(self):
+    async def test_long_then_short_sequential_same_day(self):
         """Both directions are evaluated on the same day but only one
         position is open at a time: a long opens first, and only after
         it closes does the short signal (a break above the H1 high and
@@ -817,7 +828,7 @@ class TestBothDirectionsOnePositionAtATime:
             m5_candle(7, 8035, 8045, 8030, 8040),  # end of day
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         assert len(result.trades) == 2
 
@@ -834,7 +845,7 @@ class TestBothDirectionsOnePositionAtATime:
         assert second.exit_price == 8040
         assert second.points == -2
 
-    def test_high_breach_closing_a_long_does_not_also_open_a_short(self):
+    async def test_high_breach_closing_a_long_does_not_also_open_a_short(self):
         """Because the short reference (H1 high) sits above the long
         take-profit (H1 high - 10), the very candle that breaks above
         the high closes the open long on take-profit. That closing
@@ -851,7 +862,7 @@ class TestBothDirectionsOnePositionAtATime:
             m5_candle(5, 8042, 8046, 8038, 8040),  # last candle, flat
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.direction == Direction.BUY
@@ -874,7 +885,9 @@ class TestTimeCutVariant:
         m5_candle(2, 8010, 8020, 8005, 8015),  # breakout -> entry @8015
     ]
 
-    def test_long_position_is_cut_after_30_min_without_favorable_move(self):
+    async def test_long_position_is_cut_after_30_min_without_favorable_move(
+        self,
+    ):
         candles = self.ENTRY_CANDLES + [
             m5_candle(3, 8015, 8018, 8010, 8016),
             m5_candle(4, 8016, 8019, 8011, 8017),
@@ -884,7 +897,7 @@ class TestTimeCutVariant:
             m5_candle(8, 8014, 8018, 8009, 8012),  # 08:40 -> time cut
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.direction == Direction.BUY
@@ -894,7 +907,9 @@ class TestTimeCutVariant:
         assert trade.exit_time == candles[8].date
         assert trade.points == -3
 
-    def test_position_survives_when_favorable_move_exceeds_threshold(self):
+    async def test_position_survives_when_favorable_move_exceeds_threshold(
+        self,
+    ):
         candles = self.ENTRY_CANDLES + [
             m5_candle(3, 8015, 8030, 8010, 8025),  # +15 favorable
             m5_candle(4, 8020, 8022, 8012, 8018),
@@ -904,13 +919,13 @@ class TestTimeCutVariant:
             m5_candle(8, 8014, 8018, 8009, 8012),  # 08:40, but not cut
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.END_OF_DAY
         assert trade.exit_price == 8012
 
-    def test_exactly_five_points_favorable_still_cuts(self):
+    async def test_exactly_five_points_favorable_still_cuts(self):
         """ "Never been higher than 5 points" is inclusive: a best move of
         exactly 5 points (a high of 8020) does not spare the position."""
         candles = self.ENTRY_CANDLES + [
@@ -922,10 +937,10 @@ class TestTimeCutVariant:
             m5_candle(8, 8014, 8018, 8009, 8012),  # 08:40 -> time cut
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
         assert result.trades[0].exit_reason == ExitReason.TIME_CUT
 
-    def test_plain_b9h_definition_is_never_time_cut(self):
+    async def test_plain_b9h_definition_is_never_time_cut(self):
         """The same stalling day on the plain B9H definition (no time-cut
         config) holds the position to the end of day - proving the rule
         is isolated to the time-cut variant."""
@@ -938,10 +953,12 @@ class TestTimeCutVariant:
             m5_candle(8, 8014, 8018, 8009, 8012),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
         assert result.trades[0].exit_reason == ExitReason.END_OF_DAY
 
-    def test_short_position_is_cut_after_30_min_without_favorable_move(self):
+    async def test_short_position_is_cut_after_30_min_without_favorable_move(
+        self,
+    ):
         candles = [
             m5_candle(0, 8055, 8060, 8050, 8052),  # breach above high
             m5_candle(1, 8050, 8052, 8040, 8045),  # candidate, lower=8040
@@ -954,7 +971,7 @@ class TestTimeCutVariant:
             m5_candle(8, 8038, 8041, 8034, 8037),  # 08:40 -> time cut
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
         assert len(result.trades) == 1
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
@@ -976,7 +993,7 @@ def make_trade(exit_reason, points, entry_price=8010.0):
 
 
 class TestRunRange:
-    def test_aggregates_across_days_and_excludes_no_data(self, mocker):
+    async def test_aggregates_across_days_and_excludes_no_data(self, mocker):
         service = BacktestService(MagicMock(spec=CandlesService))
         day1 = datetime.date(2026, 6, 1)
         day2 = datetime.date(2026, 6, 2)
@@ -1007,7 +1024,7 @@ class TestRunRange:
             side_effect=lambda d, date, params: results[date],
         )
 
-        result = service.run_range(DEFINITION, day1, day3)
+        result = await service.run_range(DEFINITION, day1, day3)
 
         assert result.summary.number_of_days == 2  # NO_DATA excluded
         assert result.summary.number_of_trades == 3
@@ -1024,7 +1041,9 @@ class TestRunRange:
         assert result.days[1].trade_count == 3
         assert result.days[1].points == -20
 
-    def test_weekends_are_skipped_without_calling_evaluate_day(self, mocker):
+    async def test_weekends_are_skipped_without_calling_evaluate_day(
+        self, mocker
+    ):
         """Saturday/Sunday never trade, so run_range must not spend a
         fetch resolving them to NO_DATA - it should skip evaluate_day
         for those dates entirely."""
@@ -1039,13 +1058,13 @@ class TestRunRange:
             ),
         )
 
-        result = service.run_range(DEFINITION, friday, monday)
+        result = await service.run_range(DEFINITION, friday, monday)
 
         called_dates = [call.args[1] for call in evaluate_day.call_args_list]
         assert called_dates == [friday, monday]
         assert result.summary.number_of_days == 2
 
-    def test_empty_range_returns_all_zero_summary(self, mocker):
+    async def test_empty_range_returns_all_zero_summary(self, mocker):
         service = BacktestService(MagicMock(spec=CandlesService))
         day = datetime.date(2026, 6, 2)
         mocker.patch.object(
@@ -1056,7 +1075,7 @@ class TestRunRange:
             ),
         )
 
-        result = service.run_range(DEFINITION, day, day)
+        result = await service.run_range(DEFINITION, day, day)
 
         assert result.summary.number_of_days == 1
         assert result.summary.number_of_trades == 0
@@ -1067,7 +1086,7 @@ class TestRunRange:
         assert result.summary.average_loss is None
         assert result.summary.final_result == 0
 
-    def test_zero_point_non_be_trade_counts_as_losing(self, mocker):
+    async def test_zero_point_non_be_trade_counts_as_losing(self, mocker):
         """A trade with points == 0 that did NOT close via the
         break-even mechanism (e.g. an end-of-day close landing exactly
         on the entry price) counts as a losing position, not a win or
@@ -1086,14 +1105,14 @@ class TestRunRange:
             ),
         )
 
-        result = service.run_range(DEFINITION, day, day)
+        result = await service.run_range(DEFINITION, day, day)
 
         assert result.summary.number_of_trades == 1
         assert result.summary.number_of_winning_positions == 0
         assert result.summary.number_of_losing_positions == 1
         assert result.summary.number_of_be == 0
 
-    def test_gapped_be_trade_stays_be_not_losing(self, mocker):
+    async def test_gapped_be_trade_stays_be_not_losing(self, mocker):
         """A BREAK_EVEN trade with non-zero points (gap-through, see
         evaluate_day's gap test) is still classified as BE, not as a
         loss, and its points are excluded from average_loss - only
@@ -1113,7 +1132,7 @@ class TestRunRange:
             ),
         )
 
-        result = service.run_range(DEFINITION, day, day)
+        result = await service.run_range(DEFINITION, day, day)
 
         assert result.summary.number_of_trades == 1
         assert result.summary.number_of_be == 1
@@ -1122,7 +1141,7 @@ class TestRunRange:
         assert result.summary.average_loss is None
         assert result.summary.final_result == -5
 
-    def test_zero_point_end_of_day_trade_counts_as_losing(self, mocker):
+    async def test_zero_point_end_of_day_trade_counts_as_losing(self, mocker):
         """A non-BE trade that closes at exactly 0 points (e.g. entry
         confirmed on the session's last candle, see evaluate_day's
         same-candle EOD test) is classified as a losing position, not a
@@ -1142,7 +1161,7 @@ class TestRunRange:
             ),
         )
 
-        result = service.run_range(DEFINITION, day, day)
+        result = await service.run_range(DEFINITION, day, day)
 
         assert result.summary.number_of_trades == 1
         assert result.summary.number_of_be == 0
@@ -1164,9 +1183,9 @@ class TestBacktestParameters:
         m5_candle(3, 8000, 8005, 7950, 7955),  # stop hit, no gap
     ]
 
-    def test_explicit_default_params_match_the_hardcoded_result(self):
+    async def test_explicit_default_params_match_the_hardcoded_result(self):
         service = make_service([h1_candle()], self.STOP_LOSS_CANDLES)
-        result = service.evaluate_day(
+        result = await service.evaluate_day(
             DEFINITION, TRADING_DATE, BacktestParameters()
         )
         trade = result.trades[0]
@@ -1174,16 +1193,16 @@ class TestBacktestParameters:
         assert trade.exit_price == 7965
         assert trade.points == -50
 
-    def test_custom_stop_loss_points_tightens_the_stop(self):
+    async def test_custom_stop_loss_points_tightens_the_stop(self):
         service = make_service([h1_candle()], self.STOP_LOSS_CANDLES)
         params = BacktestParameters(stop_loss_points=30)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE, params)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE, params)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 7985  # 8015 - 30 instead of - 50
         assert trade.points == -30
 
-    def test_custom_take_profit_offset_moves_the_target(self):
+    async def test_custom_take_profit_offset_moves_the_target(self):
         candles = [
             m5_candle(0, 8005, 8010, 7990, 7995),
             m5_candle(1, 8000, 8015, 7995, 8010),  # candidate, higher=8015
@@ -1192,19 +1211,19 @@ class TestBacktestParameters:
         ]
         service = make_service([h1_candle()], candles)
         params = BacktestParameters(take_profit_offset_points=20)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE, params)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE, params)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8030  # 8050 - 20 instead of - 10
         assert trade.points == 15
 
-    def test_custom_max_entry_distance_rejects_a_far_entry(self):
+    async def test_custom_max_entry_distance_rejects_a_far_entry(self):
         """With the default 20-point window the breakout at 8015 (15
         points above the 8000 low) is a valid entry; tightening the
         window to 10 points rejects it, so no trade is taken."""
         service = make_service([h1_candle()], self.STOP_LOSS_CANDLES)
         params = BacktestParameters(max_entry_distance_points=10)
-        result = service.evaluate_day(DEFINITION, TRADING_DATE, params)
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE, params)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
 
@@ -1275,7 +1294,7 @@ class TestMm50SlopeBefore:
 
 
 class TestRunRangeThreadsRegime:
-    def test_mm50_slope_populated_on_summary(self):
+    async def test_mm50_slope_populated_on_summary(self):
         trading_date = datetime.date(2026, 6, 2)
         service = make_service(
             [h1_candle()], TestBacktestParameters.STOP_LOSS_CANDLES
@@ -1283,7 +1302,9 @@ class TestRunRangeThreadsRegime:
         service.candles_service.build_candles.return_value = (
             uptrend_daily_series(trading_date, 70)
         )
-        result = service.run_range(DEFINITION, trading_date, trading_date)
+        result = await service.run_range(
+            DEFINITION, trading_date, trading_date
+        )
         assert len(result.days) == 1
         assert result.days[0].mm50_slope is not None
         assert result.days[0].mm50_slope > 0
@@ -1384,35 +1405,54 @@ class TestWideRangeStructuralStop:
         m5_candle(2, 8010, 8020, 8005, 8015),  # breakout -> entry @8015
     ]
 
-    def test_narrow_range_day_takes_no_trades(self):
+    async def test_narrow_range_day_takes_no_trades(self):
         narrow = h1_candle(higher=8030.0, lower=8000.0)  # range 30 <= 40
         service = make_service([narrow], self.ENTRY_CANDLES)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
         assert result.h1_high == 8030.0 and result.h1_low == 8000.0
 
-    def test_range_exactly_at_threshold_takes_no_trades(self):
+    async def test_range_exactly_at_threshold_takes_no_trades(self):
         # strictly greater than 40 required -> a range of exactly 40 is out
         at_threshold = h1_candle(higher=8040.0, lower=8000.0)
         service = make_service([at_threshold], self.ENTRY_CANDLES)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.NO_TRADE
 
-    def test_wide_range_long_structural_stop_exits_at_close(self):
+    async def test_narrow_range_day_skips_the_five_minute_fetch(self):
+        """The range filter must run before the m5 fetch (FR-033), both
+        to avoid the wasted Saxo call and so a re-run of the same day
+        stays NO_TRADE from the cached H1 candle alone."""
+        narrow = h1_candle(higher=8030.0, lower=8000.0)  # range 30 <= 40
+        candles_service = MagicMock(spec=CandlesService)
+
+        def side_effect(code, ut, horizon, start, end):
+            if ut == UnitTime.H1:
+                return [narrow]
+            raise AssertionError("m5 candles must not be fetched")
+
+        candles_service.get_candles_in_window.side_effect = side_effect
+        service = BacktestService(candles_service)
+
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+
+        assert result.status == DayStatus.NO_TRADE
+
+    async def test_wide_range_long_structural_stop_exits_at_close(self):
         candles = self.ENTRY_CANDLES + [
             # unarmed; closes below h1 low 8000 -> structural stop at close
             m5_candle(3, 8000, 8005, 7950, 7955),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         assert result.status == DayStatus.TRADED
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 7955.0  # the candle's close, not h1 low
         assert trade.points == round(7955.0 - 8015.0, 4)
 
-    def test_wide_range_short_structural_stop_exits_at_close(self):
+    async def test_wide_range_short_structural_stop_exits_at_close(self):
         short_candles = [
             m5_candle(0, 8045, 8060, 8040, 8055),  # breach above h1 high
             m5_candle(1, 8050, 8055, 8035, 8040),  # candidate, lower=8035
@@ -1421,14 +1461,14 @@ class TestWideRangeStructuralStop:
             m5_candle(3, 8090, 8110, 8085, 8095),
         ]
         service = make_service([h1_candle()], short_candles)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
         assert trade.exit_reason == ExitReason.STOP_LOSS
         assert trade.exit_price == 8095.0
         assert trade.points == round(8035.0 - 8095.0, 4)
 
-    def test_break_even_supersedes_structural_stop(self):
+    async def test_break_even_supersedes_structural_stop(self):
         candles = self.ENTRY_CANDLES + [
             # high 8036 >= entry+20 (8035) arms break-even, no TP (8040)
             m5_candle(3, 8016, 8036, 8015, 8030),
@@ -1437,29 +1477,151 @@ class TestWideRangeStructuralStop:
             m5_candle(4, 8020, 8022, 7990, 7995),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.BREAK_EVEN
         assert trade.exit_price == 8015.0
 
-    def test_take_profit_wins_over_structural_in_same_candle(self):
+    async def test_take_profit_wins_over_structural_in_same_candle(self):
         candles = self.ENTRY_CANDLES + [
             # high 8045 reaches TP (8040) AND close 7995 is below h1 low:
             # TP is reached intrabar (earlier), so it wins
             m5_candle(3, 8016, 8045, 7990, 7995),
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8040.0
 
-    def test_take_profit_still_exits_normally(self):
+    async def test_take_profit_still_exits_normally(self):
         candles = self.ENTRY_CANDLES + [
             m5_candle(3, 8016, 8045, 8014, 8042),  # high 8045 >= TP 8040
         ]
         service = make_service([h1_candle()], candles)
-        result = service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8040.0
+
+
+class TestBacktestCandleCache:
+    """FR-036-FR-040: the raw-candle cache is a capability of
+    BacktestService itself, keyed by (definition.code, trading_date) -
+    these tests exercise it directly against a mocked DynamoDBClient,
+    independently of the CandlesService-fetch tests above."""
+
+    def _service(self, dynamodb_client):
+        candles_service = MagicMock(spec=CandlesService)
+
+        def side_effect(code, ut, horizon, start, end):
+            if ut == UnitTime.H1:
+                return [h1_candle()]
+            return [m5_candle(0, 8005, 8010, 7995, 8000)]
+
+        candles_service.get_candles_in_window.side_effect = side_effect
+        return BacktestService(candles_service, dynamodb_client), (
+            candles_service
+        )
+
+    async def test_cache_hit_skips_saxo_and_uses_cached_candles(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value={
+                "has_data": True,
+                "h1_candle": h1_candle().to_dict(),
+                "m5_candles": [m5_candle(0, 8005, 8010, 7995, 8000).to_dict()],
+            }
+        )
+        service, candles_service = self._service(dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_not_called()
+        dynamodb_client.store_backtest_candles.assert_not_called()
+        assert result.h1_high == H1_HIGH
+        assert result.h1_low == H1_LOW
+        assert len(result.candles) == 1
+
+    async def test_cache_hit_no_data_skips_saxo(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value={"has_data": False}
+        )
+        service, candles_service = self._service(dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_not_called()
+        assert result.status == DayStatus.NO_DATA
+
+    async def test_cache_miss_fetches_and_stores(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        service, candles_service = self._service(dynamodb_client)
+
+        await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_called()
+        dynamodb_client.store_backtest_candles.assert_called_once()
+        args = dynamodb_client.store_backtest_candles.call_args[0]
+        assert args[0] == DEFINITION.code
+        assert args[1] == TRADING_DATE.isoformat()
+        assert args[2] is True
+
+    async def test_cache_miss_with_no_h1_data_stores_no_data_marker(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        candles_service = MagicMock(spec=CandlesService)
+        candles_service.get_candles_in_window.return_value = []
+        service = BacktestService(candles_service, dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        assert result.status == DayStatus.NO_DATA
+        dynamodb_client.store_backtest_candles.assert_called_once_with(
+            DEFINITION.code, TRADING_DATE.isoformat(), False, None, None
+        )
+
+    async def test_no_dynamodb_client_falls_back_to_saxo_every_time(self):
+        service, candles_service = self._service(None)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_called()
+        assert result.h1_high == H1_HIGH
+
+    async def test_cache_lookup_failure_falls_back_to_saxo(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            side_effect=DynamoDBOperationError("get_item", "boom")
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock(
+            side_effect=DynamoDBOperationError("put_item", "boom")
+        )
+        service, candles_service = self._service(dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_called()
+        assert result.h1_high == H1_HIGH
+
+    async def test_different_definitions_cache_independently(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        service, _ = self._service(dynamodb_client)
+
+        await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
+
+        dynamodb_client.get_cached_backtest_candles.assert_called_once_with(
+            TIME_CUT_DEFINITION.code, TRADING_DATE.isoformat()
+        )

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -1408,7 +1408,9 @@ class TestWideRangeStructuralStop:
     async def test_narrow_range_day_takes_no_trades(self):
         narrow = h1_candle(higher=8030.0, lower=8000.0)  # range 30 <= 40
         service = make_service([narrow], self.ENTRY_CANDLES)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         assert result.status == DayStatus.NO_TRADE
         assert result.trades == []
         assert result.h1_high == 8030.0 and result.h1_low == 8000.0
@@ -1417,7 +1419,9 @@ class TestWideRangeStructuralStop:
         # strictly greater than 40 required -> a range of exactly 40 is out
         at_threshold = h1_candle(higher=8040.0, lower=8000.0)
         service = make_service([at_threshold], self.ENTRY_CANDLES)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         assert result.status == DayStatus.NO_TRADE
 
     async def test_narrow_range_day_skips_the_five_minute_fetch(self):
@@ -1435,7 +1439,9 @@ class TestWideRangeStructuralStop:
         candles_service.get_candles_in_window.side_effect = side_effect
         service = BacktestService(candles_service)
 
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
 
         assert result.status == DayStatus.NO_TRADE
 
@@ -1445,7 +1451,9 @@ class TestWideRangeStructuralStop:
             m5_candle(3, 8000, 8005, 7950, 7955),
         ]
         service = make_service([h1_candle()], candles)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         assert result.status == DayStatus.TRADED
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.STOP_LOSS
@@ -1461,7 +1469,9 @@ class TestWideRangeStructuralStop:
             m5_candle(3, 8090, 8110, 8085, 8095),
         ]
         service = make_service([h1_candle()], short_candles)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         trade = result.trades[0]
         assert trade.direction == Direction.SELL
         assert trade.exit_reason == ExitReason.STOP_LOSS
@@ -1477,7 +1487,9 @@ class TestWideRangeStructuralStop:
             m5_candle(4, 8020, 8022, 7990, 7995),
         ]
         service = make_service([h1_candle()], candles)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.BREAK_EVEN
         assert trade.exit_price == 8015.0
@@ -1489,7 +1501,9 @@ class TestWideRangeStructuralStop:
             m5_candle(3, 8016, 8045, 7990, 7995),
         ]
         service = make_service([h1_candle()], candles)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8040.0
@@ -1499,7 +1513,9 @@ class TestWideRangeStructuralStop:
             m5_candle(3, 8016, 8045, 8014, 8042),  # high 8045 >= TP 8040
         ]
         service = make_service([h1_candle()], candles)
-        result = await service.evaluate_day(WIDE_RANGE_DEFINITION, TRADING_DATE)
+        result = await service.evaluate_day(
+            WIDE_RANGE_DEFINITION, TRADING_DATE
+        )
         trade = result.trades[0]
         assert trade.exit_reason == ExitReason.TAKE_PROFIT
         assert trade.exit_price == 8040.0
@@ -1507,9 +1523,10 @@ class TestWideRangeStructuralStop:
 
 class TestBacktestCandleCache:
     """FR-036-FR-040: the raw-candle cache is a capability of
-    BacktestService itself, keyed by (definition.code, trading_date) -
-    these tests exercise it directly against a mocked DynamoDBClient,
-    independently of the CandlesService-fetch tests above."""
+    BacktestService itself, keyed by (definition code, instrument,
+    schema version, trading_date) - these tests exercise it directly
+    against a mocked DynamoDBClient, independently of the
+    CandlesService-fetch tests above."""
 
     def _service(self, dynamodb_client):
         candles_service = MagicMock(spec=CandlesService)
@@ -1555,6 +1572,21 @@ class TestBacktestCandleCache:
         candles_service.get_candles_in_window.assert_not_called()
         assert result.status == DayStatus.NO_DATA
 
+    async def test_cache_key_covers_code_instrument_and_version(self):
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        service, _ = self._service(dynamodb_client)
+
+        await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        dynamodb_client.get_cached_backtest_candles.assert_called_once_with(
+            f"{DEFINITION.code}:{DEFINITION.instrument}:v1",
+            TRADING_DATE.isoformat(),
+        )
+
     async def test_cache_miss_fetches_and_stores(self):
         dynamodb_client = MagicMock(spec=DynamoDBClient)
         dynamodb_client.get_cached_backtest_candles = AsyncMock(
@@ -1568,7 +1600,7 @@ class TestBacktestCandleCache:
         candles_service.get_candles_in_window.assert_called()
         dynamodb_client.store_backtest_candles.assert_called_once()
         args = dynamodb_client.store_backtest_candles.call_args[0]
-        assert args[0] == DEFINITION.code
+        assert args[0] == f"{DEFINITION.code}:{DEFINITION.instrument}:v1"
         assert args[1] == TRADING_DATE.isoformat()
         assert args[2] is True
 
@@ -1586,8 +1618,74 @@ class TestBacktestCandleCache:
 
         assert result.status == DayStatus.NO_DATA
         dynamodb_client.store_backtest_candles.assert_called_once_with(
-            DEFINITION.code, TRADING_DATE.isoformat(), False, None, None
+            f"{DEFINITION.code}:{DEFINITION.instrument}:v1",
+            TRADING_DATE.isoformat(),
+            False,
+            None,
+            None,
         )
+
+    async def test_h1_fetch_failure_is_not_cached(self):
+        """A transient Saxo failure (expired token, rate limit, network
+        blip) must never be persisted as a permanent NO_DATA - only a
+        genuine empty result from Saxo is cacheable."""
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        candles_service = MagicMock(spec=CandlesService)
+        candles_service.get_candles_in_window.side_effect = SaxoException(
+            "boom"
+        )
+        service = BacktestService(candles_service, dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        assert result.status == DayStatus.NO_DATA
+        dynamodb_client.store_backtest_candles.assert_not_called()
+
+    async def test_m5_fetch_failure_is_not_cached(self):
+        """Mirror of the H1 case: a transient failure on the 5-minute
+        fetch must not be persisted as a permanent has_data=True/empty
+        NO_TRADE - only a genuine empty Saxo result is cacheable."""
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value=None
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        candles_service = MagicMock(spec=CandlesService)
+
+        def side_effect(code, ut, horizon, start, end):
+            if ut == UnitTime.H1:
+                return [h1_candle()]
+            raise SaxoException("boom")
+
+        candles_service.get_candles_in_window.side_effect = side_effect
+        service = BacktestService(candles_service, dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        assert result.status == DayStatus.NO_TRADE
+        assert result.h1_high == H1_HIGH
+        dynamodb_client.store_backtest_candles.assert_not_called()
+
+    async def test_malformed_cache_item_falls_back_to_saxo(self):
+        """An item written under an earlier/different schema (missing
+        the expected keys) must be treated as a miss, not raise - a
+        cache problem must never break a backtest."""
+        dynamodb_client = MagicMock(spec=DynamoDBClient)
+        dynamodb_client.get_cached_backtest_candles = AsyncMock(
+            return_value={"has_data": True}
+        )
+        dynamodb_client.store_backtest_candles = AsyncMock()
+        service, candles_service = self._service(dynamodb_client)
+
+        result = await service.evaluate_day(DEFINITION, TRADING_DATE)
+
+        candles_service.get_candles_in_window.assert_called()
+        dynamodb_client.store_backtest_candles.assert_called_once()
+        assert result.h1_high == H1_HIGH
 
     async def test_no_dynamodb_client_falls_back_to_saxo_every_time(self):
         service, candles_service = self._service(None)
@@ -1623,5 +1721,6 @@ class TestBacktestCandleCache:
         await service.evaluate_day(TIME_CUT_DEFINITION, TRADING_DATE)
 
         dynamodb_client.get_cached_backtest_candles.assert_called_once_with(
-            TIME_CUT_DEFINITION.code, TRADING_DATE.isoformat()
+            f"{TIME_CUT_DEFINITION.code}:{TIME_CUT_DEFINITION.instrument}:v1",
+            TRADING_DATE.isoformat(),
         )

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -56,6 +56,13 @@ TRADING_DATE = datetime.date(2026, 6, 2)
 H1_HIGH = 8050.0
 H1_LOW = 8000.0
 
+# A real DynamoDBClient with no active resource - dynamodb_client is a
+# required BacktestService constructor param (not Optional), but calls
+# through it still degrade to a cache miss/no-op (RuntimeError, caught
+# in _get_cached_candles/_store_candles), the same as in local/dev
+# usage without AWS. Used wherever a test doesn't care about caching.
+NO_CACHE_CLIENT = DynamoDBClient(dynamodb_resource=None)
+
 
 def h1_candle(higher=H1_HIGH, lower=H1_LOW):
     return Candle(
@@ -93,7 +100,7 @@ def make_service(h1_candles, m5_candles, raise_on_h1=False, raise_on_m5=False):
         return m5_candles
 
     candles_service.get_candles_in_window.side_effect = side_effect
-    return BacktestService(candles_service)
+    return BacktestService(candles_service, NO_CACHE_CLIENT)
 
 
 class TestTimezoneHelpers:
@@ -994,7 +1001,9 @@ def make_trade(exit_reason, points, entry_price=8010.0):
 
 class TestRunRange:
     async def test_aggregates_across_days_and_excludes_no_data(self, mocker):
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         day1 = datetime.date(2026, 6, 1)
         day2 = datetime.date(2026, 6, 2)
         day3 = datetime.date(2026, 6, 3)
@@ -1047,7 +1056,9 @@ class TestRunRange:
         """Saturday/Sunday never trade, so run_range must not spend a
         fetch resolving them to NO_DATA - it should skip evaluate_day
         for those dates entirely."""
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         friday = datetime.date(2026, 6, 5)
         monday = datetime.date(2026, 6, 8)
         evaluate_day = mocker.patch.object(
@@ -1065,7 +1076,9 @@ class TestRunRange:
         assert result.summary.number_of_days == 2
 
     async def test_empty_range_returns_all_zero_summary(self, mocker):
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         day = datetime.date(2026, 6, 2)
         mocker.patch.object(
             service,
@@ -1091,7 +1104,9 @@ class TestRunRange:
         break-even mechanism (e.g. an end-of-day close landing exactly
         on the entry price) counts as a losing position, not a win or
         a BE (per spec.md Assumptions)."""
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         day = datetime.date(2026, 6, 2)
         mocker.patch.object(
             service,
@@ -1118,7 +1133,9 @@ class TestRunRange:
         loss, and its points are excluded from average_loss - only
         final_result reflects the actual value (resolved explicitly
         after PR review, see spec.md Assumptions)."""
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         day = datetime.date(2026, 6, 2)
         mocker.patch.object(
             service,
@@ -1147,7 +1164,9 @@ class TestRunRange:
         same-candle EOD test) is classified as a losing position, not a
         win or a BE - only break-even-mechanism exits get the "BE"
         label (documented in spec.md Assumptions)."""
-        service = BacktestService(MagicMock(spec=CandlesService))
+        service = BacktestService(
+            MagicMock(spec=CandlesService), NO_CACHE_CLIENT
+        )
         day = datetime.date(2026, 6, 2)
         mocker.patch.object(
             service,
@@ -1437,7 +1456,7 @@ class TestWideRangeStructuralStop:
             raise AssertionError("m5 candles must not be fetched")
 
         candles_service.get_candles_in_window.side_effect = side_effect
-        service = BacktestService(candles_service)
+        service = BacktestService(candles_service, NO_CACHE_CLIENT)
 
         result = await service.evaluate_day(
             WIDE_RANGE_DEFINITION, TRADING_DATE
@@ -1687,8 +1706,12 @@ class TestBacktestCandleCache:
         dynamodb_client.store_backtest_candles.assert_called_once()
         assert result.h1_high == H1_HIGH
 
-    async def test_no_dynamodb_client_falls_back_to_saxo_every_time(self):
-        service, candles_service = self._service(None)
+    async def test_no_active_resource_falls_back_to_saxo_every_time(self):
+        """dynamodb_client is a required parameter (not Optional), but a
+        DynamoDBClient with no active resource - local/dev usage
+        without AWS, see get_dynamodb_client_best_effort - degrades to
+        a cache miss/no-op every time, exactly like a DynamoDB failure."""
+        service, candles_service = self._service(NO_CACHE_CLIENT)
 
         result = await service.evaluate_day(DEFINITION, TRADING_DATE)
 

--- a/tests/client/test_aws_client_backtest_cache.py
+++ b/tests/client/test_aws_client_backtest_cache.py
@@ -19,52 +19,6 @@ def client(mock_dynamodb_resource):
     return DynamoDBClient(dynamodb_resource=mock_resource)
 
 
-class TestGetCachedBacktestCandles:
-    async def test_returns_item_on_hit(self, mock_dynamodb_resource, client):
-        _, mock_table = mock_dynamodb_resource
-        mock_table.get_item.return_value = {
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-            "Item": {
-                "definition_code": "B9H",
-                "trading_date": "2026-07-14",
-                "has_data": True,
-            },
-        }
-
-        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
-
-        mock_table.get_item.assert_called_once_with(
-            Key={
-                "definition_code": "B9H",
-                "trading_date": "2026-07-14",
-            }
-        )
-        assert item is not None
-        assert item["has_data"] is True
-
-    async def test_returns_none_on_miss(self, mock_dynamodb_resource, client):
-        _, mock_table = mock_dynamodb_resource
-        mock_table.get_item.return_value = {
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-        }
-
-        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
-
-        assert item is None
-
-    async def test_returns_none_on_error_response(
-        self, mock_dynamodb_resource, client
-    ):
-        _, mock_table = mock_dynamodb_resource
-        mock_table.get_item.return_value = {
-            "ResponseMetadata": {"HTTPStatusCode": 500},
-        }
-
-        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
-
-        assert item is None
-
-
 class TestStoreBacktestCandles:
     async def test_stores_candles_and_converts_floats_to_decimal(
         self, mock_dynamodb_resource, client

--- a/tests/client/test_aws_client_backtest_cache.py
+++ b/tests/client/test_aws_client_backtest_cache.py
@@ -1,0 +1,127 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from client.aws_client import DynamoDBClient
+
+
+@pytest.fixture
+def mock_dynamodb_resource():
+    mock_resource = AsyncMock()
+    mock_table = AsyncMock()
+    mock_resource.Table.return_value = mock_table
+    return mock_resource, mock_table
+
+
+@pytest.fixture
+def client(mock_dynamodb_resource):
+    mock_resource, _ = mock_dynamodb_resource
+    return DynamoDBClient(dynamodb_resource=mock_resource)
+
+
+class TestGetCachedBacktestCandles:
+    async def test_returns_item_on_hit(self, mock_dynamodb_resource, client):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.get_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Item": {
+                "definition_code": "B9H",
+                "trading_date": "2026-07-14",
+                "has_data": True,
+            },
+        }
+
+        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
+
+        mock_table.get_item.assert_called_once_with(
+            Key={
+                "definition_code": "B9H",
+                "trading_date": "2026-07-14",
+            }
+        )
+        assert item is not None
+        assert item["has_data"] is True
+
+    async def test_returns_none_on_miss(self, mock_dynamodb_resource, client):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.get_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+
+        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
+
+        assert item is None
+
+    async def test_returns_none_on_error_response(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.get_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 500},
+        }
+
+        item = await client.get_cached_backtest_candles("B9H", "2026-07-14")
+
+        assert item is None
+
+
+class TestStoreBacktestCandles:
+    async def test_stores_candles_and_converts_floats_to_decimal(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.put_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200}
+        }
+        h1_candle = {
+            "lower": 8000.0,
+            "higher": 8050.0,
+            "open": 8020.0,
+            "close": 8030.0,
+            "ut": "1h",
+            "date": "2026-07-14T07:00:00",
+        }
+        m5_candles = [
+            {
+                "lower": 8010.0,
+                "higher": 8020.0,
+                "open": 8012.0,
+                "close": 8018.0,
+                "ut": "5m",
+                "date": "2026-07-14T08:00:00",
+            }
+        ]
+
+        await client.store_backtest_candles(
+            "B9H",
+            "2026-07-14",
+            True,
+            h1_candle,
+            m5_candles,
+        )
+
+        mock_table.put_item.assert_called_once()
+        item = mock_table.put_item.call_args[1]["Item"]
+        assert item["definition_code"] == "B9H"
+        assert item["trading_date"] == "2026-07-14"
+        assert item["has_data"] is True
+        assert str(item["h1_candle"]["lower"]) == "8000.0"
+        assert str(item["m5_candles"][0]["higher"]) == "8020.0"
+        assert isinstance(item["cached_at"], int)
+
+    async def test_stores_no_data_marker_without_candles(
+        self, mock_dynamodb_resource, client
+    ):
+        _, mock_table = mock_dynamodb_resource
+        mock_table.put_item.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200}
+        }
+
+        await client.store_backtest_candles(
+            "B9H", "2026-07-15", False, None, None
+        )
+
+        item = mock_table.put_item.call_args[1]["Item"]
+        assert item["has_data"] is False
+        assert "h1_candle" not in item
+        assert "m5_candles" not in item


### PR DESCRIPTION
## Summary

Implements a caching layer for backtest candle data using DynamoDB to avoid redundant Saxo API calls when evaluating the same trading day multiple times. This addresses FR-036 through FR-040 requirements for cost optimization without affecting correctness.

## Key Changes

- **Async backtest evaluation**: Converted `BacktestService.evaluate_day()` and `run_range()` to async methods to support cache operations
  - Updated all test methods to use `async def` and `await` calls
  - Modified router endpoints to `await` the async service methods

- **DynamoDB cache integration**:
  - Added `get_cached_backtest_candles()` and `store_backtest_candles()` methods to `DynamoDBClient`
  - Implemented `_get_cached_candles()` and `_store_candles()` in `BacktestService` with graceful degradation (cache misses/failures fall back to Saxo)
  - Added `_candle_from_cached_dict()` to reconstruct `Candle` objects from cached DynamoDB items, converting Decimal prices back to float

- **New data model**: Added `CachedDayCandles` dataclass to represent cached raw candle data (H1 reference + 5-minute session candles) without computed trades

- **Infrastructure**: Created `backtest_candle_cache` DynamoDB table with `definition_code` and `trading_date` as composite key, no TTL (historical data never changes)

- **Dependency injection**: Updated `BacktestService` constructor to accept optional `DynamoDBClient` and modified `get_backtest_service()` dependency to inject it

## Implementation Details

- Cache lookup happens before Saxo fetches; on miss, candles are fetched and stored for future requests
- Strategy evaluation always runs fresh against cached or fetched candles (FR-039)
- Cache outages never break backtest runs—missing client or DynamoDB errors log warnings and fall back to Saxo
- Float-to-Decimal conversion handled automatically by existing `_convert_floats_to_decimal()` utility
- All 100+ backtest tests converted to async with proper `await` syntax

https://claude.ai/code/session_01L22im68hZx7KQG7TexS6NP