### PR TITLE
feat: add entry cut-off and daily loss cap to G9HIC (spec 025)

### DIFF
--- a/api/services/backtest/definitions.py
+++ b/api/services/backtest/definitions.py
@@ -1,5 +1,6 @@
 """The registry of hardcoded backtests exposed by the Backtest menu."""
 
+import datetime
 from typing import List, Optional
 
 from model import (
@@ -71,7 +72,9 @@ BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
     # us out". stop_loss_points is carried for shape only - nothing reads
     # it under an impulse stop (FR-G15), as is already true of B9HWS. It
     # trades the 9:00-22:00 CFD session, so a position can run five hours
-    # past the Xetra cash close before an end-of-day exit.
+    # past the Xetra cash close before an end-of-day exit - hence the two
+    # entry filters (FR-G19/FR-G20), which bound how late and how deep
+    # into a losing day it will still open something new.
     BacktestDefinition(
         code="G9HIC",
         name=Strategy.G9HIC.value,
@@ -87,6 +90,8 @@ BACKTEST_DEFINITIONS: List[BacktestDefinition] = [
         min_h1_range_points=70.0,
         impulsive_candle_points=70.0,
         impulsive_close_fraction=0.25,
+        last_entry_time=datetime.time(16, 0),
+        max_daily_losses=2,
     ),
 ]
 

--- a/api/services/backtest/entry_gate.py
+++ b/api/services/backtest/entry_gate.py
@@ -1,0 +1,109 @@
+"""Whether the engine may *open* a position on a given candle.
+
+The exit chain answers "does this rule close an open position?". These
+rules never close anything - they decide whether a confirmed breakout is
+allowed to become a position at all, which is a different question with
+different state behind it: the clock, and what the day has already lost.
+
+They are not entry *validity* either. `is_valid_entry` judges a candidate
+breakout against price levels and is deliberately stateless across
+positions; the cut-off and the loss cap are properties of the run, so they
+live here rather than being threaded into DirectionSearch.
+"""
+
+import datetime
+from typing import Optional, Protocol
+
+from api.services.backtest.calendar import PARIS_TZ
+from model import Market, Trade
+from utils.helper import market_in_utc
+
+
+class EntryGate(Protocol):
+    def allows(self, candle_time: datetime.datetime) -> bool:
+        """Whether a position may open on the candle starting at
+        `candle_time` (naive UTC, as the Saxo candles are)."""
+        ...
+
+    def record(self, trade: Trade) -> None:
+        """Feed back a position that just closed, so the gate can count
+        the day's losses."""
+        ...
+
+
+class AlwaysOpen:
+    """The gate for a definition carrying neither filter: every candle is
+    allowed and closed trades are of no interest. Keeps the engine free of
+    a "does this definition have entry filters?" branch."""
+
+    def allows(self, candle_time: datetime.datetime) -> bool:
+        return True
+
+    def record(self, trade: Trade) -> None:
+        return None
+
+
+class FilteredEntry:
+    """The impulsive variant's gate (FR-G19/FR-G20).
+
+    Two independent reasons to refuse an entry - either alone is enough:
+
+    - the candle starts at or after the cut-off (16:00 market-local), so
+      the last candle that can open a position is the one starting 15:55;
+    - the day has already closed `max_losses` positions with negative
+      points.
+
+    A loss is `points < 0` whatever the exit reason, matching how the run
+    summary counts losing positions. Deliberately not "stop-loss exits":
+    under an impulse stop a day can bleed away through end-of-day closes
+    without a single stop firing, and a cap blind to those would not bound
+    what it claims to. A trade closing at exactly 0 is not a loss.
+    """
+
+    def __init__(
+        self,
+        cutoff_utc: Optional[datetime.datetime],
+        max_losses: Optional[int],
+    ):
+        self.cutoff_utc = cutoff_utc
+        self.max_losses = max_losses
+        self.losses = 0
+
+    def allows(self, candle_time: datetime.datetime) -> bool:
+        if self.cutoff_utc is not None and candle_time >= self.cutoff_utc:
+            return False
+        if self.max_losses is not None and self.losses >= self.max_losses:
+            return False
+        return True
+
+    def record(self, trade: Trade) -> None:
+        if trade.points < 0:
+            self.losses += 1
+
+
+def cutoff_utc(
+    local_time: datetime.time, market: Market, trading_date: datetime.date
+) -> datetime.datetime:
+    """A market-local cut-off as a naive UTC datetime for `trading_date`.
+
+    Resolved per date through the same DST-aware conversion the session
+    windows use, so a 16:00 Paris cut-off is 14:00 UTC in summer and 15:00
+    in winter rather than a hardcoded offset."""
+    reference = datetime.datetime(
+        trading_date.year,
+        trading_date.month,
+        trading_date.day,
+        tzinfo=PARIS_TZ,
+    )
+    utc_market = market_in_utc(market, reference)
+    hour_shift = utc_market.open_hour - market.open_hour
+    return datetime.datetime(
+        trading_date.year,
+        trading_date.month,
+        trading_date.day,
+        local_time.hour,
+        local_time.minute,
+    ) + datetime.timedelta(hours=hour_shift)
+
+
+ALWAYS_OPEN = AlwaysOpen()

--- a/api/services/backtest/rules.py
+++ b/api/services/backtest/rules.py
@@ -7,8 +7,15 @@ adding one policy) rather than threading another boolean through the
 engine.
 """
 
+import datetime
 from typing import List
 
+from api.services.backtest.entry_gate import (
+    ALWAYS_OPEN,
+    EntryGate,
+    FilteredEntry,
+    cutoff_utc,
+)
 from api.services.backtest.lots import SINGLE_LOT, LotModel, TwoLot
 from api.services.backtest.policies import (
     ArmBreakEven,
@@ -78,6 +85,29 @@ def build_exit_chain(
 
     chain.append(ArmBreakEven(params.break_even_trigger_points))
     return chain
+
+
+def build_entry_gate(
+    definition: BacktestDefinition, trading_date: datetime.date
+) -> EntryGate:
+    """The definition's entry filters (FR-G19/FR-G20), or a gate that
+    allows everything when it carries none - so the engine never asks
+    which backtest it is running.
+
+    Built per day, because the cut-off resolves to a different UTC instant
+    either side of a DST boundary and the loss counter is per trading
+    day."""
+    if (
+        definition.last_entry_time is None
+        and definition.max_daily_losses is None
+    ):
+        return ALWAYS_OPEN
+    cutoff = (
+        cutoff_utc(definition.last_entry_time, definition.market, trading_date)
+        if definition.last_entry_time is not None
+        else None
+    )
+    return FilteredEntry(cutoff, definition.max_daily_losses)
 
 
 def build_lot_model(definition: BacktestDefinition) -> LotModel:

--- a/api/services/backtest/service.py
+++ b/api/services/backtest/service.py
@@ -19,7 +19,11 @@ from api.services.backtest.entry import DirectionSearch
 from api.services.backtest.lots import LotModel
 from api.services.backtest.policies import resolve_exit
 from api.services.backtest.position import Position
-from api.services.backtest.rules import build_exit_chain, build_lot_model
+from api.services.backtest.rules import (
+    build_entry_gate,
+    build_exit_chain,
+    build_lot_model,
+)
 from api.services.backtest.side import LONG, SHORT, Side
 from api.services.backtest.statistics import build_summary
 from client.aws_client import DynamoDBClient
@@ -110,7 +114,12 @@ class BacktestService:
 
         chronological = sorted(five_min_candles, key=candle_date)
         trades = self._evaluate_trades(
-            chronological, h1_high, h1_low, params, definition
+            chronological,
+            h1_high,
+            h1_low,
+            params,
+            definition,
+            trading_date,
         )
 
         status = DayStatus.TRADED if trades else DayStatus.NO_TRADE
@@ -234,6 +243,7 @@ class BacktestService:
         h1_low: float,
         params: BacktestParameters,
         definition: BacktestDefinition,
+        trading_date: datetime.date,
     ) -> List[Trade]:
         """Evaluate both directions concurrently, with at most one
         position open at any time. The H1 high/low reference levels are
