### PR TITLE
fix: read bb_first 3 candles back to match the bollinger slope distance

### DIFF
--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -189,7 +189,7 @@ def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     ma50_first = mobile_average(candles[10:], 50)
     bb_last = bollinger_bands(candles, 2.5)
     bb25_1 = bollinger_bands(candles[1:], 2.5)
-    bb_first = bollinger_bands(candles[2:], 2.5)
+    bb_first = bollinger_bands(candles[3:], 2.5)
     bb20 = bollinger_bands(candles, 2.0)
     bb20_1 = bollinger_bands(candles[1:], 2.0)
     ma50_slope = slope_percentage(0, ma50_first, 10, ma50_last)

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -410,20 +410,12 @@ class TestIndicatorService:
         "file_candles, expected",
         [
             (
+                # Was a buy signal while bb_first was read 2 candles back
+                # but scaled over 3: the correct slope (bbh -6.96, bbb
+                # -21.23) fails the flat-bands gate, so the combo is now
+                # discarded. See the bb slope offset fix.
                 "combo_buy_daily_cac.obj",
-                ComboSignal(
-                    7401.35,
-                    True,
-                    Direction.BUY,
-                    SignalStrength.MEDIUM,
-                    {
-                        "macd": True,
-                        "ma50_over_bb": False,
-                        "price_within_bb": True,
-                        "strong_ma50": True,
-                        "both_bb_flat": False,
-                    },
-                ),
+                None,
             ),
             (
                 "combo_buy_h4_dax.obj",


### PR DESCRIPTION
Follow-up to #682, found while auditing the band comparisons there. **Stacked on `fix/combo-indicator-band-checks`** — base retargets to `main` once #682 merges.

## The bug

`bb_first` is read **2** candles back, but both bollinger slopes are scaled over an x-distance of **3**:

```python
bb_first = bollinger_bands(candles[2:], 2.5)
bbh_slope = slope_percentage(0, bb_first.up, 3, bb_last.up)
bbb_slope = slope_percentage(0, bb_first.bottom, 3, bb_last.bottom)
```

Compare `ma50_slope` two lines up, where `candles[10:]` correctly pairs with a distance of `10`. `slope_percentage` divides by `dx`, so the band slopes come out ~2/3 as steep as they actually are. That feeds straight into `COMBO_BB_FLAT_SLOPE_MAX` and the `both_bb_flat` signal — the bands read flatter than they are.

This PR moves `bb_first` to `candles[3:]` so the offset matches the distance.

## ⚠️ This changes live alerting behaviour

Measured across all 13 combo fixtures. The flat/reject gate moves on two, and **one recorded positive case flips to no-signal**:

| Fixture | current | this PR (offset 3) | the other candidate (distance 2) |
|---|---|---|---|
| `combo_buy_daily_cac` | signal | **None** | **None** |
| `no_combo_daily_stmpa` | flat ✓ | **not flat** | flat ✓ |
| `combo_sell_daily_aca` | pass | pass | **reject** |
| `combo_sell_h1_dax` | flat ✓ | flat ✓ | **not flat** |
| `no_combo_daily_vie` | flat ✓ | flat ✓ | **not flat** |

`combo_buy_daily_cac.obj` was recorded as a *positive* buy combo, and its expectation changes to `None` here. The mechanism:

| | bbh | bbb | rejected by flat gate |
|---|---|---|---|
| current | -4.72 | -15.44 | no |
| offset 3 | **-6.96** | -21.23 | **yes** |
| distance 2 | -7.08 | -23.17 | yes |

`bbh` crosses the 5.0 threshold once the scaling is corrected.

**Worth weighing before merge:** *both* candidate corrections suppress that fixture. That is consistent with `COMBO_BB_FLAT_SLOPE_MAX = 5.0` having been tuned empirically against the under-scaled slopes — in which case correcting the scale without rescaling the threshold tightens the gate rather than leaving it neutral. Rescaling it to `7.5` would keep `combo_buy_daily_cac` alive (`6.96 < 7.5`). I have deliberately **not** made that change: it is a separate judgement about what the gate should mean, not part of fixing the off-by-one.

The alternative correction (keep offset 2, use distance 2) is an exact 3/2 rescale of the current slopes, so pairing *that* with a 7.5 threshold would be a provable no-op — a pure readability fix. This PR takes the offset-3 route as chosen, which reads genuinely different data and is not a rescale.

## Test plan

- `poetry run pytest` — 801 passed, 10 skipped
- black / isort / flake8 / mypy clean
- Only `combo_buy_daily_cac` needed an expectation change; the other 12 fixtures are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)