### PR TITLE
fix: correct Ouinex GraphQL schema so search works

### DIFF
--- a/client/ouinex_client.py
+++ b/client/ouinex_client.py
@@ -9,6 +9,9 @@ from model.enum import AssetType, Exchange
 from utils.exception import OuinexException
 from utils.logger import Logger
 
+# UNVERIFIED: the Ouinex schema exposes no `signIn` mutation (introspection is
+# disabled, and no candidate name validates). Authenticated operations —
+# candles and reporting — stay blocked until the auth entry point is known.
 SIGN_IN_MUTATION = """
 mutation SignIn($apiKey: String!, $secretKey: String!) {
   signIn(apiKey: $apiKey, secretKey: $secretKey) {
@@ -22,13 +25,19 @@ mutation SignIn($apiKey: String!, $secretKey: String!) {
 INSTRUMENTS_QUERY = """
 query Instruments {
   instruments {
-    id
-    symbol
-    baseCurrency
-    quoteCurrency
+    instrument_id
+    name
+    base_currency {
+      currency_id
+    }
+    quote_currency {
+      currency_id
+    }
   }
 }
 """
+
+CONVERSION_SUFFIX = "_CONV"
 
 
 class OuinexClient:
@@ -67,7 +76,9 @@ class OuinexClient:
         try:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            raise OuinexException(f"Ouinex sign-in request failed: {e}")
+            raise OuinexException(
+                f"Ouinex sign-in request failed: {e} - {response.text}"
+            )
 
         payload = response.json()
         if payload.get("errors"):
@@ -88,19 +99,32 @@ class OuinexClient:
             self._sign_in()
 
     def _execute(
-        self, query: str, variables: Optional[Dict[str, Any]] = None
+        self,
+        query: str,
+        variables: Optional[Dict[str, Any]] = None,
+        authenticated: bool = True,
     ) -> Dict[str, Any]:
         """
-        Execute a GraphQL query/mutation against the Ouinex endpoint with a
-        valid JWT, refreshing the token once on an authentication failure.
+        Execute a GraphQL query/mutation against the Ouinex endpoint.
+
+        Authenticated operations sign in first and refresh the token once on an
+        authentication failure. Public operations (`authenticated=False`, e.g.
+        `instruments`) are sent without a bearer token and never sign in, but a
+        401 still triggers one signed retry.
         """
-        self._ensure_token()
+        if authenticated:
+            self._ensure_token()
 
         def _post() -> requests.Response:
+            headers = (
+                {"Authorization": f"Bearer {self._access_token}"}
+                if self._access_token
+                else {}
+            )
             return self.session.post(
                 self.graphql_url,
                 json={"query": query, "variables": variables or {}},
-                headers={"Authorization": f"Bearer {self._access_token}"},
+                headers=headers,
                 timeout=10,
             )
 
@@ -112,7 +136,9 @@ class OuinexClient:
         try:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            raise OuinexException(f"Ouinex request failed: {e}")
+            raise OuinexException(
+                f"Ouinex request failed: {e} - {response.text}"
+            )
 
         payload = response.json()
         if payload.get("errors"):
@@ -120,26 +146,31 @@ class OuinexClient:
 
         return payload.get("data") or {}
 
+    @staticmethod
+    def _currencies(instrument: Dict[str, Any]) -> tuple:
+        base = (instrument.get("base_currency") or {}).get("currency_id", "")
+        quote = (instrument.get("quote_currency") or {}).get("currency_id", "")
+        return base, quote
+
     def _map_instrument_to_asset(self, instrument: Dict[str, Any]) -> Asset:
-        base = instrument.get("baseCurrency", "")
-        quote = instrument.get("quoteCurrency", "")
-        symbol = instrument.get("symbol") or f"{base}{quote}"
-        identifier = instrument.get("id")
+        base, quote = self._currencies(instrument)
+        symbol = instrument.get("instrument_id") or f"{base}{quote}"
         return Asset(
             symbol=symbol,
-            description=f"{base}/{quote}",
+            description=instrument.get("name") or f"{base}/{quote}",
             asset_type=AssetType.CRYPTO,
             exchange=Exchange.OUINEX,
-            identifier=int(identifier) if identifier is not None else None,
+            identifier=None,
         )
 
     def search(self, keyword: str) -> List[Asset]:
         """
         Search Ouinex instruments by keyword.
 
-        Fetches the instrument list via the `instruments` GraphQL query and
-        filters client-side against the symbol and base/quote currencies,
-        mirroring the Binance search behavior.
+        Fetches the instrument list via the public `instruments` GraphQL query
+        and filters client-side against the symbol and base/quote currencies,
+        mirroring the Binance search behavior. Conversion pairs (`*_CONV`) are
+        excluded — they are not tradable instruments.
 
         Args:
             keyword: Search keyword to match against symbol or currencies
