### PR TITLE
fix: correct combo indicator band comparisons and speed up macd0lag

### DIFF
--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -103,6 +103,15 @@ def mobile_average(candles: List[Candle], period: int) -> float:
 MM50_TOUCH_PROXIMITY = 0.01
 MM50_TOUCH_SLOPE_MIN = 3.0
 
+COMBO_MA50_SLOPE_MIN = 3.0
+COMBO_MA50_SLOPE_STRONG = 10.0
+COMBO_BB_FLAT_SLOPE_MAX = 5.0
+COMBO_BB_BREACH_TOLERANCE = 0.001
+COMBO_BB_TOLERANCE = 0.005
+COMBO_ATR_BB_MARGIN = 0.3
+COMBO_ATR_MA50_MARGIN = 0.1
+COMBO_STRONG_SIGNAL_MIN = 4
+
 
 def mm50_touch(candles: List[Candle]) -> Optional[Dict[str, float]]:
     if len(candles) < 60:
@@ -138,6 +147,32 @@ def containing_candle(candles: List[Candle]) -> Optional[Candle]:
     return None
 
 
+def is_far_from_supports(
+    candles: List[Candle],
+    band: float,
+    ma50: float,
+    margin_band: float,
+    margin_ma50: float,
+    direction: Direction,
+) -> bool:
+    """
+    True when the last two candles sit clear of both the 2.0 bollinger band
+    and the ma50: the pullback never came close enough to be tradable.
+    The candle extreme facing the level is used - the low for a buy, the
+    high for a sell - so a wick reaching the level counts as a touch.
+    """
+    closes = [candle.close for candle in candles[:2]]
+    if direction == Direction.BUY:
+        values = closes + [candle.lower for candle in candles[:2]]
+        return all(value > band + margin_band for value in values) and all(
+            value > ma50 + margin_ma50 for value in values
+        )
+    values = closes + [candle.higher for candle in candles[:2]]
+    return all(value < band - margin_band for value in values) and all(
+        value < ma50 - margin_ma50 for value in values
+    )
+
+
 def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     logger = Logger.get_logger("combo")
     logger.debug(
@@ -146,7 +181,7 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     ma50_last = mobile_average(candles, 50)
     ma50_first = mobile_average(candles[10:], 50)
     bb_last = bollinger_bands(candles, 2.5)
-    bb25_1 = bollinger_bands(candles, 2.5)
+    bb25_1 = bollinger_bands(candles[1:], 2.5)
     bb_first = bollinger_bands(candles[2:], 2.5)
     bb20 = bollinger_bands(candles, 2.0)
     bb20_1 = bollinger_bands(candles[1:], 2.0)
@@ -155,13 +190,20 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     bbb_slope = slope_percentage(0, bb_first.bottom, 3, bb_last.bottom)
     macd_0lag = macd0lag(candles)
     atr = average_true_range(candles)
-    margin_variation_bb = atr * 0.3
-    margin_variation_ma50 = atr * 0.1
+    margin_variation_bb = atr * COMBO_ATR_BB_MARGIN
+    margin_variation_ma50 = atr * COMBO_ATR_MA50_MARGIN
+    both_bb_flat = (
+        abs(bbh_slope) < COMBO_BB_FLAT_SLOPE_MAX
+        and abs(bbb_slope) < COMBO_BB_FLAT_SLOPE_MAX
+    )
 
-    if (bbh_slope < -5 or bbh_slope > 5) and (bbb_slope < -5 or bbb_slope > 5):
+    if (
+        abs(bbh_slope) > COMBO_BB_FLAT_SLOPE_MAX
+        and abs(bbb_slope) > COMBO_BB_FLAT_SLOPE_MAX
+    ):
         logger.debug(f"BB bands are not flat bbh={bbh_slope}, bbb={bbb_slope}")
         return None
-    if ma50_slope > 3:
+    if ma50_slope > COMBO_MA50_SLOPE_MIN:
         logger.debug(f"testing a buying combo ma50_slope={ma50_slope}")
         signal = 0
         if candles[0].close < ma50_last:
@@ -169,28 +211,24 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
                 f"close {candles[0].close} is bellow ma50 {ma50_last}"
             )
             return None