@@ -245,6 +255,7 @@ class BacktestService:
         position: Optional[Position] = None
         chain = build_exit_chain(definition, params)
         lots = build_lot_model(definition)
+        gate = build_entry_gate(definition, trading_date)
         # TP1, where a two-lot position exits its first lot; None for a
         # single lot, where it is not consulted.
         first_target = lots.first_target_level(h1_high, h1_low)
@@ -281,6 +292,13 @@ class BacktestService:
                     side: search.feed(candle)
                     for side, search in searches.items()
                 }
+                # Checked after feeding, not before: the searches advance
+                # on every candle either way, so a gate-blocked entry
+                # leaves their state exactly where a confirmed-but-invalid
+                # entry does, and there is no second walk that behaves
+                # differently late in the day.
+                if not gate.allows(candle_time):
+                    continue
                 for side in (LONG, SHORT):
                     entry_price = entries[side]
                     if entry_price is not None:
@@ -303,6 +321,7 @@ class BacktestService:
             closed = resolve_exit(chain, position, candle, candle_time)
             if closed is not None:
                 trades.append(closed)
+                gate.record(closed)
                 position = None
                 self._reset(searches)
 

--- a/model/backtest.py
+++ b/model/backtest.py
@@ -82,6 +82,14 @@ class BacktestDefinition:
     # backtests so their behavior is unchanged.
     impulsive_candle_points: Optional[float] = None
     impulsive_close_fraction: Optional[float] = None
