### PR TITLE
Add G9HSL backtest definition (GER40 single lot control)

### DIFF
--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -72,6 +72,25 @@ BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
         first_target_fraction=0.5,
         stop_from_reference_level=True,
     ),
+    # Control run for G9H: the same GER40 setup and the same 150-point
+    # stop measured from the H1 reference level, but a single lot and a
+    # single take-profit. Isolates what the double take-profit overlay
+    # itself contributes. Note it also drops the TP1 entry filter (a
+    # midpoint that only exists under double_take_profit), so it takes
+    # entries G9H rejects rather than the same entries at half size.
+    BacktestDefinition(
+        code="G9HSL",
+        name=Strategy.G9HSL.value,
+        display_name="GER40 Bougie de 9h (lot unique)",
+        instrument="GER40.I",
+        default_parameters=BacktestParameters(
+            stop_loss_points=150,
+            take_profit_offset_points=10,
+            break_even_trigger_points=50,
+            max_entry_distance_points=40,
+        ),
+        stop_from_reference_level=True,
+    ),
     BacktestDefinition(
         code="B9HWS",
         name=Strategy.B9HWS.value,

--- a/model/enum.py
+++ b/model/enum.py
@@ -6,6 +6,7 @@ class Strategy(EnumWithGetValue):
     B9H = "Bougie de 9h"
     B9HTC = "Bougie de 9h (time cut)"
     G9H = "Bougie de 9h GER40"
+    G9HSL = "Bougie de 9h GER40 (lot unique)"
     B9HWS = "Bougie de 9h (wide-range structural stop)"
     BH = "Breakout haussier"
     C200 = "Cassure mm200"

--- a/tests/api/services/test_backtest_service.py
+++ b/tests/api/services/test_backtest_service.py
@@ -190,13 +190,13 @@ class TestListAndGetDefinition:
     def test_list_definitions_returns_the_hardcoded_backtests(self):
         service = make_service([], [])
         definitions = service.list_definitions()
-        assert len(definitions) == 4
+        assert len(definitions) == 5
         assert definitions[0].code == "B9H"
         assert definitions[0].display_name == "CAC40 Bougie de 9h"
         assert definitions[0].instrument == "FRA40.I"
         assert definitions[0].time_cut_minutes is None
         codes = [definition.code for definition in definitions]
-        assert codes == ["B9H", "B9HTC", "G9H", "B9HWS"]
+        assert codes == ["B9H", "B9HTC", "G9H", "G9HSL", "B9HWS"]
         g9h = service.get_definition("G9H")
         assert g9h is not None
         assert g9h.instrument == "GER40.I"
@@ -204,6 +204,20 @@ class TestListAndGetDefinition:
         assert g9h.first_target_fraction == 0.5
         assert g9h.stop_from_reference_level is True
         assert g9h.default_parameters.stop_loss_points == 150
+
+    def test_ger40_single_lot_definition_is_registered(self):
+        service = make_service([], [])
+        definition = service.get_definition("G9HSL")
+        assert definition is not None
+        assert definition.display_name == "GER40 Bougie de 9h (lot unique)"
+        assert definition.instrument == "GER40.I"
+        assert definition.double_take_profit is False
+        assert definition.first_target_fraction is None
+        assert definition.stop_from_reference_level is True
+        assert definition.default_parameters.stop_loss_points == 150
+        assert definition.default_parameters.take_profit_offset_points == 10
+        assert definition.default_parameters.break_even_trigger_points == 50
+        assert definition.default_parameters.max_entry_distance_points == 40
 
     def test_wide_range_structural_definition_is_registered(self):
         service = make_service([], [])
@@ -1917,6 +1931,123 @@ class TestEvaluateDayDoubleTakeProfit:
         assert result.trades[0].points == -330
         assert result.trades[1].exit_reason == ExitReason.TAKE_PROFIT
         assert result.trades[1].points == 33  # (8025-8016) + (8040-8016)
+
+
+GER_SINGLE_LOT_DEFINITION = BacktestDefinition(
+    code="G9HSL",
+    name="Bougie de 9h GER40 (lot unique)",
+    display_name="GER40 Bougie de 9h (lot unique)",
+    instrument="GER40.I",
+    default_parameters=BacktestParameters(
+        stop_loss_points=150,
+        take_profit_offset_points=10,
+        break_even_trigger_points=50,
+        max_entry_distance_points=40,
+    ),
+    stop_from_reference_level=True,
+)
+
+
+async def _run_ger_single(m5_candles, higher=H1_HIGH, lower=H1_LOW):
+    service = make_service([h1_candle(higher=higher, lower=lower)], m5_candles)
+    return await service.evaluate_day(
+        GER_SINGLE_LOT_DEFINITION, TRADING_DATE, GER_PARAMS
+    )
+
+
+class TestEvaluateDayGerSingleLot:
+    """G9HSL: the G9H setup with the 150-point stop still measured from
+    the H1 reference level, but a single lot and a single take-profit.
+    With H1 8000-8050 and a long entry at 8015: TP = 8040, stop = 7850,
+    break-even trigger = 8065. The H1 midpoint (8025) has no meaning
+    here - neither as an exit nor as an entry filter."""
+
+    ENTRY_CANDLES = TestEvaluateDayDoubleTakeProfit.ENTRY_CANDLES
+
+    async def test_take_profit_is_a_single_leg(self):
+        candles = self.ENTRY_CANDLES + [
+            m5_candle(3, 8020, 8030, 8018, 8028),  # crosses 8025, no exit
+            m5_candle(4, 8030, 8045, 8028, 8042),  # TP @8040
+        ]
+        result = await _run_ger_single(candles)
+        assert result.status == DayStatus.TRADED
+        assert len(result.trades) == 1
+        trade = result.trades[0]
+        assert trade.direction == Direction.BUY
+        assert trade.entry_price == 8015
+        assert trade.exit_reason == ExitReason.TAKE_PROFIT
+        assert trade.exit_price == 8040
+        assert trade.points == 25  # 8040 - 8015, not 35
+
+    async def test_stop_out_is_a_single_leg_from_the_h1_level(self):
+        candles = self.ENTRY_CANDLES + [
+            m5_candle(3, 8010, 8012, 7840, 7845),  # low <= stop 7850
+        ]
+        result = await _run_ger_single(candles)
+        trade = result.trades[0]
+        assert trade.exit_reason == ExitReason.STOP_LOSS
+        assert trade.exit_price == 7850  # h1_low - 150, not entry - 150
+        assert trade.points == -165  # 7850 - 8015, half of G9H's -330
+
+    async def test_midpoint_does_not_close_anything(self):
+        candles = self.ENTRY_CANDLES + [
+            m5_candle(3, 8020, 8030, 8018, 8028),  # reaches the midpoint 8025
+            m5_candle(4, 8026, 8030, 8024, 8028),  # last candle, still open
+        ]
+        result = await _run_ger_single(candles)
+        trade = result.trades[0]
+        assert trade.exit_reason == ExitReason.END_OF_DAY
+        assert trade.exit_price == 8028
+        assert trade.points == 13  # 8028 - 8015, one lot, nothing banked
+
+    async def test_break_even_still_armed_by_the_plus_50_trigger(self):
+        candles = self.ENTRY_CANDLES + [
+            m5_candle(3, 8020, 8070, 8018, 8065),  # high >= entry+50 -> arm BE
+            m5_candle(4, 8060, 8062, 8010, 8012),  # low <= entry -> BE stop
+        ]
+        result = await _run_ger_single(candles, higher=8200.0, lower=8000.0)
+        trade = result.trades[0]
+        assert trade.exit_reason == ExitReason.BREAK_EVEN
+        assert trade.exit_price == 8015
+        assert trade.points == 0
+
+    async def test_short_mirror_take_profit(self):
+        # Short off the H1 high: TP = 8010, stop = 8200 (h1_high + 150).
+        candles = [
+            m5_candle(0, 8045, 8060, 8040, 8055),  # breach above high
+            m5_candle(1, 8050, 8055, 8035, 8040),  # candidate, lower=8035
+            m5_candle(2, 8040, 8045, 8030, 8035),  # breakdown -> entry @8035
+            m5_candle(3, 8034, 8038, 8020, 8024),  # crosses 8025, no exit
+            m5_candle(4, 8020, 8024, 8005, 8008),  # TP @8010
+        ]
+        result = await _run_ger_single(candles)
+        trade = result.trades[0]
+        assert trade.direction == Direction.SELL
+        assert trade.entry_price == 8035
+        assert trade.exit_reason == ExitReason.TAKE_PROFIT
+        assert trade.exit_price == 8010
+        assert trade.points == 25  # 8035 - 8010, not 35
+
+    async def test_entry_past_the_midpoint_is_accepted_unlike_g9h(self):
+        """The TP1 entry filter is a double-take-profit rule (FR-G02).
+        Without it, an entry above the H1 midpoint - still within the
+        max entry distance and below the take-profit - is valid, so
+        G9HSL trades days G9H sits out."""
+        candles = [
+            m5_candle(0, 8005, 8010, 7990, 7995),  # breach (close < h1_low)
+            m5_candle(1, 8000, 8035, 7995, 8010),  # candidate, higher=8035
+            m5_candle(2, 8010, 8036, 8005, 8030),  # breakout -> entry @8035
+            m5_candle(3, 8036, 8045, 8034, 8042),  # TP @8040
+        ]
+        result = await _run_ger_single(candles)
+        assert result.status == DayStatus.TRADED
+        trade = result.trades[0]
+        assert trade.entry_price == 8035  # above the midpoint 8025
+        assert trade.exit_reason == ExitReason.TAKE_PROFIT
+        assert trade.points == 5  # 8040 - 8035
+
+        rejected = await _run_ger(candles)
+        assert rejected.status == DayStatus.NO_TRADE
 
 
 def _closed_trade(points, exit_reason, direction=Direction.BUY):


### PR DESCRIPTION
## Summary
Adds a new backtest definition `G9HSL` ("GER40 Bougie de 9h (lot unique)") as a control variant of the existing `G9H` strategy. This variant uses the same GER40 instrument and 150-point stop measured from the H1 reference level, but with a single lot and single take-profit instead of the double take-profit overlay. This allows isolating the impact of the double take-profit mechanism itself.

## Key Changes
- **New Strategy Enum**: Added `G9HSL` to the `Strategy` enum in `model/enum.py`
- **New Backtest Definition**: Registered `G9HSL` in `backtest_service.py` with:
  - Single lot configuration (no `first_target_fraction`)
  - Single take-profit at 10 points offset
  - Break-even trigger at 50 points
  - Max entry distance of 40 points
  - Stop measured from H1 reference level (150 points)
  - Notably drops the TP1 entry filter (midpoint), accepting entries G9H would reject
- **Comprehensive Test Suite**: Added `TestEvaluateDayGerSingleLot` class with 7 test cases covering:
  - Single-leg take-profit behavior
  - Stop-loss from H1 reference level
  - Midpoint no longer acting as exit/entry filter
  - Break-even trigger mechanics
  - Short mirror trades
  - Entry acceptance above midpoint (unlike G9H)
- **Updated Existing Tests**: Modified `test_list_definitions_returns_the_hardcoded_backtests` to expect 5 definitions instead of 4, with `G9HSL` inserted in the correct position

## Implementation Details
The `G9HSL` definition is positioned as a control run to measure the isolated contribution of the double take-profit overlay mechanism. By keeping the same stop level and instrument but removing the dual-lot structure and midpoint filter, it enables direct comparison of strategy performance with and without the overlay.

https://claude.ai/code/session_015Q6AQ8AVgY5juSD62iPRBH