-        if candles[0].close < bb_last.bottom * 0.999:
+        if candles[0].close < bb_last.bottom * (1 - COMBO_BB_BREACH_TOLERANCE):
             logger.debug(
                 f"close {candles[0].close} is bellow bbb 2.5 {bb_last.bottom}"
             )
             return None
-        if (
-            candles[0].close > bb20.bottom + margin_variation_bb
-            and candles[1].close > bb20.bottom + margin_variation_bb
-            and candles[0].lower > bb20.bottom + margin_variation_bb
-            and candles[1].lower > bb20.bottom + margin_variation_bb
+        if is_far_from_supports(
+            candles,
+            bb20.bottom,
+            ma50_last,
+            margin_variation_bb,
+            margin_variation_ma50,
+            Direction.BUY,
         ):
-            if (
-                candles[0].close > ma50_last + margin_variation_ma50
-                and candles[1].close > ma50_last + margin_variation_ma50
-                and candles[0].higher > ma50_last + margin_variation_ma50
-                and candles[1].higher > ma50_last + margin_variation_ma50
-            ):
-                logger.debug(
-                    f"candle {candles[0]} is far from the bbb 2.0 "
-                    f"{bb20.bottom} and from the ma50 {ma50_last}"
-                )
-                return None
+            logger.debug(
+                f"candle {candles[0]} is far from the bbb 2.0 "
+                f"{bb20.bottom} and from the ma50 {ma50_last}"
+            )
+            return None
         buy_combo = ComboSignal(
             price=0,
             direction=Direction.BUY,
@@ -204,21 +242,25 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
                 "both_bb_flat": False,
             },
         )
-        if 5 > bbh_slope > -5 and 5 > bbb_slope > -5:  # both bb are flat
+        if both_bb_flat:
             signal += 1
             buy_combo.details["both_bb_flat"] = True
         if ma50_last < bb_last.bottom:
             signal += 1
             buy_combo.details["ma50_over_bb"] = True
 
-        if ma50_slope > 10:
+        if ma50_slope > COMBO_MA50_SLOPE_STRONG:
             signal += 1
             buy_combo.details["strong_ma50"] = True
 
         if (
-            bb25_1.bottom * 0.9995 < candles[1].close < bb20_1.bottom * 1.005
+            bb25_1.bottom * (1 - COMBO_BB_TOLERANCE)
+            < candles[1].close
+            < bb20_1.bottom * (1 + COMBO_BB_TOLERANCE)
         ) or (
-            bb_last.bottom * 0.9995 < candles[0].close < bb20.bottom * 1.005
+            bb_last.bottom * (1 - COMBO_BB_TOLERANCE)
+            < candles[0].close
+            < bb20.bottom * (1 + COMBO_BB_TOLERANCE)
         ):  # candle -1 or candle is between bb 2.0 / 2.5
             signal += 1
             buy_combo.details["price_within_bb"] = True
@@ -232,37 +274,33 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
             buy_combo.price = candles[0].higher
         if signal == 0:
             buy_combo.strength = SignalStrength.WEAK
-        elif signal > 3:
+        elif signal >= COMBO_STRONG_SIGNAL_MIN:
             buy_combo.strength = SignalStrength.STRONG
         return buy_combo
-    elif ma50_slope < -3:
+    elif ma50_slope < -COMBO_MA50_SLOPE_MIN:
         logger.debug(f"testing a selling combo ma50_slope={ma50_slope}")
         signal = 0
         if candles[0].close > ma50_last:
             logger.debug(f"close {candles[0].close} is above ma50 {ma50_last}")
             return None
-        if candles[0].close > bb_last.up * 1.001:
+        if candles[0].close > bb_last.up * (1 + COMBO_BB_BREACH_TOLERANCE):
             logger.debug(
                 f"close {candles[0].close} is above bbb 2.5 {bb_last.up}"
             )
             return None