+    # Entry filters (spec 025 addendum 2, FR-G19/FR-G20). Both are about
+    # *opening* a position and never affect one already open: no new
+    # position on a candle starting at or after last_entry_time (market
+    # local, DST-aware), and none once max_daily_losses positions have
+    # closed with negative points that day. Left None on the other
+    # backtests, which take entries at any hour and under any loss run.
+    last_entry_time: Optional[datetime.time] = None
+    max_daily_losses: Optional[int] = None
 
     def __post_init__(self) -> None:
         """Reject at construction (registration) time any combination of
@@ -161,6 +169,30 @@ class BacktestDefinition:
                 "an impulsive-candle stop is not supported together with a "
                 f"structural stop (definition {self.code!r})"
             )
+        if self.max_daily_losses is not None and self.max_daily_losses <= 0:
+            raise ValueError(
+                "max_daily_losses must be positive - a cap of zero would "
+                f"forbid every entry (definition {self.code!r})"
+            )
+        if self.last_entry_time is not None and not (
+            datetime.time(self.market.open_hour, self.market.open_minutes)
+            < self.last_entry_time
+            <= self._market_close_time()
+        ):
+            raise ValueError(
+                "last_entry_time must fall inside the session - a cut-off "
+                "outside it either forbids every entry or can never fire "
+                f"(definition {self.code!r})"
+            )
+
+    def _market_close_time(self) -> datetime.time:
+        """The market's local closing time. end_minute is added as an
+        offset because it is documented to exceed 59 when close_hour
+        labels the last full H1 candle rather than the literal close."""
+        close = datetime.datetime(
+            2000, 1, 1, self.market.close_hour
+        ) + datetime.timedelta(minutes=self.market.end_minute)
+        return close.time()
 
 
 @dataclass

--- a/specs/025-ger40-bougie-9h/plan.md
+++ b/specs/025-ger40-bougie-9h/plan.md
@@ -183,3 +183,62 @@ Chain for `G9HIC`: `Stop(only_when_armed=True)` → `Target()` → `ImpulsiveSto
 | Moving `Market`/`USMarket`/`EUMarket` to `model/market.py`. | `model/__init__.py` imports `model.backtest` before the market classes are defined, so `BacktestDefinition.market` would be a circular import. | Pure move + re-export; every `from model import EUMarket` keeps working, and no other module changes. |
 | A definition with **no stop-loss distance at all** while unarmed. | FR-G15 — the variant's entire premise. | Not new machinery: `B9HWS` already runs `Stop(only_when_armed=True)`. `stop_loss_points` stays on the params object (it is a shared shape) and is simply unread, as it already is for `B9HWS`. |
 | The impulse test is amplitude **and** shape **and** level, not amplitude alone. | Clarifications 2026-07-27 — amplitude alone would fire on long-wick reversal candles that closed back inside the range, which are indecision, not impulse. | Makes the name honest: "impulsive" implies a decisive move, and the 25% close fraction is what enforces it. |
+
+---
+
+# Addendum 2: entry cut-off and daily loss cap (`G9HIC`)
+
+**Branch**: `claude/dax-backtest-impulsive-candle-61dj2p` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md) §Addendum 2
+
+## Summary
+
+Two entry filters on `G9HIC`: no position opened on a candle starting at or after 16:00 Paris, and none once two positions have closed at a loss that day. Exit handling is untouched.
+
+## Design
+
+### Where these belong
+
+The exit-policy chain is the wrong home for both. A policy answers "does this rule close an open position?", and neither of these ever closes anything — they decide whether the engine may open one. Forcing them into the chain would mean a policy that mutates engine state it does not own, which is the coupling the #672 refactor removed.
+
+They also do not belong in `is_valid_entry`/`DirectionSearch`: that layer judges a *candidate breakout* against price levels and is deliberately stateless across positions. The clock and the day's realised losses are properties of the run, not of the breakout.
+
+So they go where the engine already decides whether to open — `service._evaluate_trades` — behind one small, testable object rather than two `if`s inline:
+
+```python
+class EntryGate:
+    """Whether the engine may open a position on this candle."""
+    def allows(self, candle_time) -> bool
+    def record(self, trade) -> None     # counts a closed loss
+```
+
+`rules.build_entry_gate(definition, trading_date)` constructs it from the definition's flags, mirroring `build_exit_chain`/`build_lot_model` — so `definitions.py` stays the only place variant flags are read, and a definition with neither filter gets a gate that always allows (the existing behavior, no branching at the call site).
+
+The engine change is then two lines: consult `gate.allows(candle_time)` before opening, and `gate.record(closed)` where trades are already appended.
+
+### Definition fields
+
+- `last_entry_time: Optional[datetime.time] = None` — 16:00 for `G9HIC`. Stored as a naive local time and resolved against the definition's market timezone per trading date, the same DST-aware path `paris_reference_window_utc` uses, so it is 14:00 UTC in summer and 15:00 in winter. Candle timestamps are naive UTC, so the gate compares in UTC.
+- `max_daily_losses: Optional[int] = None` — 2 for `G9HIC`.
+
+`__post_init__` guards, in the existing style: a positive `max_daily_losses`, and a `last_entry_time` that actually falls inside the session (a cut-off at 23:00 on a 22:00 market, or at 08:00 before the 10:00 scan start, is a filter that could never fire or could never allow — both are configuration errors worth failing at registration).
+
+### What counts as a loss
+
+`trade.points < 0`, matching `SingleLot.classify`'s losing branch and therefore the summary's "number of losing positions". Deliberately not `exit_reason == STOP_LOSS`: under an impulse stop a day can bleed through end-of-day closes without a single stop firing, and a cap that ignored those would not bound what it claims to.
+
+## Constitution Check
+
+| Principle | Check | Result |
+|---|---|---|
+| I. Layered Architecture | Definition fields in `model/`; the gate and its construction in the Service layer beside the exit chain; no router, client or frontend change. | PASS |
+| II. Clean Code First | One object with two methods rather than two inline conditions; built by the same `rules.py` that builds the chain, so variant flags stay read in one place; no `assert` — the registration guards raise `ValueError`. | PASS |
+| III. Configuration-Driven | Both are fixed strategy properties (FR-G22), not deployment config and not per-run knobs. | PASS |
+| IV. Safe Deployment | Additive to one definition; no infrastructure change. The `G9HIC` golden rows move, which is the intended, reviewable evidence. | PASS |
+| V. Domain Model Integrity | `Candle`/`Trade` throughout; no new instrument or market handling. | PASS |
+
+## Complexity Tracking
+
+| Design point | Why | Note |
+|---|---|---|
+| A new `EntryGate` concept rather than two `if`s in `_evaluate_trades`. | The engine loop is the one place that already knows both the clock and the closed trades; adding two stateful conditions inline would put day-scoped state in the middle of the candle walk. | It is ~20 lines and is unit-testable without building candles. `build_entry_gate` returns an always-allow gate for the five definitions with neither filter, so their code path is unchanged. |
+| The `G9HIC` golden snapshot moves. | FR-G19/FR-G20 change which entries are taken. | Expected and load-bearing: the diff shows exactly which trades the filters removed. The other five definitions must stay byte-for-byte identical (SC-G13). |

--- a/specs/025-ger40-bougie-9h/spec.md
+++ b/specs/025-ger40-bougie-9h/spec.md
@@ -226,3 +226,85 @@ Requirements below are numbered FR-G1## and are additive on top of spec 021 and 
 - GER40.I is quoted as a CFD outside the Xetra cash session, so 5-minute candles are expected to exist between 17:30 and 22:00. A day where Saxo returns nothing after 17:30 simply behaves as it does today (the scan ends with the last candle available).
 - A definition's market governs **what it trades** (the 5-minute scan window, the session end, the "has today closed" check), never **how it is measured**. The regime columns stay on the cash session regardless (FR-G17b).
 - The variant is expected to have a worse worst-case loss than `G9HSL` and a higher win rate; whether that trade is favorable is exactly what the backtest is being built to answer. No deployment decision is implied by adding it.
+
+---
+
+# Addendum 2: entry cut-off and daily loss cap for `G9HIC`
+
+**Added**: 2026-07-27
+**Input**: User description: "add a new condition I forgot. We don't take any new position after 4pm and we don't take any new position if we already had two lost."
+
+## Context
+
+Two **entry filters** on the existing `G9HIC` definition. Neither touches how an open position is managed: an impulsive candle, the take-profit, the armed break-even stop and the 22:00 end-of-day exit all behave exactly as specified in Addendum 1. These rules only decide whether the engine is allowed to *open* a new position.
+
+They are a change to `G9HIC` **in place**, not a seventh definition (Clarifications below). The other five definitions are untouched.
+
+Both address the same weakness of a variant with no fixed stop: its worst case is unbounded, so the cost of a bad afternoon compounds. The cut-off stops a position being opened so late that its only realistic exit is the 22:00 close, and the loss cap stops a day that is already going badly from paying for a third attempt.
+
+## Clarifications
+
+### Session 2026-07-27 (2)
+
+- Q: What counts as one of the "two lost" trades? → A: Any trade that closed with **negative points**, whatever its exit reason — an impulse stop, a break-even exit whose gap-fill landed below entry, or an end-of-day close below entry. This is the same test the run summary already uses to count losing positions, so "2 losses" means the same thing in the day detail, the summary and this rule.
+- Q: Should these rules change `G9HIC` in place or ship as a new definition? → A: **In place.** `G9HIC` has never been run for real or written up in `backtests/`, so no published result is invalidated, and the menu does not grow a near-duplicate. The `G9HIC` golden snapshot is expected to shift.
+- Q: Does the 16:00 cut-off close an already-open position? → A: **No.** It is purely an entry filter. A position opened at 15:55 is managed to its normal exit and may well close at 22:00. Only *opening* is blocked.
+- Q: Does the loss cap count across days? → A: **No — per trading day.** A backtest day is evaluated independently and no position spans days, so the counter starts at zero each day and resets with it.
+- Q: Are the 16:00 cut-off and the 2-loss cap tunable per run? → A: **No.** Like the 70-point impulse threshold and the 25% close fraction, they are fixed properties of this backtest (FR-G18).
+
+## User Scenarios & Testing
+
+### User Story 5 - Stop opening positions late in the day or after a bad start (Priority: P1)
+
+A trader running "GER40 Bougie de 9h (bougie impulsive)" sees no entries taken after 16:00 Paris, and none once the day has already produced two losing trades — while positions opened before either limit are managed to their normal exits.
+
+**Why this priority**: Both rules bound a variant whose worst case is otherwise unbounded; without them the strategy's exposure is not what the trader intends.
+
+**Independent Test**: Run a day whose candles would confirm a valid breakout at 16:05 and verify no position is opened; run a day with three consecutive losing setups and verify only the first two are taken.
+
+**Acceptance Scenarios**:
+
+1. **Given** a day where a valid breakout confirms on a 5-minute candle starting at **15:55 Paris**, **When** the backtest runs, **Then** the position **is** opened normally.
+2. **Given** a day where a valid breakout confirms on a 5-minute candle starting at **16:00 Paris** or later, **When** the backtest runs, **Then** **no position is opened**, and none is opened by any later candle that day.
+3. **Given** a position opened at 15:55 that has not hit a take-profit, an impulsive candle or a break-even stop, **When** the session reaches 22:00, **Then** it closes at end-of-day as usual — the 16:00 cut-off did not close it early.
+4. **Given** a day where the first two positions both close with negative points, **When** a third valid breakout confirms before 16:00, **Then** **no position is opened**.
+5. **Given** a day where the first two positions close one with negative points and one with positive points, **When** a third valid breakout confirms before 16:00, **Then** the position **is** opened — the cap counts losses, not trades.
+6. **Given** a day whose second losing position is still open, **When** a candle would confirm another entry, **Then** the question does not arise: the one-position-at-a-time rule (FR-011) already blocks it, and the loss counter only increments when a position **closes**.
+7. **Given** a day where two positions have closed at a loss, **When** the session ends with no position open, **Then** the day reports exactly those two trades and `TRADED` status.
+8. **Given** a day whose losses come from mixed exit reasons — one impulse stop and one end-of-day close below entry — **When** a third breakout confirms, **Then** it is blocked: both count, because both closed with negative points.
+
+---
+
+### Edge Cases
+
+- **A trade closing at exactly 0 points** (an end-of-day close landing on the entry price, or a clean break-even) is **not** a loss and does not count toward the cap. Only strictly negative points count.
+- **Cut-off and cap are independent**: either one alone blocks an entry. A day can be stopped by the clock having taken no losses at all, or by two losses at 10:30.
+- **The cut-off is measured on the candle's start time**, the same timestamp the entry is recorded at, so the last candle that can open a position is the one starting 15:55 and running to 16:00.
+- **DST**: 16:00 is Paris local time, resolved the same DST-aware way as the 9:00 reference window and the 22:00 session end, so it is 14:00 UTC in summer and 15:00 UTC in winter.
+- **A day with no data or an H1 range ≤ 70 points** is unaffected — it never reaches the entry search at all (FR-G17).
+- **Interaction with the breakout search**: blocking an entry must not corrupt the direction searches. After the cut-off the search state is irrelevant because nothing can open; before it, a blocked entry behaves as the existing "confirmed but not valid" path already does.
+
+## Requirements
+
+- **FR-G19**: `G9HIC` MUST NOT open a new position on any 5-minute candle whose start time is **at or after 16:00 Paris local time** (DST-aware, derived from the definition's market timezone). The last candle that can open a position is the one starting at 15:55. This filter applies to both directions.
+- **FR-G20**: `G9HIC` MUST NOT open a new position once **two positions have already closed with negative points on that trading day**. A trade's points being strictly less than 0 is the test, whatever its exit reason; a trade closing at exactly 0 points does not count. The counter is per trading day and starts at zero each day.
+- **FR-G21**: Neither filter MUST affect an already-open position. Exit handling — the impulse stop (FR-G14/FR-G15), the take-profit and break-even arming (FR-G16), and the 22:00 end-of-day close (FR-G12) — is unchanged, including for a position opened at 15:55 and for the second losing position while it is still open.
+- **FR-G22**: Both filters MUST be **fixed properties** of `G9HIC`, not per-run tunable parameters (extending FR-G18). The four numeric thresholds remain tunable, with `stop_loss_points` still unused (FR-G15).
+- **FR-G23**: The filters MUST leave every other definition unchanged: `B9H`, `B9HTC`, `G9H`, `G9HSL` and `B9HWS` take entries at any hour of their session and are not subject to a loss cap.
+
+### Key Entities
+
+- **Backtest Definition** (extended): gains a last-entry cut-off time and a maximum-losses-per-day count. Both default to "off" (None) so a definition without them behaves exactly as it does today.
+
+## Success Criteria
+
+- **SC-G10**: On a hand-built day where a valid breakout confirms at 16:00, no position is opened; on the same setup shifted to 15:55, one is.
+- **SC-G11**: On a hand-built day with three losing setups, exactly two trades are reported; with a loss/win/loss sequence, three are.
+- **SC-G12**: A position opened at 15:55 still closes at 22:00 end-of-day, proving the cut-off is an entry filter only.
+- **SC-G13**: `B9H`, `B9HTC`, `G9H`, `G9HSL` and `B9HWS` produce byte-for-byte identical golden results before and after this change; only `G9HIC`'s rows move.
+
+## Assumptions
+
+- 16:00 and "two losses" are, like the 70-point threshold, judgement calls stated to be tested rather than derived — fixed on the definition so a run's results always correspond to the rules as shipped.
+- The loss cap is evaluated when a position **closes**, so the third entry of a day is blocked only if both prior positions have already resolved as losses; this falls out of the one-position-at-a-time rule and needs no separate ordering rule.
+- Both filters reduce the number of trades and are expected to reduce the number of days that end deeply negative. Whether they improve the strategy overall is what the run is for; adding them implies no deployment decision.

--- a/specs/025-ger40-bougie-9h/tasks.md
+++ b/specs/025-ger40-bougie-9h/tasks.md
@@ -254,3 +254,33 @@ Task: "G9H /day aggregated-trade test in tests/api/routers/test_backtest.py"    
 
 - T031 runs alongside T032–T035 (different files).
 - T032/T033/T034/T035 are four independent test files.
+
+---
+
+# Addendum 2 tasks: entry cut-off and daily loss cap (`G9HIC`)
+
+**Input**: [spec.md](./spec.md) §Addendum 2, [plan.md](./plan.md) §Addendum 2
+
+## Phase 10: The entry gate
+
+- [x] T045 Add `last_entry_time: Optional[datetime.time]` and `max_daily_losses: Optional[int]` to `BacktestDefinition` in `model/backtest.py`, with `__post_init__` guards: `max_daily_losses` positive, and `last_entry_time` strictly inside the definition's session (after the market open, at or before its close).
+- [x] T046 Add `api/services/backtest/entry_gate.py` with an `EntryGate` exposing `allows(candle_time)` / `record(trade)`, plus an always-allow gate for definitions carrying neither filter. The cut-off resolves the definition's local `last_entry_time` to naive UTC for the trading date via the existing DST-aware market conversion; the loss counter increments on `trade.points < 0`.
+- [x] T047 Add `build_entry_gate(definition, trading_date)` to `api/services/backtest/rules.py`, alongside `build_exit_chain`/`build_lot_model`, so variant flags stay read in one place.
+- [x] T048 Wire the gate into `BacktestService._evaluate_trades`: consult it before opening a position, and record each closed trade. `_evaluate_from_candles` passes the trading date through. Depends on T046, T047.
+- [x] T049 Set `last_entry_time=datetime.time(16, 0)` and `max_daily_losses=2` on the `G9HIC` definition in `api/services/backtest/definitions.py`. Depends on T045.
+
+## Phase 11: Tests
+
+- [x] T050 [P] `tests/api/services/backtest/test_entry_gate.py`: the gate in isolation — allows at 15:55 and blocks at 16:00 and later (both DST regimes); blocks after two negative-points trades; a 0-point trade does not count; a win between two losses does not; the always-allow gate ignores both.
+- [x] T051 [P] Extend `tests/api/services/backtest/test_engine_impulsive.py` with the end-to-end cases (SC-G10–SC-G12): a breakout confirming at 15:55 opens, the same setup at 16:00 does not; a third setup after two losses is refused while loss/win/loss takes all three; a position opened at 15:55 still closes END_OF_DAY at 21:55.
+- [x] T052 [P] Add the `G9HIC` field assertions to `tests/api/services/backtest/test_definitions.py` and the `__post_init__` guard cases (non-positive `max_daily_losses`, a `last_entry_time` outside the session).
+- [x] T053 [P] Add a `build_entry_gate` case to `tests/api/services/backtest/test_rules.py`: `G9HIC` gets a filtering gate, every other definition an always-allow one.
+- [x] T054 Regenerate the golden snapshot and confirm the diff touches **only** `G9HIC` rows (SC-G13). Depends on T048, T049.
+
+## Phase 12: Polish
+
+- [x] T055 `poetry run black . && poetry run isort . && poetry run flake8 && poetry run mypy .`, then the full suite.
+
+## Dependencies
+
+Phase 10 in order (fields → gate → builder → wiring → registration); Phase 11 tests are independent of each other except T054, which needs the wiring live; Phase 12 last.

--- a/tests/api/services/backtest/helpers.py
+++ b/tests/api/services/backtest/helpers.py
@@ -93,6 +93,8 @@ IMPULSIVE_DEFINITION = BacktestDefinition(
     min_h1_range_points=70.0,
     impulsive_candle_points=70.0,
     impulsive_close_fraction=0.25,
+    last_entry_time=datetime.time(16, 0),
+    max_daily_losses=2,
 )
 GER_PARAMS = GER_DEFINITION.default_parameters
 

--- a/tests/api/services/backtest/test_definitions.py
+++ b/tests/api/services/backtest/test_definitions.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from api.services.backtest import (
@@ -86,6 +88,8 @@ class TestRegistry:
         assert definition.min_h1_range_points == 70.0
         assert definition.impulsive_candle_points == 70.0
         assert definition.impulsive_close_fraction == 0.25
+        assert definition.last_entry_time == datetime.time(16, 0)
+        assert definition.max_daily_losses == 2
         # Single lot, and no close-measured stop other than the impulse.
         assert definition.double_take_profit is False
         assert definition.structural_stop is False
@@ -192,6 +196,34 @@ class TestBacktestDefinitionValidation:
             self._build(
                 double_take_profit=True, first_target_fraction=fraction
             )
+
+    @pytest.mark.parametrize("cap", [0, -1])
+    def test_a_non_positive_loss_cap_is_rejected(self, cap):
+        with pytest.raises(ValueError, match="max_daily_losses"):
+            self._build(max_daily_losses=cap)
+
+    @pytest.mark.parametrize(
+        "cut_off",
+        [
+            datetime.time(8, 0),  # before the 9:00 open
+            datetime.time(9, 0),  # at it, so nothing could ever open
+            datetime.time(18, 0),  # after the 17:30 close
+        ],
+    )
+    def test_a_cut_off_outside_the_session_is_rejected(self, cut_off):
+        with pytest.raises(ValueError, match="last_entry_time"):
+            self._build(last_entry_time=cut_off)
+
+    def test_a_cut_off_inside_the_session_is_accepted(self):
+        assert self._build(
+            last_entry_time=datetime.time(16, 0)
+        ).last_entry_time == datetime.time(16, 0)
+
+    def test_the_cut_off_bound_follows_the_definition_market(self):
+        """18:00 is outside EUMarket's session but inside the CFD one."""
+        assert self._build(
+            market=EuCfdMarket(), last_entry_time=datetime.time(18, 0)
+        ).last_entry_time == datetime.time(18, 0)
 
     def test_half_configured_impulse_is_rejected(self):
         with pytest.raises(ValueError, match="impulsive-candle stop needs"):