@@ -147,14 +178,16 @@ class OuinexClient:
         Returns:
             List of Asset objects tagged Exchange.OUINEX / AssetType.CRYPTO
         """
-        data = self._execute(INSTRUMENTS_QUERY)
+        data = self._execute(INSTRUMENTS_QUERY, authenticated=False)
         keyword_lower = keyword.lower()
 
         results = []
         for instrument in data.get("instruments", []):
-            base = instrument.get("baseCurrency", "")
-            quote = instrument.get("quoteCurrency", "")
-            symbol = instrument.get("symbol") or f"{base}{quote}"
+            base, quote = self._currencies(instrument)
+            symbol = instrument.get("instrument_id") or f"{base}{quote}"
+
+            if symbol.endswith(CONVERSION_SUFFIX):
+                continue
 
             if (
                 keyword_lower in symbol.lower()

--- a/specs/024-ouinex-provider/research.md
+++ b/specs/024-ouinex-provider/research.md
@@ -4,6 +4,16 @@ Source: Ouinex API landing (https://api.ouinex.com/, live endpoint https://live-
 
 > ⚠️ The Ouinex API surface below was derived from the public landing page and is **incomplete**. Items marked **VERIFY** must be confirmed against full Ouinex docs (or the Ouinex team) before or during implementation. They do not block planning but shape the task list and risk profile.
 
+## Verification results (2026-07-28)
+
+Probed against the live endpoint. Introspection is **disabled** (Apollo, `INTROSPECTION_DISABLED`), so the schema can only be discovered through validation-error suggestions.
+
+- ❌ **Auth (Decision 3) — REFUTED.** There is no `signIn` mutation; `Cannot query field "signIn" on type "Mutation"` is the 400 that broke search. No candidate name validates (`login`, `signin`, `sign_in`, `auth`, `authenticate`, `token`, `refresh_token`, `api_key_login`, …). The schema is snake_case (`create_kyc_session`, `add_push_token`). **The real auth entry point is unknown and must come from Ouinex docs or support.**
+- ✅ **Instruments (search) — CONFIRMED, and it is PUBLIC.** `query { instruments { … } }` returns 100 instruments with **no** `Authorization` header. Real field names: `instrument_id` (String, e.g. `"BTCUSD"` — not an Int), `name` (`"BTC/USD"`), `base_currency { currency_id }`, `quote_currency { currency_id }`, `price` (`InstrumentPrice`). The spec's `id` / `symbol` / `baseCurrency` / `quoteCurrency` do not exist. About half the list are `*_CONV` conversion pairs, filtered out of search.
+- ❓ **Historical candles (Decision 4) — still unresolved.** Neither `price_bars` nor `candles` exists on `Query`. Combined with the unknown auth, this keeps the primary risk open.
+
+**Consequence:** search works unauthenticated today. Candles and reporting remain blocked on real Ouinex documentation — do not re-derive their schema by guessing.
+
 ---
 
 ## Decision 1: Provider modeled as a new `Exchange.OUINEX`, mapped to Binance only at the journal boundary

--- a/tests/client/test_ouinex_client.py
+++ b/tests/client/test_ouinex_client.py
@@ -15,6 +15,7 @@ def make_response(
     response = MagicMock()
     response.status_code = status_code
     response.json.return_value = json_data or {}
+    response.text = ""
     if status_code >= 400:
         import requests
 
@@ -118,7 +119,7 @@ class TestOuinexClientExecute:
             make_response(200, {"data": {"instruments": []}}),
         ]
 
-        result = client._execute("query { instruments { id } }")
+        result = client._execute("query { instruments { instrument_id } }")
 
         assert result == {"instruments": []}
         auth_call = session.post.call_args_list[-1]
@@ -154,21 +155,21 @@ class TestOuinexClientExecute:
             client._execute("query { ok }")
 
 
+def instrument(instrument_id: str, base: str, quote: str) -> dict:
+    return {
+        "instrument_id": instrument_id,
+        "name": f"{base}/{quote}",
+        "base_currency": {"currency_id": base},
+        "quote_currency": {"currency_id": quote},
+    }
+
+
 INSTRUMENTS_OK = {
     "data": {
         "instruments": [
-            {
-                "id": 1,
-                "symbol": "BTCUSD",
-                "baseCurrency": "BTC",
-                "quoteCurrency": "USD",
-            },
-            {
-                "id": 2,
-                "symbol": "ETHUSD",
-                "baseCurrency": "ETH",
-                "quoteCurrency": "USD",
-            },
+            instrument("BTCUSD", "BTC", "USD"),
+            instrument("ETHUSD", "ETH", "USD"),
+            instrument("BTCUSD_CONV", "BTC", "USD"),
         ]
     }
 }
@@ -179,10 +180,7 @@ class TestOuinexClientSearch:
         self, client_and_session: Tuple[OuinexClient, MagicMock]
     ):
         client, session = client_and_session
-        session.post.side_effect = [
-            make_response(200, SIGN_IN_OK),
-            make_response(200, INSTRUMENTS_OK),
-        ]
+        session.post.return_value = make_response(200, INSTRUMENTS_OK)
 
         results = client.search("btc")
 
@@ -192,18 +190,27 @@ class TestOuinexClientSearch:
         assert asset.description == "BTC/USD"
         assert asset.exchange == Exchange.OUINEX
         assert asset.asset_type == AssetType.CRYPTO
-        assert asset.identifier == 1
+        assert asset.identifier is None
 
     def test_search_matches_quote_currency(
         self, client_and_session: Tuple[OuinexClient, MagicMock]
     ):
         client, session = client_and_session
-        session.post.side_effect = [
-            make_response(200, SIGN_IN_OK),
-            make_response(200, INSTRUMENTS_OK),
-        ]
+        session.post.return_value = make_response(200, INSTRUMENTS_OK)
 
         results = client.search("usd")
 
         assert {asset.symbol for asset in results} == {"BTCUSD", "ETHUSD"}
         assert all(asset.exchange == Exchange.OUINEX for asset in results)
+
+    def test_search_does_not_sign_in(
+        self, client_and_session: Tuple[OuinexClient, MagicMock]
+    ):
+        client, session = client_and_session
+        session.post.return_value = make_response(200, INSTRUMENTS_OK)
+
+        client.search("btc")
+
+        assert session.post.call_count == 1
+        assert session.post.call_args.kwargs["headers"] == {}
+        assert client._access_token is None


### PR DESCRIPTION
## Problem

Every Ouinex search failed with:

```
Ouinex search error: Ouinex sign-in request failed: 400 Client Error: Bad Request for url: https://live-api.ouinex.com/graphql
```

The client was built from the schema guesses in `specs/024-ouinex-provider/research.md` — which flagged all of them **VERIFY** — and none of them match the live API. The `signIn` mutation does not exist:

```
Cannot query field "signIn" on type "Mutation"
```

## What was verified

Probed against the live endpoint. Introspection is disabled (Apollo, `INTROSPECTION_DISABLED`), so the schema was discovered through validation-error suggestions.

| Spec assumption | Reality |
|---|---|
| `signIn` mutation for JWT auth | ❌ Does not exist. No candidate name validates (`login`, `sign_in`, `auth`, `authenticate`, `refresh_token`, …). Schema is snake_case. |
| `instruments` requires auth | ✅ Exists and is **public** — returns 100 instruments with no `Authorization` header. |
| `Instrument { id, symbol, baseCurrency, quoteCurrency }` | ❌ Real fields: `instrument_id` (String), `name`, `base_currency { currency_id }`, `quote_currency { currency_id }`. |
| `price_bars` / `candles` history query | ❌ Neither exists on `Query`. |

## Changes

- `INSTRUMENTS_QUERY` rewritten with the real field names.
- `_execute` takes `authenticated: bool = True`; `search` passes `False`, so it sends no bearer header and never signs in. The 401 → sign-in → retry path stays intact for future authenticated calls.
- `_map_instrument_to_asset` reads the nested currency objects and passes `identifier=None` — Ouinex ids are strings like `"BTCUSD"`, so the old `int(identifier)` would have raised. Matches what `BinanceClient` already does.
- `*_CONV` conversion pairs filtered out of search (roughly half the instrument list; not tradable).
- Both `OuinexException` paths append `response.text`, so a GraphQL rejection reports its actual reason rather than a bare "400 Bad Request" — the reason this took probing to diagnose.
- `SIGN_IN_MUTATION` kept but marked UNVERIFIED, since it is known-wrong.

## Verification

Live, with empty credentials:

```
btc  → BTCEUR (BTC/EUR), BTCUSD (BTC/USD)
xaut → XAUTUSDC (XAUT/USDC)
signed in? None
```

Test fixtures rewritten to the real payload shape, plus `test_search_does_not_sign_in` asserting one request, empty headers, no token. Full suite passes; black/isort/flake8/mypy clean.

## Still blocked

**Sign-in and historical candles.** No auth mutation name validates and no history query exists on `Query` — both need real Ouinex documentation or a word from their support. Ouinex reporting, indicators, and watchlist remain non-functional; only search is live. Findings are recorded in `research.md` so the schema is not re-derived by guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)