-        if (
-            candles[0].close < bb20.up - margin_variation_bb
-            and candles[1].close < bb20.up - margin_variation_bb
-            and candles[0].higher < bb20.up - margin_variation_bb
-            and candles[1].higher < bb20.up - margin_variation_bb
+        if is_far_from_supports(
+            candles,
+            bb20.up,
+            ma50_last,
+            margin_variation_bb,
+            margin_variation_ma50,
+            Direction.SELL,
         ):
-            if (
-                candles[0].close < ma50_last - margin_variation_ma50
-                and candles[1].close < ma50_last - margin_variation_ma50
-                and candles[0].higher < ma50_last - margin_variation_ma50
-                and candles[1].higher < ma50_last - margin_variation_ma50
-            ):
-                logger.debug(
-                    f"candle {candles[0]} is far from the bbb 2.0 "
-                    f"{bb20.up} and from the ma50 {ma50_last}"
-                )
-                return None
+            logger.debug(
+                f"candle {candles[0]} is far from the bbb 2.0 "
+                f"{bb20.up} and from the ma50 {ma50_last}"
+            )
+            return None
         sell_combo = ComboSignal(
             price=0,
             direction=Direction.SELL,
@@ -276,18 +314,24 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
                 "both_bb_flat": False,
             },
         )
-        if 5 > bbh_slope > -5 and 5 > bbb_slope > -5:  # both bb are flat
+        if both_bb_flat:
             signal += 1
             sell_combo.details["both_bb_flat"] = True
         if ma50_last > bb_last.up:
             signal += 1
             sell_combo.details["ma50_over_bb"] = True
-        if ma50_slope < -10:
+        if ma50_slope < -COMBO_MA50_SLOPE_STRONG:
             signal += 1
             sell_combo.details["strong_ma50"] = True
 