--- a/tests/api/services/backtest/test_engine_impulsive.py
+++ b/tests/api/services/backtest/test_engine_impulsive.py
@@ -310,3 +310,130 @@ class TestSessionFetchWindow:
 
         assert start == datetime.datetime(2026, 6, 2, 8, 0)
         assert end == datetime.datetime(2026, 6, 2, 15, 30)
+
+
+def entry_sequence(base):
+    """The breach / candidate / breakout trio that opens a long at 8015,
+    placed so the *breakout* candle (the one the entry is timed at) starts
+    at offset `base`."""
+    return [
+        m5_candle(base - 2, 8005, 8010, 7990, 7995),
+        m5_candle(base - 1, 8000, 8015, 7995, 8010),
+        m5_candle(base, 8010, 8020, 8005, 8015),
+    ]
+
+
+class TestEntryCutoff:
+    """FR-G19: no position opened at or after 16:00 Paris.
+
+    m5_candle(n) is 08:00 UTC + 5n, and 16:00 Paris is 14:00 UTC in
+    summer, so offset 72 is exactly the cut-off and 71 is the last candle
+    that may open.
+    """
+
+    CUTOFF_OFFSET = 72
+
+    async def test_a_breakout_confirming_at_1555_still_opens(self):
+        candles = entry_sequence(self.CUTOFF_OFFSET - 1) + [
+            m5_candle(143, 8015, 8030, 8010, 8025),
+        ]
+
+        result = await run_impulsive(candles)
+
+        assert result.status == DayStatus.TRADED
+        assert len(result.trades) == 1
+        assert result.trades[0].entry_time == datetime.datetime(
+            2026, 6, 2, 13, 55
+        )
+
+    async def test_the_same_breakout_at_1600_does_not(self):
+        candles = entry_sequence(self.CUTOFF_OFFSET) + [
+            m5_candle(143, 8015, 8030, 8010, 8025),
+        ]
+
+        result = await run_impulsive(candles)
+
+        assert result.status == DayStatus.NO_TRADE
+        assert result.trades == []
+
+    async def test_nothing_opens_later_in_the_evening_either(self):
+        candles = entry_sequence(120) + [
+            m5_candle(143, 8015, 8030, 8010, 8025),
+        ]
+
+        result = await run_impulsive(candles)
+
+        assert result.trades == []
+
+    async def test_a_position_opened_at_1555_still_runs_to_22h(self):
+        """The cut-off blocks opening, never closing (FR-G21)."""
+        candles = entry_sequence(self.CUTOFF_OFFSET - 1) + [
+            m5_candle(100, 8015, 8020, 8010, 8018),
+            m5_candle(143, 8018, 8026, 8016, 8024),
+        ]
+
+        result = await run_impulsive(candles)
+
+        trade = result.trades[0]
+        assert trade.exit_reason == ExitReason.END_OF_DAY
+        assert trade.exit_time == datetime.datetime(2026, 6, 2, 19, 55)
+        assert trade.points == 9.0
+
+
+class TestDailyLossCap:
+    """FR-G20: no new position once two have closed at a loss."""
+
+    def _losing_cycle(self, base):
+        """Enter long at 8015 on offset `base`, stopped by an impulsive
+        candle on the next one for -75."""
+        return entry_sequence(base) + [
+            m5_candle(base + 1, 8010, 8012, 7935, 7940)
+        ]
+
+    def _winning_cycle(self, base):
+        """The same entry, taken to the 8090 take-profit for +75."""
+        return entry_sequence(base) + [
+            m5_candle(base + 1, 8020, 8090, 8015, 8085)
+        ]
+
+    async def test_the_third_setup_after_two_losses_is_refused(self):
+        candles = (
+            self._losing_cycle(2)
+            + self._losing_cycle(6)
+            + self._losing_cycle(10)
+        )
+
+        result = await run_impulsive(candles)
+
+        assert len(result.trades) == 2
+        assert [trade.points for trade in result.trades] == [-75.0, -75.0]
+
+    async def test_a_win_between_two_losses_leaves_the_gate_open(self):
+        """Proves the third cycle *would* have traded - the cap counts
+        losses, not trades."""
+        candles = (
+            self._losing_cycle(2)
+            + self._winning_cycle(6)
+            + self._losing_cycle(10)
+        )
+
+        result = await run_impulsive(candles)
+
+        assert len(result.trades) == 3
+        assert [trade.points for trade in result.trades] == [
+            -75.0,
+            75.0,
+            -75.0,
+        ]
+
+    async def test_the_cap_holds_for_the_rest_of_the_day(self):
+        candles = (
+            self._losing_cycle(2)
+            + self._losing_cycle(6)
+            + self._winning_cycle(10)
+            + self._winning_cycle(20)
+        )
+
+        result = await run_impulsive(candles)
+
+        assert len(result.trades) == 2

--- a/tests/api/services/backtest/test_entry_gate.py
+++ b/tests/api/services/backtest/test_entry_gate.py
@@ -1,0 +1,139 @@
+"""The entry gate in isolation: when the engine may open a position.
+
+Built without candles - the gate only ever sees a candle's start time and
+the trades that have closed, so its rules are asserted directly rather
+than inferred from a day's result.
+"""
+
+import datetime
+
+from api.services.backtest.entry_gate import (
+    ALWAYS_OPEN,
+    FilteredEntry,
+    cutoff_utc,
+)
+from model import EuCfdMarket, EUMarket
+from model.enum import Direction, ExitReason
+from tests.api.services.backtest.helpers import closed_trade
+
+SUMMER = datetime.date(2026, 6, 2)
+WINTER = datetime.date(2026, 1, 15)
+FOUR_PM = datetime.time(16, 0)
+
+
+def at(hour, minute=0, day=SUMMER):
+    return datetime.datetime(day.year, day.month, day.day, hour, minute)
+
+
+class TestCutoffResolution:
+    """16:00 market-local, resolved per date - not a hardcoded UTC hour."""
+
+    def test_summer_is_14h_utc(self):
+        assert cutoff_utc(FOUR_PM, EuCfdMarket(), SUMMER) == at(14, 0)
+
+    def test_winter_is_15h_utc(self):
+        assert cutoff_utc(FOUR_PM, EuCfdMarket(), WINTER) == at(
+            15, 0, day=WINTER
+        )
+
+    def test_the_shift_follows_the_timezone_not_the_session(self):
+        """EUMarket and EuCfdMarket close at different hours but share a
+        timezone, so a 16:00 cut-off lands on the same instant."""
+        assert cutoff_utc(FOUR_PM, EUMarket(), SUMMER) == cutoff_utc(
+            FOUR_PM, EuCfdMarket(), SUMMER
+        )
+
+
+class TestEntryCutoff:
+    def _gate(self):
+        return FilteredEntry(cutoff_utc(FOUR_PM, EuCfdMarket(), SUMMER), None)
+
+    def test_the_1555_candle_may_still_open(self):
+        assert self._gate().allows(at(13, 55)) is True
+
+    def test_the_1600_candle_may_not(self):
+        assert self._gate().allows(at(14, 0)) is False
+
+    def test_nothing_later_may_either(self):
+        gate = self._gate()
+        assert gate.allows(at(14, 5)) is False
+        assert gate.allows(at(19, 55)) is False
+
+    def test_the_morning_is_unaffected(self):
+        assert self._gate().allows(at(8, 0)) is True
+
+
+class TestDailyLossCap:
+    def _gate(self):
+        return FilteredEntry(None, 2)
+
+    def test_two_losses_close_the_gate(self):
+        gate = self._gate()
+        assert gate.allows(at(8, 0)) is True
+
+        gate.record(closed_trade(-75, ExitReason.STOP_LOSS))
+        assert gate.allows(at(8, 30)) is True
+
+        gate.record(closed_trade(-40, ExitReason.END_OF_DAY))
+        assert gate.allows(at(9, 0)) is False
+
+    def test_the_cap_counts_losses_not_trades(self):
+        gate = self._gate()
+        gate.record(closed_trade(-75, ExitReason.STOP_LOSS))
+        gate.record(closed_trade(120, ExitReason.TAKE_PROFIT))
+        gate.record(closed_trade(30, ExitReason.TAKE_PROFIT))
+
+        assert gate.allows(at(9, 0)) is True
+
+    def test_any_negative_exit_reason_counts(self):
+        """Not just stop-losses: under an impulse stop a day can bleed
+        away through end-of-day and gapped break-even closes."""
+        for reason in (
+            ExitReason.STOP_LOSS,
+            ExitReason.END_OF_DAY,
+            ExitReason.BREAK_EVEN,
+            ExitReason.TAKE_PROFIT,
+        ):
+            gate = self._gate()
+            gate.record(closed_trade(-5, reason))
+            gate.record(closed_trade(-5, reason))
+            assert gate.allows(at(9, 0)) is False
+
+    def test_a_flat_trade_is_not_a_loss(self):
+        gate = self._gate()
+        gate.record(closed_trade(0, ExitReason.BREAK_EVEN))
+        gate.record(closed_trade(0, ExitReason.END_OF_DAY))
+        gate.record(closed_trade(0, ExitReason.TAKE_PROFIT))
+
+        assert gate.allows(at(9, 0)) is True
+
+    def test_shorts_count_the_same_way(self):
+        gate = self._gate()
+        gate.record(closed_trade(-20, ExitReason.STOP_LOSS, Direction.SELL))
+        gate.record(closed_trade(-20, ExitReason.STOP_LOSS, Direction.SELL))
+
+        assert gate.allows(at(9, 0)) is False
+
+
+class TestFiltersAreIndependent:
+    def test_either_alone_refuses(self):
+        gate = FilteredEntry(cutoff_utc(FOUR_PM, EuCfdMarket(), SUMMER), 2)
+
+        # The clock alone, with no losses at all.
+        assert gate.allows(at(14, 0)) is False
+        # The losses alone, in the morning.
+        gate.record(closed_trade(-10, ExitReason.STOP_LOSS))
+        gate.record(closed_trade(-10, ExitReason.STOP_LOSS))
+        assert gate.allows(at(8, 5)) is False
+
+
+class TestAlwaysOpen:
+    """The gate the other five definitions get: no filtering at all."""
+
+    def test_every_candle_is_allowed_whatever_has_closed(self):
+        ALWAYS_OPEN.record(closed_trade(-75, ExitReason.STOP_LOSS))
+        ALWAYS_OPEN.record(closed_trade(-75, ExitReason.STOP_LOSS))
+        ALWAYS_OPEN.record(closed_trade(-75, ExitReason.STOP_LOSS))
+
+        assert ALWAYS_OPEN.allows(at(8, 0)) is True
+        assert ALWAYS_OPEN.allows(at(19, 55)) is True