-        if (bb25_1.up * 1.005 > candles[1].close > bb20_1.up * 0.9995) or (
-            bb_last.up * 1.005 > candles[0].close > bb20.up * 0.995
+        if (
+            bb20_1.up * (1 - COMBO_BB_TOLERANCE)
+            < candles[1].close
+            < bb25_1.up * (1 + COMBO_BB_TOLERANCE)
+        ) or (
+            bb20.up * (1 - COMBO_BB_TOLERANCE)
+            < candles[0].close
+            < bb_last.up * (1 + COMBO_BB_TOLERANCE)
         ):  # candle -1 or candle is between bb 2.0 / 2.5
             signal += 1
             sell_combo.details["price_within_bb"] = True
@@ -301,7 +345,7 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
             sell_combo.price = candles[0].lower
         if signal == 0:
             sell_combo.strength = SignalStrength.WEAK
-        elif signal > 3:
+        elif signal >= COMBO_STRONG_SIGNAL_MIN:
             sell_combo.strength = SignalStrength.STRONG
         return sell_combo
     return None
@@ -319,42 +363,48 @@ def macd0lag(
     return a tuple(last macd0lag, signal)
     """
 
-    def _macd0lag(
-        candles: List[Candle],
-        short_term_period: int = 12,
-        long_term_period: int = 26,
-    ) -> float:
-        if len(candles) < long_term_period * 4:
+    # The loops below ask for the ema of heavily overlapping suffixes of the
+    # same list, so cache each (offset, period) result.
+    ema_cache: Dict[tuple, float] = {}
+
+    def _ema(offset: int, period: int) -> float:
+        key = (offset, period)
+        if key not in ema_cache:
+            ema_cache[key] = exponentiel_mobile_average(
+                candles[offset:], period
+            )
+        return ema_cache[key]
+
+    def _macd0lag(offset: int) -> float:
+        if len(candles) - offset < long_term_period * 4:
             Logger.get_logger("macd0lag").error(
-                f"Missing candles to calculate a macd0lag len={len(candles)}:"
+                "Missing candles to calculate a macd0lag"
+                f" len={len(candles) - offset}:"
                 f"needed {long_term_period * 4}"
             )
             raise SaxoException("Missing candles")
-        short_ma = exponentiel_mobile_average(candles, short_term_period)
-        long_ma = exponentiel_mobile_average(candles, long_term_period)
-        short_ma_list = [short_ma]
-        for i in range(1, short_term_period * 3):
-            short_ma_list.append(
-                exponentiel_mobile_average(candles[i:], short_term_period)
-            )
+        short_ma = _ema(offset, short_term_period)
+        long_ma = _ema(offset, long_term_period)
         short_ma_ma = exponentiel_mobile_average(
-            short_ma_list,
+            [
+                _ema(offset + i, short_term_period)
+                for i in range(short_term_period * 3)
+            ],
             short_term_period,
         )
-        long_ma_list = [long_ma]
-        for i in range(1, long_term_period * 3):
-            long_ma_list.append(
-                exponentiel_mobile_average(candles[i:], long_term_period)
-            )
-        long_ma_ma = exponentiel_mobile_average(long_ma_list, long_term_period)
+        long_ma_ma = exponentiel_mobile_average(
+            [
+                _ema(offset + i, long_term_period)
+                for i in range(long_term_period * 3)
+            ],
+            long_term_period,
+        )
         macd = (2 * short_ma - short_ma_ma) - (2 * long_ma - long_ma_ma)
         return macd
 
     macd_list = []
     for i in range(0, signal_period * 9):
-        macd_list.append(
-            _macd0lag(candles[i:], short_term_period, long_term_period)
-        )
+        macd_list.append(_macd0lag(i))
     macd_ma_list = []
     for i in range(0, signal_period * 3):
         macd_ma_list.append(

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy
 
@@ -147,7 +147,7 @@ def containing_candle(candles: List[Candle]) -> Optional[Candle]:
     return None
 
 
-def is_far_from_supports(
+def is_far_from_levels(
     candles: List[Candle],
     band: float,
     ma50: float,
@@ -158,9 +158,16 @@ def is_far_from_supports(
     """
     True when the last two candles sit clear of both the 2.0 bollinger band
     and the ma50: the pullback never came close enough to be tradable.
+    The levels are supports for a buy and resistances for a sell.
     The candle extreme facing the level is used - the low for a buy, the
     high for a sell - so a wick reaching the level counts as a touch.
     """
+    if len(candles) < 2:
+        Logger.get_logger("is_far_from_levels").error(
+            "Two candles are needed to measure the distance,"
+            f" got {len(candles)}"
+        )
+        raise SaxoException("Missing candles")
     closes = [candle.close for candle in candles[:2]]
     if direction == Direction.BUY:
         values = closes + [candle.lower for candle in candles[:2]]
@@ -216,7 +223,7 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
                 f"close {candles[0].close} is bellow bbb 2.5 {bb_last.bottom}"
             )
             return None
-        if is_far_from_supports(
+        if is_far_from_levels(
             candles,
             bb20.bottom,
             ma50_last,
@@ -288,7 +295,7 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
                 f"close {candles[0].close} is above bbb 2.5 {bb_last.up}"
             )
             return None
-        if is_far_from_supports(
+        if is_far_from_levels(
             candles,
             bb20.up,
             ma50_last,
@@ -365,7 +372,7 @@ def macd0lag(
 
     # The loops below ask for the ema of heavily overlapping suffixes of the
     # same list, so cache each (offset, period) result.
-    ema_cache: Dict[tuple, float] = {}
+    ema_cache: Dict[Tuple[int, int], float] = {}
 
     def _ema(offset: int, period: int) -> float:
         key = (offset, period)

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -147,6 +147,27 @@ def containing_candle(candles: List[Candle]) -> Optional[Candle]:
     return None
 
 
+def is_price_within_bands(
+    close: float, outer: float, inner: float, direction: Direction
+) -> bool:
+    """
+    True when close sits in the zone between the 2.0 (inner) and the 2.5
+    (outer) bollinger band, widened by COMBO_BB_TOLERANCE at both ends.
+    Both bands must be read at the same candle offset as the close.
+    """
+    if direction == Direction.BUY:
+        return (
+            outer * (1 - COMBO_BB_TOLERANCE)
+            < close
+            < inner * (1 + COMBO_BB_TOLERANCE)
+        )
+    return (
+        inner * (1 - COMBO_BB_TOLERANCE)
+        < close
+        < outer * (1 + COMBO_BB_TOLERANCE)
+    )
+
+
 def is_far_from_levels(
     candles: List[Candle],
     band: float,
@@ -260,14 +281,10 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
             signal += 1
             buy_combo.details["strong_ma50"] = True
 
-        if (
-            bb25_1.bottom * (1 - COMBO_BB_TOLERANCE)
-            < candles[1].close
-            < bb20_1.bottom * (1 + COMBO_BB_TOLERANCE)
-        ) or (
-            bb_last.bottom * (1 - COMBO_BB_TOLERANCE)
-            < candles[0].close
-            < bb20.bottom * (1 + COMBO_BB_TOLERANCE)
+        if is_price_within_bands(
+            candles[1].close, bb25_1.bottom, bb20_1.bottom, Direction.BUY
+        ) or is_price_within_bands(
+            candles[0].close, bb_last.bottom, bb20.bottom, Direction.BUY
         ):  # candle -1 or candle is between bb 2.0 / 2.5
             signal += 1
             buy_combo.details["price_within_bb"] = True
@@ -331,14 +348,10 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
             signal += 1
             sell_combo.details["strong_ma50"] = True
 
-        if (
-            bb20_1.up * (1 - COMBO_BB_TOLERANCE)
-            < candles[1].close
-            < bb25_1.up * (1 + COMBO_BB_TOLERANCE)
-        ) or (
-            bb20.up * (1 - COMBO_BB_TOLERANCE)
-            < candles[0].close
-            < bb_last.up * (1 + COMBO_BB_TOLERANCE)
+        if is_price_within_bands(
+            candles[1].close, bb25_1.up, bb20_1.up, Direction.SELL
+        ) or is_price_within_bands(
+            candles[0].close, bb_last.up, bb20.up, Direction.SELL
         ):  # candle -1 or candle is between bb 2.0 / 2.5
             signal += 1
             sell_combo.details["price_within_bb"] = True

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -22,7 +22,7 @@ from services.indicator_service import (
     double_top,
     exponentiel_mobile_average,
     find_linear_function,
-    is_far_from_supports,
+    is_far_from_levels,
     macd0lag,
     mm50_touch,
     number_of_day_between_dates,
@@ -692,21 +692,30 @@ def _candle(lower: float, higher: float, close: float) -> Candle:
     return Candle(lower=lower, higher=higher, open=close, close=close)
 
 
-class TestIsFarFromSupports:
+class TestIsFarFromLevels:
     """
-    The buy cases use a geometry where the ma50 (1000) sits above the
-    bollinger bottom (960), so the ma50 leg decides the outcome on its own.
+    Both legs of the conjunction have to be exercised on their own, so the
+    geometry changes per test: whichever level is the harder one to clear is
+    the leg that decides the outcome. The default geometry puts the ma50
+    (1000) above the bollinger bottom (960), making the ma50 the deciding
+    leg for a buy; `band` is overridden where the band leg must decide.
     """
 
-    BAND = 960.0
     MA50 = 1000.0
     MARGIN_BAND = 3.0
     MARGIN_MA50 = 1.0
 
-    def _is_far(self, candles: List[Candle], direction: Direction) -> bool:
-        return is_far_from_supports(
+    def _is_far(
+        self,
+        candles: List[Candle],
+        direction: Direction,
+        band: Optional[float] = None,
+    ) -> bool:
+        if band is None:
+            band = 960.0 if direction == Direction.BUY else 1040.0
+        return is_far_from_levels(
             candles,
-            self.BAND if direction == Direction.BUY else 1040.0,
+            band,
             self.MA50,
             self.MARGIN_BAND,
             self.MARGIN_MA50,
@@ -736,12 +745,16 @@ class TestIsFarFromSupports:
         ]
         assert self._is_far(candles, Direction.BUY) is False
 
-    def test_buy_close_below_the_band_is_not_far(self):
+    def test_buy_band_leg_alone_decides(self):
+        """Band (1000 + 3) above the ma50 (1000 + 1), so only the band leg
+        can fail: the low clears the ma50 but not the band."""
         candles = [
-            _candle(lower=955.0, higher=1030.0, close=962.0),
+            _candle(lower=1002.0, higher=1030.0, close=1020.0),
             _candle(lower=1008.0, higher=1025.0, close=1015.0),
         ]
-        assert self._is_far(candles, Direction.BUY) is False
+        assert self._is_far(candles, Direction.BUY, band=1000.0) is False
+        candles[0] = _candle(lower=1004.0, higher=1030.0, close=1020.0)
+        assert self._is_far(candles, Direction.BUY, band=1000.0) is True
 
     def test_sell_far_from_both_levels(self):
         candles = [
@@ -756,6 +769,32 @@ class TestIsFarFromSupports:
             _candle(lower=975.0, higher=992.0, close=985.0),
         ]
         assert self._is_far(candles, Direction.SELL) is False
+
+    def test_sell_previous_high_wicking_into_the_ma50_is_not_far(self):
+        """Only the second candle pierces: the first one stays clear."""
+        candles = [
+            _candle(lower=970.0, higher=990.0, close=980.0),
+            _candle(lower=975.0, higher=999.5, close=985.0),
+        ]
+        assert self._is_far(candles, Direction.SELL) is False
+
+    def test_sell_band_leg_alone_decides(self):
+        """Band (990 - 3) below the ma50 (1000 - 1), so only the band leg
+        can fail: the high clears the ma50 but not the band."""
+        candles = [
+            _candle(lower=970.0, higher=990.0, close=980.0),
+            _candle(lower=975.0, higher=985.0, close=980.0),
+        ]
+        assert self._is_far(candles, Direction.SELL, band=990.0) is False
+        candles[0] = _candle(lower=970.0, higher=986.0, close=980.0)
+        assert self._is_far(candles, Direction.SELL, band=990.0) is True
+
+    def test_fewer_than_two_candles_raises(self):
+        candle = _candle(lower=1010.0, higher=1030.0, close=1020.0)
+        with pytest.raises(SaxoException):
+            self._is_far([candle], Direction.BUY)
+        with pytest.raises(SaxoException):
+            self._is_far([], Direction.BUY)
 
     def test_only_the_last_two_candles_are_considered(self):
         candles = [

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -23,6 +23,7 @@ from services.indicator_service import (
     exponentiel_mobile_average,
     find_linear_function,
     is_far_from_levels,
+    is_price_within_bands,
     macd0lag,
     mm50_touch,
     number_of_day_between_dates,
@@ -690,6 +691,118 @@ class TestIndicatorService:
 
 def _candle(lower: float, higher: float, close: float) -> Candle:
     return Candle(lower=lower, higher=higher, open=close, close=close)
+
+
+class TestIsPriceWithinBands:
+    """
+    The zone is widened by COMBO_BB_TOLERANCE (0.5%) at both ends. The
+    values just inside each end are the ones that pin the tolerance down:
+    they fall outside the zone under the 0.05% factor the buy side used
+    before, so these cases fail if the tolerance regresses.
+    """
+
+    OUTER = 1000.0  # the 2.5 band
+    INNER = 1100.0  # the 2.0 band
+
+    @pytest.mark.parametrize(
+        "close, expected",
+        [
+            (996.0, True),  # inside only thanks to the 0.5% tolerance
+            (995.5, True),
+            (994.0, False),  # past the widened outer edge
+            (1050.0, True),
+            (1105.0, True),  # inside only thanks to the 0.5% tolerance
+            (1106.0, False),  # past the widened inner edge
+        ],
+    )
+    def test_buy_zone(self, close: float, expected: bool):
+        assert (
+            is_price_within_bands(close, self.OUTER, self.INNER, Direction.BUY)
+            is expected
+        )
+
+    @pytest.mark.parametrize(
+        "close, expected",
+        [
+            (996.0, True),
+            (995.5, True),
+            (994.0, False),
+            (1050.0, True),
+            (1105.0, True),
+            (1106.0, False),
+        ],
+    )
+    def test_sell_zone(self, close: float, expected: bool):
+        """Mirrored: the 2.0 band is the lower edge and the 2.5 the upper."""
+        assert (
+            is_price_within_bands(
+                close, self.INNER, self.OUTER, Direction.SELL
+            )
+            is expected
+        )
+
+
+class TestComboBandOffsets:
+    """
+    The previous candle must be compared against bands read at its own
+    offset. No recorded fixture separates the shifted from the unshifted
+    2.5 band - the perturbation is too small for any recorded close to land
+    in the gap - so the two leading candles are constructed on top of 233
+    recorded ones: the spike in candle 0 lifts the 20-period deviation
+    enough to pull bb25 and bb25_1 apart, and candle 1 is placed in the
+    resulting gap.
+    """
+
+    def _candles(self) -> List[Candle]:
+        with open("tests/services/files/combo_buy_h4_dax.obj", "r") as f:
+            candles = eval(
+                f.read(),
+                {"datetime": datetime, "Candle": Candle, "UnitTime": UnitTime},
+            )
+        candles[0] = Candle(
+            lower=18670.0,
+            higher=18730.0,
+            open=18690.0,
+            close=18700.0,
+            ut=candles[0].ut,
+            date=candles[0].date,
+        )
+        candles[1] = Candle(
+            lower=18355.0,
+            higher=18415.0,
+            open=18395.0,
+            close=18385.0,
+            ut=candles[1].ut,
+            date=candles[1].date,
+        )
+        return candles
+
+    def test_the_two_offsets_disagree_on_this_input(self):
+        """Guards the premise of the test below: if a future change makes
+        both offsets agree here, the next test stops proving anything."""
+        candles = self._candles()
+        previous_close = candles[1].close
+        bb25 = bollinger_bands(candles, 2.5)
+        bb25_1 = bollinger_bands(candles[1:], 2.5)
+        bb20_1 = bollinger_bands(candles[1:], 2.0)
+
+        assert (
+            is_price_within_bands(
+                previous_close, bb25_1.bottom, bb20_1.bottom, Direction.BUY
+            )
+            is True
+        )
+        assert (
+            is_price_within_bands(
+                previous_close, bb25.bottom, bb20_1.bottom, Direction.BUY
+            )
+            is False
+        )
+
+    def test_combo_reads_the_previous_candle_band_at_its_own_offset(self):
+        signal = combo(self._candles())
+        assert signal is not None
+        assert signal.details["price_within_bb"] is True
 
 
 class TestIsFarFromLevels:

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -22,6 +22,7 @@ from services.indicator_service import (
     double_top,
     exponentiel_mobile_average,
     find_linear_function,
+    is_far_from_supports,
     macd0lag,
     mm50_touch,
     number_of_day_between_dates,
@@ -685,6 +686,84 @@ class TestIndicatorService:
     def test_mm50_touch_returns_none_when_fewer_than_sixty_candles(self):
         candles = _make_candles([100.0] * 59)
         assert mm50_touch(candles) is None
+
+
+def _candle(lower: float, higher: float, close: float) -> Candle:
+    return Candle(lower=lower, higher=higher, open=close, close=close)
+
+
+class TestIsFarFromSupports:
+    """
+    The buy cases use a geometry where the ma50 (1000) sits above the
+    bollinger bottom (960), so the ma50 leg decides the outcome on its own.
+    """
+
+    BAND = 960.0
+    MA50 = 1000.0
+    MARGIN_BAND = 3.0
+    MARGIN_MA50 = 1.0
+
+    def _is_far(self, candles: List[Candle], direction: Direction) -> bool:
+        return is_far_from_supports(
+            candles,
+            self.BAND if direction == Direction.BUY else 1040.0,
+            self.MA50,
+            self.MARGIN_BAND,
+            self.MARGIN_MA50,
+            direction,
+        )
+
+    def test_buy_far_from_both_levels(self):
+        candles = [
+            _candle(lower=1010.0, higher=1030.0, close=1020.0),
+            _candle(lower=1008.0, higher=1025.0, close=1015.0),
+        ]
+        assert self._is_far(candles, Direction.BUY) is True
+
+    def test_buy_low_wicking_into_the_ma50_is_not_far(self):
+        """The close stays above the ma50 but the low pierces it: the
+        pullback did touch, so the signal must not be discarded."""
+        candles = [
+            _candle(lower=999.0, higher=1030.0, close=1020.0),
+            _candle(lower=1008.0, higher=1025.0, close=1015.0),
+        ]
+        assert self._is_far(candles, Direction.BUY) is False
+
+    def test_buy_previous_low_wicking_into_the_ma50_is_not_far(self):
+        candles = [
+            _candle(lower=1010.0, higher=1030.0, close=1020.0),
+            _candle(lower=1000.5, higher=1025.0, close=1015.0),
+        ]
+        assert self._is_far(candles, Direction.BUY) is False
+
+    def test_buy_close_below_the_band_is_not_far(self):
+        candles = [
+            _candle(lower=955.0, higher=1030.0, close=962.0),
+            _candle(lower=1008.0, higher=1025.0, close=1015.0),
+        ]
+        assert self._is_far(candles, Direction.BUY) is False
+
+    def test_sell_far_from_both_levels(self):
+        candles = [
+            _candle(lower=970.0, higher=990.0, close=980.0),
+            _candle(lower=975.0, higher=992.0, close=985.0),
+        ]
+        assert self._is_far(candles, Direction.SELL) is True
+
+    def test_sell_high_wicking_into_the_ma50_is_not_far(self):
+        candles = [
+            _candle(lower=970.0, higher=1000.0, close=980.0),
+            _candle(lower=975.0, higher=992.0, close=985.0),
+        ]
+        assert self._is_far(candles, Direction.SELL) is False
+
+    def test_only_the_last_two_candles_are_considered(self):
+        candles = [
+            _candle(lower=1010.0, higher=1030.0, close=1020.0),
+            _candle(lower=1008.0, higher=1025.0, close=1015.0),
+            _candle(lower=900.0, higher=900.0, close=900.0),
+        ]
+        assert self._is_far(candles, Direction.BUY) is True
 
 
 def _trending_daily(count: int, step: float = 5.0) -> List[Candle]:


### PR DESCRIPTION
## Summary

Fixes four defects found while analysing the `combo` indicator, plus a magic-number cleanup.

### 1. `bb25_1` was not shifted
`bb25_1 = bollinger_bands(candles, 2.5)` was identical to `bb_last` — no slicing. The "candle -1" branch of `price_within_bb` therefore compared the *previous* candle against the *current* candle's 2.5σ band while pairing it with the correctly-shifted `bb20_1`. Now `bollinger_bands(candles[1:], 2.5)`.

### 2. Inconsistent `price_within_bb` tolerances
The two branches used four different values and neither mirrored the buy side:

| | outer band (2.5σ) | inner band (2.0σ) |
|---|---|---|
| BUY, both branches | 0.05% | 0.5% |
| SELL, candle-1 branch | 0.5% | 0.05% |
| SELL, candle-0 branch | 0.5% | 0.5% |

Unified at 0.5% (`COMBO_BB_TOLERANCE`). The sell branches are rewritten in the same `low < close < high` orientation as the buy ones — the reversed orientation is what made the asymmetry hard to see.

### 3. Buy-side MA50 proximity clause was a no-op
```python
candles[0].higher > ma50_last + margin_variation_ma50
```
The preceding clause already requires `close > ma50 + margin`, and `higher >= close`, so both `higher` clauses were unconditionally true — the MA50 conjunction collapsed to just the close checks. The BB clause directly above uses `lower` for the same "even the extreme is clear of it" logic, and the sell mirror correctly uses `higher`. Now uses `lower`.

The buy/sell copies of this block were 8-line near-duplicates differing only in comparison direction and which extreme they read — exactly where the bug was hiding. Extracted into `is_far_from_supports()`, which takes a `Direction`.

### 4. `macd0lag` performance
`_macd0lag` ran 81 times, each rebuilding ~114 EMAs over heavily overlapping suffixes of the same list — ~9,300 EMA passes per call, per asset, per alerting run. An `(offset, period)` cache brings it to ~275. Same function, same inputs, so **output is bit-identical**: the golden expectations (`-36.07337`, `113.46834`) pass untouched. `tests/services/test_indicator_service.py` runs 2.39s → 0.38s.

### 5. Magic numbers extracted
`COMBO_MA50_SLOPE_MIN/STRONG`, `COMBO_BB_FLAT_SLOPE_MAX`, `COMBO_BB_BREACH_TOLERANCE`, `COMBO_BB_TOLERANCE`, `COMBO_ATR_BB_MARGIN`, `COMBO_ATR_MA50_MARGIN`, `COMBO_STRONG_SIGNAL_MIN`, alongside the existing `MM50_TOUCH_*`. The flat-bands test is computed once as `both_bb_flat` instead of repeated per branch.

## Test coverage caveat

**No existing golden expectation changes.** I verified why rather than treating that as proof of correctness — a differential run over all 13 combo fixtures shows:

- `price_within_bb`: unchanged on every fixture. The 0.9995 → 0.995 widening only matters for a close within 0.45% of a band, and none land there.
- The MA50 fix flips its clause on `combo_buy_h4_dax.obj` (`True` → `False`), but that fixture's outer BB clause is `False`, so the MA50 leg is short-circuited and the outcome is identical.

So the recorded fixtures don't exercise the fixed paths at the output level. The 7 new `TestIsFarFromSupports` tests close that gap for fix 3. **Fixes 1 and 2 remain without a fixture that distinguishes old from new** — that needs a case recorded from real data with price sitting within ~0.5% of a band, which I did not want to fabricate.

## Test plan

- `poetry run pytest` — 798 passed, 10 skipped
- black / isort / flake8 / mypy clean (pre-commit hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)