--- a/tests/api/services/backtest/test_rules.py
+++ b/tests/api/services/backtest/test_rules.py
@@ -5,6 +5,9 @@ its membership is the only place a definition's variant flags are read -
 so both are asserted here rather than inferred from engine behavior.
 """
 
+import datetime
+
+from api.services.backtest.entry_gate import ALWAYS_OPEN, FilteredEntry
 from api.services.backtest.policies import (
     ArmBreakEven,
     DoubleTarget,
@@ -14,7 +17,7 @@ from api.services.backtest.policies import (
     Target,
     TimeCut,
 )
-from api.services.backtest.rules import build_exit_chain
+from api.services.backtest.rules import build_entry_gate, build_exit_chain
 from model import BacktestDefinition, BacktestParameters
 
 PARAMS = BacktestParameters()
@@ -149,6 +152,52 @@ class TestChainComposition:
             StructuralStop,
             ArmBreakEven,
         ]
+
+
+class TestEntryGate:
+    """Entry filters are read here, the same place the exit chain is
+    built, so a definition's flags stay read in exactly one module."""
+
+    TRADING_DATE = datetime.date(2026, 6, 2)
+
+    def test_a_definition_without_filters_gets_the_always_open_gate(self):
+        gate = build_entry_gate(_definition(), self.TRADING_DATE)
+
+        assert gate is ALWAYS_OPEN
+
+    def test_the_filters_are_carried_onto_the_gate(self):
+        definition = _definition(
+            last_entry_time=datetime.time(16, 0), max_daily_losses=2
+        )
+
+        gate = build_entry_gate(definition, self.TRADING_DATE)
+
+        assert isinstance(gate, FilteredEntry)
+        assert gate.cutoff_utc == datetime.datetime(2026, 6, 2, 14, 0)
+        assert gate.max_losses == 2
+
+    def test_either_filter_alone_still_builds_a_gate(self):
+        cut_off_only = build_entry_gate(
+            _definition(last_entry_time=datetime.time(16, 0)),
+            self.TRADING_DATE,
+        )
+        cap_only = build_entry_gate(
+            _definition(max_daily_losses=2), self.TRADING_DATE
+        )
+
+        assert cut_off_only.max_losses is None
+        assert cap_only.cutoff_utc is None
+
+    def test_only_g9hic_ships_with_entry_filters(self):
+        from api.services.backtest import list_definitions
+
+        filtered = [
+            definition.code
+            for definition in list_definitions()
+            if build_entry_gate(definition, self.TRADING_DATE)
+            is not ALWAYS_OPEN
+        ]
+        assert filtered == ["G9HIC"]
 
 
 class TestRegisteredDefinitionChains:

--- a/tests/api/services/files/backtest_golden.json
+++ b/tests/api/services/files/backtest_golden.json
@@ -2323,34 +2323,25 @@
           "exit_reason": "take_profit",
           "exit_time": "2026-03-03T12:05:00",
           "points": 85.26
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 24602.59,
-          "entry_time": "2026-03-03T16:10:00",
-          "exit_price": 24529.68,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": 72.91
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 28,
-        "points": -18.84
+        "count": 26,
+        "points": -17.98
       },
       "end_of_day": {
-        "count": 6,
-        "points": -44.63
+        "count": 2,
+        "points": -187.76
       },
       "stop_loss": {
-        "count": 13,
-        "points": -1277.22
+        "count": 11,
+        "points": -1112.69
       },
       "take_profit": {
-        "count": 28,
-        "points": 2827.0
+        "count": 24,
+        "points": 2381.03
       }
     },
     "run": {
@@ -2375,9 +2366,9 @@
           "h1_open": 24517.88,
           "mm50_slope": 9.86641,
           "overnight_gap": 94.98,
-          "points": 158.17,
+          "points": 85.26,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 14.13522,
@@ -2387,9 +2378,9 @@
           "h1_open": 24476.26,
           "mm50_slope": 10.13151,
           "overnight_gap": -2.1,
-          "points": -20.73,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 13.50398,
@@ -2437,7 +2428,7 @@
           "overnight_gap": -4.05,
           "points": 112.35,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 15.72043,
@@ -2447,9 +2438,9 @@
           "h1_open": 24670.64,
           "mm50_slope": 11.1303,
           "overnight_gap": 28.46,
-          "points": 125.24,
+          "points": 126.1,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 16.95558,
@@ -2483,9 +2474,9 @@
           "h1_open": 24695.57,
           "mm50_slope": 11.27264,
           "overnight_gap": 17.2,
-          "points": 28.65,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 17.49488,
@@ -2507,9 +2498,9 @@
           "h1_open": 24792.03,
           "mm50_slope": 11.7235,
           "overnight_gap": -7.27,
-          "points": 237.76,
+          "points": 123.05,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 19.98255,
@@ -2579,9 +2570,9 @@
           "h1_open": 24805.58,
           "mm50_slope": 11.22718,
           "overnight_gap": 64.53,
-          "points": 62.3,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 22.05312,
@@ -2603,9 +2594,9 @@
           "h1_open": 24878.25,
           "mm50_slope": 11.08169,
           "overnight_gap": 117.65,
-          "points": 103.56,
+          "points": -14.64,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 22.46958,
@@ -2615,9 +2606,9 @@
           "h1_open": 24834.5,
           "mm50_slope": 11.03512,
           "overnight_gap": -226.45,
-          "points": 260.27,
+          "points": 122.77,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 23.17763,
@@ -2663,9 +2654,9 @@
           "h1_open": 24883.25,
           "mm50_slope": 11.04254,
           "overnight_gap": -157.29,
-          "points": -125.23,
+          "points": -3.34,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 22.53728,
@@ -2675,9 +2666,9 @@
           "h1_open": 24940.82,
           "mm50_slope": 10.57134,
           "overnight_gap": -40.14,
-          "points": 160.89,
+          "points": 203.53,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 22.56853,
@@ -2747,9 +2738,9 @@
           "h1_open": 24922.2,
           "mm50_slope": 9.48713,
           "overnight_gap": 191.53,
-          "points": 80.3,
+          "points": 4.74,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 3
         },
         {
           "adx14": 23.50007,
@@ -2861,16 +2852,16 @@
         }
       ],
       "summary": {
-        "average_loss": 92.8569,
-        "average_win": 96.4794,
+        "average_loss": 100.0346,
+        "average_win": 99.2096,
         "definition_code": "G9HIC",
         "end_date": "2026-04-30",
-        "final_result": 1486.31,
-        "number_of_be": 28,
+        "final_result": 1062.6,
+        "number_of_be": 26,
         "number_of_days": 42,
-        "number_of_losing_positions": 16,
-        "number_of_trades": 75,
-        "number_of_winning_positions": 31,
+        "number_of_losing_positions": 13,
+        "number_of_trades": 63,
+        "number_of_winning_positions": 24,
         "start_date": "2026-03-02"
       }
     }


### PR DESCRIPTION
Two entry filters on the impulsive-candle variant (`G9HIC`), specified in [spec 025 §Addendum 2](https://github.com/RNiveau/saxo-order/blob/claude/dax-backtest-impulsive-candle-61dj2p/specs/025-ger40-bougie-9h/spec.md) as FR-G19–FR-G23:

- **No position opened on a candle starting at or after 16:00 Paris.** DST-aware, so 14:00 UTC in summer and 15:00 in winter; the last candle that can open is the one starting 15:55.
- **No position opened once two have closed with negative points that day.** Per trading day, counter reset with it.

Both bound a strategy whose worst case is otherwise unbounded: the cut-off stops opening something whose only realistic exit is the 22:00 close, the cap stops a day that is already going badly from paying for a third attempt.

Applied to `G9HIC` **in place** rather than as a seventh definition — it has never been run for real or written up in `backtests/`, so no published result is invalidated.

## Design

Neither rule belongs in the exit chain: a policy answers "does this close an open position?", and these never close anything. They are not entry *validity* either — that layer judges a breakout against price levels and is deliberately stateless across positions, while the clock and the day's realised losses are properties of the run.

So they live in a new `EntryGate` (`api/services/backtest/entry_gate.py`), built by `rules.build_entry_gate` alongside `build_exit_chain`/`build_lot_model` — keeping `definitions.py` flags read in exactly one module. The engine gains two lines: consult the gate before opening, feed it each closed trade. A definition carrying neither filter gets an always-open gate, so the other five keep an unchanged code path rather than a new branch.

**What counts as a loss:** `points < 0`, whatever the exit reason, matching how the run summary counts losing positions. Deliberately *not* stop-loss exits — under an impulse stop a day can bleed away through end-of-day closes without a single stop firing, and a cap blind to those would not bound what it claims to. A trade closing at exactly 0 is not a loss.

Registration-time guards, in the existing `__post_init__` style: `max_daily_losses` must be positive, and `last_entry_time` must fall inside the definition's session — a cut-off outside it either forbids every entry or can never fire, and both are configuration errors worth failing at import rather than shipping as a silent no-op.

## Effect on the golden run

42 synthetic days. **Only `G9HIC` moved** — verified key by key against the previous snapshot; the other five definitions are byte-for-byte identical (SC-G13).

| | before | after |
|---|---|---|
| trades | 75 | 63 |
| win / loss / BE | 31 / 16 / 28 | 24 / 13 / 26 |
| average win | 96.48 | 99.21 |
| average loss | 92.86 | 100.03 |
| final result | +1486.31 | +1062.60 |

Worth flagging rather than burying: on this fixture the filters **cost** more than they save, and the *average loss went up* — the opposite of what a risk filter is meant to do. The cut-off is removing late entries that ended flat or slightly positive at the 22:00 close rather than the deep losses. That is a property of a random-walk fixture with no real intraday session structure, so I would not read the sign as evidence either way; the real GER40 run is what decides. The snapshot is characterization, not endorsement.

## Tests

- `tests/api/services/backtest/test_entry_gate.py` (new): the gate without candles — 15:55 allowed and 16:00 refused, the summer/winter cut-off resolution, two losses closing the gate, a win between two losses not counting, a 0-point trade not counting, every negative exit reason counting, and both filters refusing independently.
- `test_engine_impulsive.py`: end-to-end — the same breakout opening at 15:55 and refused at 16:00, a position opened at 15:55 still closing `END_OF_DAY` at 21:55 (the cut-off blocks opening, never closing), a third setup refused after two losses while loss/win/loss takes all three.
- `test_rules.py`: only `G9HIC` builds a filtering gate, derived from the registry rather than a hardcoded code list.
- `test_definitions.py`: the shipped fields, plus the guard cases.

714 passed, 10 skipped. `black`/`isort`/`flake8` clean; `mypy` at the four pre-existing missing-stub errors (`binance.error`, `aioboto3` ×3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEcj6YEihziuZtkT6fPsP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEcj6YEihziuZtkT6fPsP7)_