### PR TITLE
refactor: collapse the mirrored combo branches and defer macd0lag

### DIFF
--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -43,12 +43,23 @@ def _safe_detect(
     (IndexError on an asset that returned no candle) escaped the handler and
     aborted the entire scan. A detector that cannot run is not an error for
     the others, and never a reason to drop what has already been found.
+
+    Insufficient history is routine and logs at warning; anything else is a
+    bug that must stay visible, so it logs at error with a traceback rather
+    than being flattened into the same routine-looking line.
     """
     try:
         return detector()
-    except Exception as e:
+    except (SaxoException, IndexError) as e:
         logger.warning(
             f"{alert_type.value} skipped for {asset_description}: {e}"
+        )
+        return None
+    except Exception as e:
+        logger.error(
+            f"{alert_type.value} failed unexpectedly for"
+            f" {asset_description}: {e}",
+            exc_info=True,
         )
         return None
 

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -175,7 +175,7 @@ async def run_detection_for_asset(
     country_code: Optional[str],
     exchange: str,
     asset_description: str,
-    saxo_uic: Optional[str],
+    saxo_uic: Optional[str | int],
     saxo_client: SaxoClient,
     dynamodb_client: DynamoDBClient,
 ) -> List[Alert]:

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -3,7 +3,8 @@ import datetime
 import json
 import os
 import time
-from typing import Dict, List, Optional, Tuple
+from functools import partial
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar
 
 import click
 from click.core import Context
@@ -24,6 +25,32 @@ from utils.helper import build_daily_candles_from_h1
 from utils.logger import Logger
 
 logger = Logger.get_logger("alerting")
+
+T = TypeVar("T")
+
+
+def _safe_detect(
+    alert_type: AlertType, asset_description: str, detector: Callable[[], T]
+) -> Optional[T]:
+    """
+    Run one detector in isolation, returning None when it cannot run.
+
+    Each detector has its own history requirement - combo needs 235 candles,
+    double_inside_bar 3, double_top a non-empty list - and they used to share
+    one try/except wrapping the whole chain plus the DynamoDB write. So the
+    most demanding detector decided how much history an asset needed before
+    *any* of its alerts were persisted, and an error type nobody had listed
+    (IndexError on an asset that returned no candle) escaped the handler and
+    aborted the entire scan. A detector that cannot run is not an error for
+    the others, and never a reason to drop what has already been found.
+    """
+    try:
+        return detector()
+    except Exception as e:
+        logger.warning(
+            f"{alert_type.value} skipped for {asset_description}: {e}"
+        )
+        return None
 
 
 def _parse_asset_code(code: str) -> Tuple[str, Optional[str]]:
@@ -173,242 +200,178 @@ async def run_detection_for_asset(
         logger.warning(f"No saxo_uic for {asset_code}, skipping detection")
         return asset_alerts
 
+    asset_dict = {
+        "name": asset_description,
+        "code": asset_code,
+        "saxo_uic": saxo_uic,
+    }
     try:
-        # Build candles for detection
-        asset_dict = {
-            "name": asset_description,
-            "code": asset_code,
-            "saxo_uic": saxo_uic,
-        }
         candles = _build_candles(saxo_client, asset_dict)
+    except Exception as e:
+        logger.error(f"{asset_description} can't be scanned: {e}")
+        return asset_alerts
+    if len(candles) == 0:
+        logger.warning(f"No candle for {asset_description}, nothing to scan")
+        return asset_alerts
 
-        # Calculate MA50 slope for this asset (used for sorting alerts)
-        ma50_slope: Optional[float] = None
+    # Calculate MA50 slope for this asset (used for sorting alerts)
+    ma50_slope: Optional[float] = None
+    try:
+        if len(candles) >= 60:  # Need at least 60 candles for MA50 calculation
+            ma50_last = indicator_service.mobile_average(candles, 50)
+            ma50_first = indicator_service.mobile_average(candles[10:], 50)
+            ma50_slope = indicator_service.slope_percentage(
+                0, ma50_first, 10, ma50_last
+            )
+    except SaxoException:
+        logger.warning(
+            f"Could not calculate ma50_slope for {asset_code} - "
+            "insufficient candle data"
+        )
+
+    def detect(
+        alert_type: AlertType, detector: Callable[[], T]
+    ) -> Optional[T]:
+        return _safe_detect(alert_type, asset_description, detector)
+
+    def candle_alert(alert_type: AlertType, candle: Candle) -> Alert:
+        return Alert(
+            alert_type=alert_type,
+            date=candle.date if candle.date else datetime.datetime.now(),
+            data={
+                "close": candle.close,
+                "open": candle.open,
+                "higher": candle.higher,
+                "lower": candle.lower,
+                "ma50_slope": ma50_slope,
+            },
+            asset_code=asset_code,
+            asset_description=asset_description,
+            exchange=exchange,
+            country_code=country_code,
+        )
+
+    for alert_type, length, minimal_touch_points in (
+        (AlertType.CONGESTION20, 20, 2),
+        (AlertType.CONGESTION100, 100, 3),
+    ):
+        congestion_result = detect(
+            alert_type,
+            partial(
+                _run_congestion_indicator,
+                asset_dict,
+                candles,
+                length,
+                minimal_touch_points,
+            ),
+        )
+        if congestion_result is not None and len(congestion_result[0]) > 0:
+            touch_points = [
+                f"{c.date.strftime('%Y-%m-%d') if c.date else 'Unknown'}: "
+                + f"{c.higher} {c.lower}"
+                for c in congestion_result[0]
+            ]
+            asset_alerts.append(
+                Alert(
+                    alert_type=alert_type,
+                    date=datetime.datetime.now(),
+                    data={
+                        "touch_points": touch_points,
+                        "candles": [
+                            {
+                                "date": (
+                                    c.date.isoformat() if c.date else None
+                                ),
+                                "higher": c.higher,
+                                "lower": c.lower,
+                            }
+                            for c in congestion_result[0]
+                        ],
+                        "ma50_slope": ma50_slope,
+                    },
+                    asset_code=asset_code,
+                    asset_description=asset_description,
+                    exchange=exchange,
+                    country_code=country_code,
+                )
+            )
+
+    for alert_type, candle_detector in (
+        (
+            AlertType.DOUBLE_TOP,
+            partial(_run_double_top, saxo_client, asset_dict, candles),
+        ),
+        (
+            AlertType.DOUBLE_BOTTOM,
+            partial(_run_double_bottom, saxo_client, asset_dict, candles),
+        ),
+        (
+            AlertType.CONTAINING_CANDLE,
+            partial(_run_containing_candle, asset_dict, candles),
+        ),
+        (
+            AlertType.DOUBLE_INSIDE_BAR,
+            partial(_run_double_inside_bar, asset_dict, candles),
+        ),
+    ):
+        if (candle := detect(alert_type, candle_detector)) is not None:
+            asset_alerts.append(candle_alert(alert_type, candle))
+
+    if (
+        combo := detect(
+            AlertType.COMBO, partial(indicator_service.combo, candles)
+        )
+    ) is not None:
+        asset_alerts.append(
+            Alert(
+                alert_type=AlertType.COMBO,
+                date=datetime.datetime.now(),
+                data={
+                    "price": combo.price,
+                    "direction": combo.direction.value,
+                    "strength": combo.strength.value,
+                    "has_been_triggered": combo.has_been_triggered,
+                    "details": combo.details,
+                    "ma50_slope": ma50_slope,
+                },
+                asset_code=asset_code,
+                asset_description=asset_description,
+                exchange=exchange,
+                country_code=country_code,
+            )
+        )
+
+    mm50_touch_result = detect(
+        AlertType.MM50_TOUCH, partial(indicator_service.mm50_touch, candles)
+    )
+    if mm50_touch_result is not None:
+        asset_alerts.append(
+            Alert(
+                alert_type=AlertType.MM50_TOUCH,
+                date=datetime.datetime.now(),
+                data={
+                    **mm50_touch_result,
+                    "ma50_slope": ma50_slope,
+                },
+                asset_code=asset_code,
+                asset_description=asset_description,
+                exchange=exchange,
+                country_code=country_code,
+            )
+        )
+
+    # Store what was found even if some detector above could not run
+    if len(asset_alerts) > 0:
         try:
-            if (
-                len(candles) >= 60
-            ):  # Need at least 60 candles for MA50 calculation
-                ma50_last = indicator_service.mobile_average(candles, 50)
-                ma50_first = indicator_service.mobile_average(candles[10:], 50)
-                ma50_slope = indicator_service.slope_percentage(
-                    0, ma50_first, 10, ma50_last
-                )
-        except SaxoException:
-            logger.warning(
-                f"Could not calculate ma50_slope for {asset_code} - "
-                "insufficient candle data"
-            )
-
-        # Run CONGESTION20 detection
-        congestion_result = _run_congestion_indicator(
-            asset_dict, candles, 20, 2
-        )
-        if congestion_result is not None and len(congestion_result[0]) > 0:
-            touch_points = [
-                f"{c.date.strftime('%Y-%m-%d') if c.date else 'Unknown'}: "
-                + f"{c.higher} {c.lower}"
-                for c in congestion_result[0]
-            ]
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.CONGESTION20,
-                    date=datetime.datetime.now(),
-                    data={
-                        "touch_points": touch_points,
-                        "candles": [
-                            {
-                                "date": (
-                                    c.date.isoformat() if c.date else None
-                                ),
-                                "higher": c.higher,
-                                "lower": c.lower,
-                            }
-                            for c in congestion_result[0]
-                        ],
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run CONGESTION100 detection
-        congestion_result = _run_congestion_indicator(
-            asset_dict, candles, 100, 3
-        )
-        if congestion_result is not None and len(congestion_result[0]) > 0:
-            touch_points = [
-                f"{c.date.strftime('%Y-%m-%d') if c.date else 'Unknown'}: "
-                + f"{c.higher} {c.lower}"
-                for c in congestion_result[0]
-            ]
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.CONGESTION100,
-                    date=datetime.datetime.now(),
-                    data={
-                        "touch_points": touch_points,
-                        "candles": [
-                            {
-                                "date": (
-                                    c.date.isoformat() if c.date else None
-                                ),
-                                "higher": c.higher,
-                                "lower": c.lower,
-                            }
-                            for c in congestion_result[0]
-                        ],
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run DOUBLE_TOP detection
-        if (
-            candle := _run_double_top(saxo_client, asset_dict, candles)
-        ) is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.DOUBLE_TOP,
-                    date=(
-                        candle.date if candle.date else datetime.datetime.now()
-                    ),
-                    data={
-                        "close": candle.close,
-                        "open": candle.open,
-                        "higher": candle.higher,
-                        "lower": candle.lower,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run DOUBLE_BOTTOM detection
-        if (
-            candle := _run_double_bottom(saxo_client, asset_dict, candles)
-        ) is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.DOUBLE_BOTTOM,
-                    date=(
-                        candle.date if candle.date else datetime.datetime.now()
-                    ),
-                    data={
-                        "close": candle.close,
-                        "open": candle.open,
-                        "higher": candle.higher,
-                        "lower": candle.lower,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run CONTAINING_CANDLE detection
-        if (candle := _run_containing_candle(asset_dict, candles)) is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.CONTAINING_CANDLE,
-                    date=(
-                        candle.date if candle.date else datetime.datetime.now()
-                    ),
-                    data={
-                        "close": candle.close,
-                        "open": candle.open,
-                        "higher": candle.higher,
-                        "lower": candle.lower,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run DOUBLE_INSIDE_BAR detection
-        if (candle := _run_double_inside_bar(asset_dict, candles)) is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.DOUBLE_INSIDE_BAR,
-                    date=(
-                        candle.date if candle.date else datetime.datetime.now()
-                    ),
-                    data={
-                        "close": candle.close,
-                        "open": candle.open,
-                        "higher": candle.higher,
-                        "lower": candle.lower,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Run COMBO detection
-        if (combo := indicator_service.combo(candles)) is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.COMBO,
-                    date=datetime.datetime.now(),
-                    data={
-                        "price": combo.price,
-                        "direction": combo.direction.value,
-                        "strength": combo.strength.value,
-                        "has_been_triggered": combo.has_been_triggered,
-                        "details": combo.details,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        mm50_touch_result = indicator_service.mm50_touch(candles)
-        if mm50_touch_result is not None:
-            asset_alerts.append(
-                Alert(
-                    alert_type=AlertType.MM50_TOUCH,
-                    date=datetime.datetime.now(),
-                    data={
-                        **mm50_touch_result,
-                        "ma50_slope": ma50_slope,
-                    },
-                    asset_code=asset_code,
-                    asset_description=asset_description,
-                    exchange=exchange,
-                    country_code=country_code,
-                )
-            )
-
-        # Store alerts in DynamoDB if any were detected
-        if len(asset_alerts) > 0:
             await dynamodb_client.store_alerts(
                 asset_code,
                 country_code,
                 asset_alerts,
             )
-
-    except SaxoException as e:
-        logger.error(f"{asset_description} can't be scanned: {e}")
+        except Exception as e:
+            logger.error(
+                f"Failed to store the alerts of {asset_description}: {e}"
+            )
 
     return asset_alerts
 

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -111,6 +111,11 @@ COMBO_BB_TOLERANCE = 0.005
 COMBO_ATR_BB_MARGIN = 0.3
 COMBO_ATR_MA50_MARGIN = 0.1
 COMBO_STRONG_SIGNAL_MIN = 4
+# macd0lag feeds one scoring criterion but is the deepest reader here: see its
+# docstring for where 235 comes from. Deferring it spares the candle sets that
+# never reach it, but a set that does reach it still needs the full history,
+# so combo declines up front rather than raising mid-scoring.
+COMBO_MIN_CANDLES = 235
 
 
 def mm50_touch(candles: List[Candle]) -> Optional[Dict[str, float]]:
@@ -342,6 +347,12 @@ def _combo_for_direction(
 
 def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     logger = Logger.get_logger("combo")
+    if len(candles) < COMBO_MIN_CANDLES:
+        logger.debug(
+            f"not enough candles for a combo {len(candles)},"
+            f" needed {COMBO_MIN_CANDLES}"
+        )
+        return None
     logger.debug(
         f"do we have a combo {candles[0].ut} at the date {candles[0].date} ?"
     )
@@ -374,11 +385,21 @@ def macd0lag(
     https://www.axialfinance.fr/manuel/pagesindicateurs/pageMZLD.html
     return a tuple(last macd0lag, signal)
 
-    The nested emas read progressively older suffixes, so the whole call
-    needs more candles than any single _macd0lag guard reports: with the
-    default periods the deepest read is candles[157:] against an ema
-    needing 78 values, so 235 candles at minimum.
+    The nested emas read progressively older suffixes, so the whole call needs
+    far more candles than one macd step does. The deepest read is at offset
+    (signal_period * 9 - 1) + (long_term_period * 3 - 1) against an ema
+    needing long_term_period * 3 values, hence the minimum below - 235 with
+    the default periods. The old guard checked only one step's worth
+    (long_term_period * 4, i.e. 104) and so reported a requirement less than
+    half the real one.
     """
+    minimum = signal_period * 9 + long_term_period * 6 - 2
+    if len(candles) < minimum:
+        Logger.get_logger("macd0lag").error(
+            f"Missing candles to calculate a macd0lag {len(candles)},"
+            f" needed {minimum}"
+        )
+        raise SaxoException("Missing candles")
 
     # The loops below ask for the ema of heavily overlapping suffixes of the
     # same list, so cache each (offset, period) result.
@@ -393,13 +414,6 @@ def macd0lag(
         return ema_cache[key]
 
     def _macd0lag(offset: int) -> float:
-        if len(candles) - offset < long_term_period * 4:
-            Logger.get_logger("macd0lag").error(
-                "Missing candles to calculate a macd0lag"
-                f" len={len(candles) - offset}:"
-                f"needed {long_term_period * 4}"
-            )
-            raise SaxoException("Missing candles")
         short_ma = _ema(offset, short_term_period)
         long_ma = _ema(offset, long_term_period)
         short_ma_ma = exponentiel_mobile_average(

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -148,7 +148,7 @@ def containing_candle(candles: List[Candle]) -> Optional[Candle]:
 
 
 def is_price_within_bands(
-    close: float, outer: float, inner: float, direction: Direction
+    close: float, *, outer: float, inner: float, direction: Direction
 ) -> bool:
     """
     True when close sits in the zone between the 2.0 (inner) and the 2.5
@@ -201,173 +201,165 @@ def is_far_from_levels(
     )
 
 
+class _ComboContext:
+    """
+    The indicators a combo is scored against, computed once per candle set.
+
+    macd0lag costs about 80% of a combo call and feeds a single scoring
+    criterion, so it is computed on first use. A candle set whose ma50 is
+    flat, or whose two bollinger bands both slope, never pays for it - and
+    never raises over the 235 candles macd0lag needs, where everything else
+    here is satisfied by 60.
+    """
+
+    def __init__(self, candles: List[Candle]) -> None:
+        self.candles = candles
+        self.ma50 = mobile_average(candles, 50)
+        ma50_first = mobile_average(candles[10:], 50)
+        self.ma50_slope = slope_percentage(0, ma50_first, 10, self.ma50)
+        self.bb25 = bollinger_bands(candles, 2.5)
+        self.bb25_previous = bollinger_bands(candles[1:], 2.5)
+        self.bb20 = bollinger_bands(candles, 2.0)
+        self.bb20_previous = bollinger_bands(candles[1:], 2.0)
+        bb_first = bollinger_bands(candles[2:], 2.5)
+        self.bbh_slope = slope_percentage(0, bb_first.up, 3, self.bb25.up)
+        self.bbb_slope = slope_percentage(
+            0, bb_first.bottom, 3, self.bb25.bottom
+        )
+        atr = average_true_range(candles)
+        self.margin_band = atr * COMBO_ATR_BB_MARGIN
+        self.margin_ma50 = atr * COMBO_ATR_MA50_MARGIN
+        self._macd0lag: Optional[Tuple[float, float]] = None
+
+    @property
+    def both_bb_flat(self) -> bool:
+        return (
+            abs(self.bbh_slope) < COMBO_BB_FLAT_SLOPE_MAX
+            and abs(self.bbb_slope) < COMBO_BB_FLAT_SLOPE_MAX
+        )
+
+    @property
+    def neither_bb_flat(self) -> bool:
+        return (
+            abs(self.bbh_slope) > COMBO_BB_FLAT_SLOPE_MAX
+            and abs(self.bbb_slope) > COMBO_BB_FLAT_SLOPE_MAX
+        )
+
+    @property
+    def macd0lag(self) -> Tuple[float, float]:
+        if self._macd0lag is None:
+            self._macd0lag = macd0lag(self.candles)
+        return self._macd0lag
+
+
+def _combo_for_direction(
+    context: _ComboContext, direction: Direction
+) -> Optional[ComboSignal]:
+    """
+    Score a combo in one direction. The buy and the sell case are exact
+    mirrors, so they run through this single body: `sign` flips every
+    comparison, `band`/`inner` pick the side of the bollinger bands facing
+    the price, `trigger_level` is the previous candle's extreme the close
+    must clear to count as triggered, and `pending_price` is where the order
+    waits until it does.
+    """
+    logger = Logger.get_logger("combo")
+    candles = context.candles
+    close = candles[0].close
+    if direction == Direction.BUY:
+        sign = 1.0
+        band, band_previous = context.bb25.bottom, context.bb25_previous.bottom
+        inner, inner_previous = (
+            context.bb20.bottom,
+            context.bb20_previous.bottom,
+        )
+        trigger_level, pending_price = candles[1].higher, candles[0].higher
+    else:
+        sign = -1.0
+        band, band_previous = context.bb25.up, context.bb25_previous.up
+        inner, inner_previous = context.bb20.up, context.bb20_previous.up
+        trigger_level, pending_price = candles[1].lower, candles[0].lower
+
+    if sign * close < sign * context.ma50:
+        logger.debug(
+            f"close {close} is on the wrong side of the ma50 {context.ma50}"
+            f" for a {direction.value} combo"
+        )
+        return None
+    if sign * close < sign * band * (1 - sign * COMBO_BB_BREACH_TOLERANCE):
+        logger.debug(f"close {close} has breached the bb 2.5 {band}")
+        return None
+    if is_far_from_levels(
+        candles,
+        inner,
+        context.ma50,
+        context.margin_band,
+        context.margin_ma50,
+        direction,
+    ):
+        logger.debug(
+            f"candle {candles[0]} is far from the bb 2.0 {inner}"
+            f" and from the ma50 {context.ma50}"
+        )
+        return None
+
+    criteria = {
+        "macd": sign * context.macd0lag[0] > sign * context.macd0lag[1],
+        "ma50_over_bb": sign * context.ma50 < sign * band,
+        # candle -1 or candle is between bb 2.0 / 2.5
+        "price_within_bb": is_price_within_bands(
+            candles[1].close,
+            outer=band_previous,
+            inner=inner_previous,
+            direction=direction,
+        )
+        or is_price_within_bands(
+            close, outer=band, inner=inner, direction=direction
+        ),
+        "strong_ma50": sign * context.ma50_slope > COMBO_MA50_SLOPE_STRONG,
+        "both_bb_flat": context.both_bb_flat,
+    }
+    signal = sum(criteria.values())
+    combo_signal = ComboSignal(
+        price=0,
+        direction=direction,
+        has_been_triggered=False,
+        strength=SignalStrength.MEDIUM,
+        details=dict(criteria),
+    )
+
+    if sign * close > sign * trigger_level:
+        combo_signal.has_been_triggered = True
+        combo_signal.price = close
+    else:
+        combo_signal.price = pending_price
+    if signal == 0:
+        combo_signal.strength = SignalStrength.WEAK
+    elif signal >= COMBO_STRONG_SIGNAL_MIN:
+        combo_signal.strength = SignalStrength.STRONG
+    return combo_signal
+
+
 def combo(candles: List[Candle]) -> Optional[ComboSignal]:
     logger = Logger.get_logger("combo")
     logger.debug(
         f"do we have a combo {candles[0].ut} at the date {candles[0].date} ?"
     )
-    ma50_last = mobile_average(candles, 50)
-    ma50_first = mobile_average(candles[10:], 50)
-    bb_last = bollinger_bands(candles, 2.5)
-    bb25_1 = bollinger_bands(candles[1:], 2.5)
-    bb_first = bollinger_bands(candles[2:], 2.5)
-    bb20 = bollinger_bands(candles, 2.0)
-    bb20_1 = bollinger_bands(candles[1:], 2.0)
-    ma50_slope = slope_percentage(0, ma50_first, 10, ma50_last)
-    bbh_slope = slope_percentage(0, bb_first.up, 3, bb_last.up)
-    bbb_slope = slope_percentage(0, bb_first.bottom, 3, bb_last.bottom)
-    macd_0lag = macd0lag(candles)
-    atr = average_true_range(candles)
-    margin_variation_bb = atr * COMBO_ATR_BB_MARGIN
-    margin_variation_ma50 = atr * COMBO_ATR_MA50_MARGIN
-    both_bb_flat = (
-        abs(bbh_slope) < COMBO_BB_FLAT_SLOPE_MAX
-        and abs(bbb_slope) < COMBO_BB_FLAT_SLOPE_MAX
-    )
-
-    if (
-        abs(bbh_slope) > COMBO_BB_FLAT_SLOPE_MAX
-        and abs(bbb_slope) > COMBO_BB_FLAT_SLOPE_MAX
-    ):
-        logger.debug(f"BB bands are not flat bbh={bbh_slope}, bbb={bbb_slope}")
+    context = _ComboContext(candles)
+    if context.neither_bb_flat:
+        logger.debug(
+            f"BB bands are not flat bbh={context.bbh_slope},"
+            f" bbb={context.bbb_slope}"
+        )
         return None
-    if ma50_slope > COMBO_MA50_SLOPE_MIN:
-        logger.debug(f"testing a buying combo ma50_slope={ma50_slope}")
-        signal = 0
-        if candles[0].close < ma50_last:
-            logger.debug(
-                f"close {candles[0].close} is bellow ma50 {ma50_last}"
-            )
-            return None
-        if candles[0].close < bb_last.bottom * (1 - COMBO_BB_BREACH_TOLERANCE):
-            logger.debug(
-                f"close {candles[0].close} is bellow bbb 2.5 {bb_last.bottom}"
-            )
-            return None
-        if is_far_from_levels(
-            candles,
-            bb20.bottom,
-            ma50_last,
-            margin_variation_bb,
-            margin_variation_ma50,
-            Direction.BUY,
-        ):
-            logger.debug(
-                f"candle {candles[0]} is far from the bbb 2.0 "
-                f"{bb20.bottom} and from the ma50 {ma50_last}"
-            )
-            return None
-        buy_combo = ComboSignal(
-            price=0,
-            direction=Direction.BUY,
-            has_been_triggered=False,
-            strength=SignalStrength.MEDIUM,
-            details={
-                "macd": False,
-                "ma50_over_bb": False,
-                "price_within_bb": False,
-                "strong_ma50": False,
-                "both_bb_flat": False,
-            },
+    if context.ma50_slope > COMBO_MA50_SLOPE_MIN:
+        logger.debug(f"testing a buying combo ma50_slope={context.ma50_slope}")
+        return _combo_for_direction(context, Direction.BUY)
+    if context.ma50_slope < -COMBO_MA50_SLOPE_MIN:
+        logger.debug(
+            f"testing a selling combo ma50_slope={context.ma50_slope}"
         )
-        if both_bb_flat:
-            signal += 1
-            buy_combo.details["both_bb_flat"] = True
-        if ma50_last < bb_last.bottom:
-            signal += 1
-            buy_combo.details["ma50_over_bb"] = True
-
-        if ma50_slope > COMBO_MA50_SLOPE_STRONG:
-            signal += 1
-            buy_combo.details["strong_ma50"] = True
-
-        if is_price_within_bands(
-            candles[1].close, bb25_1.bottom, bb20_1.bottom, Direction.BUY
-        ) or is_price_within_bands(
-            candles[0].close, bb_last.bottom, bb20.bottom, Direction.BUY
-        ):  # candle -1 or candle is between bb 2.0 / 2.5
-            signal += 1
-            buy_combo.details["price_within_bb"] = True
-        if macd_0lag[0] > macd_0lag[1]:
-            signal += 1
-            buy_combo.details["macd"] = True
-        if candles[0].close > candles[1].higher:
-            buy_combo.has_been_triggered = True
-            buy_combo.price = candles[0].close
-        else:
-            buy_combo.price = candles[0].higher
-        if signal == 0:
-            buy_combo.strength = SignalStrength.WEAK
-        elif signal >= COMBO_STRONG_SIGNAL_MIN:
-            buy_combo.strength = SignalStrength.STRONG
-        return buy_combo
-    elif ma50_slope < -COMBO_MA50_SLOPE_MIN:
-        logger.debug(f"testing a selling combo ma50_slope={ma50_slope}")
-        signal = 0
-        if candles[0].close > ma50_last:
-            logger.debug(f"close {candles[0].close} is above ma50 {ma50_last}")
-            return None
-        if candles[0].close > bb_last.up * (1 + COMBO_BB_BREACH_TOLERANCE):
-            logger.debug(
-                f"close {candles[0].close} is above bbb 2.5 {bb_last.up}"
-            )
-            return None
-        if is_far_from_levels(
-            candles,
-            bb20.up,
-            ma50_last,
-            margin_variation_bb,
-            margin_variation_ma50,
-            Direction.SELL,
-        ):
-            logger.debug(
-                f"candle {candles[0]} is far from the bbb 2.0 "
-                f"{bb20.up} and from the ma50 {ma50_last}"
-            )
-            return None
-        sell_combo = ComboSignal(
-            price=0,
-            direction=Direction.SELL,
-            has_been_triggered=False,
-            strength=SignalStrength.MEDIUM,
-            details={
-                "macd": False,
-                "ma50_over_bb": False,
-                "price_within_bb": False,
-                "strong_ma50": False,
-                "both_bb_flat": False,
-            },
-        )
-        if both_bb_flat:
-            signal += 1
-            sell_combo.details["both_bb_flat"] = True
-        if ma50_last > bb_last.up:
-            signal += 1
-            sell_combo.details["ma50_over_bb"] = True
-        if ma50_slope < -COMBO_MA50_SLOPE_STRONG:
-            signal += 1
-            sell_combo.details["strong_ma50"] = True
-
-        if is_price_within_bands(
-            candles[1].close, bb25_1.up, bb20_1.up, Direction.SELL
-        ) or is_price_within_bands(
-            candles[0].close, bb_last.up, bb20.up, Direction.SELL
-        ):  # candle -1 or candle is between bb 2.0 / 2.5
-            signal += 1
-            sell_combo.details["price_within_bb"] = True
-        if macd_0lag[0] < macd_0lag[1]:
-            signal += 1
-            sell_combo.details["macd"] = True
-        if candles[0].close < candles[1].lower:
-            sell_combo.has_been_triggered = True
-            sell_combo.price = candles[0].close
-        else:
-            sell_combo.price = candles[0].lower
-        if signal == 0:
-            sell_combo.strength = SignalStrength.WEAK
-        elif signal >= COMBO_STRONG_SIGNAL_MIN:
-            sell_combo.strength = SignalStrength.STRONG
-        return sell_combo
+        return _combo_for_direction(context, Direction.SELL)
     return None
 
 
@@ -376,11 +368,16 @@ def macd0lag(
     short_term_period: int = 12,
     long_term_period: int = 26,
     signal_period: int = 9,
-) -> tuple:
+) -> Tuple[float, float]:
     """
     Here is the formula
     https://www.axialfinance.fr/manuel/pagesindicateurs/pageMZLD.html
     return a tuple(last macd0lag, signal)
+
+    The nested emas read progressively older suffixes, so the whole call
+    needs more candles than any single _macd0lag guard reports: with the
+    default periods the deepest read is candles[157:] against an ema
+    needing 78 values, so 235 candles at minimum.
     """
 
     # The loops below ask for the ema of heavily overlapping suffixes of the

--- a/tests/saxo_order/commands/test_alerting.py
+++ b/tests/saxo_order/commands/test_alerting.py
@@ -6,6 +6,7 @@ import pytest
 
 from model import AlertType, Candle, UnitTime
 from saxo_order.commands.alerting import run_detection_for_asset
+from utils.exception import SaxoException
 
 
 def _make_candles(closes: List[float]) -> List[Candle]:
@@ -422,3 +423,120 @@ class TestAssetExclusionFiltering:
         assert len(filtered_assets) == 1
         assert filtered_assets[0]["code"] == "SAN:xpar"
         assert filtered_assets[0]["name"] == "Santander"
+
+
+class TestRunDetectionForAssetIsolatesDetectors:
+    """
+    Every detector has its own history requirement, and they used to share
+    one try/except that also wrapped the DynamoDB write. So the most
+    demanding detector decided how much history an asset needed before *any*
+    of its alerts were kept, and an unlisted error type escaped the handler
+    entirely and aborted the whole scan.
+    """
+
+    @staticmethod
+    def _saxo_client() -> MagicMock:
+        """A bare MagicMock makes `"TickSizeScheme" not in detail` true, which
+        sends _run_double_top down a branch that never reads candles[0] - so
+        the mock has to carry a tick size scheme for the no-candle case to
+        exercise the code path it is about."""
+        saxo_client = MagicMock()
+        saxo_client.get_asset_detail.return_value = {
+            "TickSizeScheme": {
+                "DefaultTickSize": 0.01,
+                "Elements": [{"HighPrice": 100000, "TickSize": 0.01}],
+            }
+        }
+        return saxo_client
+
+    async def _run(self, mocker, candles: List[Candle]) -> tuple:
+        mocker.patch(
+            "saxo_order.commands.alerting._build_candles",
+            return_value=candles,
+        )
+        saxo_client = self._saxo_client()
+        dynamodb_client = MagicMock()
+        dynamodb_client.store_alerts = AsyncMock()
+        alerts = await run_detection_for_asset(
+            asset_code="TST",
+            country_code="xpar",
+            exchange="saxo",
+            asset_description="Test Asset",
+            saxo_uic=12345,
+            saxo_client=saxo_client,
+            dynamodb_client=dynamodb_client,
+        )
+        return alerts, dynamodb_client
+
+    async def test_no_candle_is_skipped_without_raising(self, mocker):
+        """A delisted or brand new instrument returns no candle at all. That
+        used to reach _run_double_top and raise IndexError, which the
+        SaxoException handler did not catch, killing the whole run."""
+        alerts, dynamodb_client = await self._run(mocker, [])
+        assert alerts == []
+        dynamodb_client.store_alerts.assert_not_called()
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 59, 60, 234])
+    async def test_short_history_never_raises(self, mocker, count: int):
+        alerts, _ = await self._run(mocker, _make_candles([100.0] * count))
+        assert isinstance(alerts, list)
+
+    async def test_a_failing_detector_does_not_discard_the_others(
+        self, mocker
+    ):
+        """combo raising must not cost the asset its mm50_touch alert, nor
+        the DynamoDB write that persists it."""
+        mocker.patch(
+            "saxo_order.commands.alerting.indicator_service.combo",
+            side_effect=SaxoException("Missing candles"),
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._run_double_top", return_value=None
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._run_double_bottom",
+            return_value=None,
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._run_containing_candle",
+            return_value=None,
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._run_double_inside_bar",
+            return_value=None,
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._run_congestion_indicator",
+            return_value=None,
+        )
+        alerts, dynamodb_client = await self._run(
+            mocker, _mm50_touch_candles()
+        )
+
+        assert [a.alert_type for a in alerts] == [AlertType.MM50_TOUCH]
+        dynamodb_client.store_alerts.assert_awaited_once()
+        assert dynamodb_client.store_alerts.await_args.args[2] == alerts
+
+    async def test_a_failing_store_does_not_raise(self, mocker):
+        mocker.patch(
+            "saxo_order.commands.alerting._run_congestion_indicator",
+            return_value=None,
+        )
+        mocker.patch(
+            "saxo_order.commands.alerting._build_candles",
+            return_value=_mm50_touch_candles(),
+        )
+        dynamodb_client = MagicMock()
+        dynamodb_client.store_alerts = AsyncMock(
+            side_effect=RuntimeError("dynamo is down")
+        )
+        alerts = await run_detection_for_asset(
+            asset_code="TST",
+            country_code="xpar",
+            exchange="saxo",
+            asset_description="Test Asset",
+            saxo_uic=12345,
+            saxo_client=self._saxo_client(),
+            dynamodb_client=dynamodb_client,
+        )
+        assert len(alerts) > 0

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -12,6 +12,7 @@ from model import (
     UnitTime,
 )
 from services.indicator_service import (
+    COMBO_MIN_CANDLES,
     adx,
     apply_linear_function,
     average_true_range,
@@ -824,11 +825,12 @@ class TestComboBandOffsets:
 
 class TestComboDefersMacd0lag:
     """
-    macd0lag needs 233 candles, far more than the 60 the rest of combo
-    needs. Computing it up front made combo raise on any shorter history,
-    and in run_detection_for_asset that exception discards every alert
-    already collected for the asset. It must only be reached once a
-    direction is actually being scored.
+    macd0lag needs COMBO_MIN_CANDLES candles, far more than the 60 the rest
+    of combo needs. Computing it up front made combo raise on any shorter
+    history, and in run_detection_for_asset that exception discarded every
+    alert already collected for the asset. It must only be reached once a
+    direction is actually being scored, and a history too short to reach it
+    at all must be declined rather than raised on.
     """
 
     def _short_flat_candles(self) -> List[Candle]:
@@ -837,6 +839,31 @@ class TestComboDefersMacd0lag:
 
     def test_short_history_returns_none_instead_of_raising(self):
         assert combo(self._short_flat_candles()) is None
+
+    def test_a_scored_direction_on_short_history_returns_none(self):
+        """The flat-ma50 sets above bail before macd0lag is reached, so they
+        say nothing about the path that does reach it. This fixture produces
+        a real signal at full length; truncated below the minimum it must
+        decline rather than raise part-way through scoring."""
+        with open("tests/services/files/combo_buy_daily_cac.obj", "r") as f:
+            candles = eval(
+                f.read(),
+                {"datetime": datetime, "Candle": Candle, "UnitTime": UnitTime},
+            )
+        assert combo(candles) is not None
+        assert combo(candles[: COMBO_MIN_CANDLES - 1]) is None
+
+    def test_the_minimum_matches_what_macd0lag_actually_needs(self):
+        """Pins the two numbers together: COMBO_MIN_CANDLES is a constant but
+        macd0lag derives its own from the periods, so they can drift."""
+        with open("tests/services/files/combo_buy_daily_cac.obj", "r") as f:
+            candles = eval(
+                f.read(),
+                {"datetime": datetime, "Candle": Candle, "UnitTime": UnitTime},
+            )
+        macd0lag(candles[:COMBO_MIN_CANDLES])
+        with pytest.raises(SaxoException):
+            macd0lag(candles[: COMBO_MIN_CANDLES - 1])
 
     def test_macd0lag_is_not_called_when_the_ma50_is_flat(self, mocker):
         spy = mocker.patch(

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -701,8 +701,10 @@ class TestIsPriceWithinBands:
     before, so these cases fail if the tolerance regresses.
     """
 
-    OUTER = 1000.0  # the 2.5 band
-    INNER = 1100.0  # the 2.0 band
+    # Same two numbers in both directions; which one is the outer 2.5 band
+    # flips with the direction, which is what the mirror is about.
+    LOWER_BAND = 1000.0
+    UPPER_BAND = 1100.0
 
     @pytest.mark.parametrize(
         "close, expected",
@@ -716,8 +718,14 @@ class TestIsPriceWithinBands:
         ],
     )
     def test_buy_zone(self, close: float, expected: bool):
+        """The 2.5 band is the lower edge and the 2.0 the upper."""
         assert (
-            is_price_within_bands(close, self.OUTER, self.INNER, Direction.BUY)
+            is_price_within_bands(
+                close,
+                outer=self.LOWER_BAND,
+                inner=self.UPPER_BAND,
+                direction=Direction.BUY,
+            )
             is expected
         )
 
@@ -736,7 +744,10 @@ class TestIsPriceWithinBands:
         """Mirrored: the 2.0 band is the lower edge and the 2.5 the upper."""
         assert (
             is_price_within_bands(
-                close, self.INNER, self.OUTER, Direction.SELL
+                close,
+                outer=self.UPPER_BAND,
+                inner=self.LOWER_BAND,
+                direction=Direction.SELL,
             )
             is expected
         )
@@ -788,13 +799,19 @@ class TestComboBandOffsets:
 
         assert (
             is_price_within_bands(
-                previous_close, bb25_1.bottom, bb20_1.bottom, Direction.BUY
+                previous_close,
+                outer=bb25_1.bottom,
+                inner=bb20_1.bottom,
+                direction=Direction.BUY,
             )
             is True
         )
         assert (
             is_price_within_bands(
-                previous_close, bb25.bottom, bb20_1.bottom, Direction.BUY
+                previous_close,
+                outer=bb25.bottom,
+                inner=bb20_1.bottom,
+                direction=Direction.BUY,
             )
             is False
         )
@@ -803,6 +820,44 @@ class TestComboBandOffsets:
         signal = combo(self._candles())
         assert signal is not None
         assert signal.details["price_within_bb"] is True
+
+
+class TestComboDefersMacd0lag:
+    """
+    macd0lag needs 233 candles, far more than the 60 the rest of combo
+    needs. Computing it up front made combo raise on any shorter history,
+    and in run_detection_for_asset that exception discards every alert
+    already collected for the asset. It must only be reached once a
+    direction is actually being scored.
+    """
+
+    def _short_flat_candles(self) -> List[Candle]:
+        """60 candles with a flat ma50: rejected before macd0lag is needed."""
+        return _make_candles([100.0] * 60)
+
+    def test_short_history_returns_none_instead_of_raising(self):
+        assert combo(self._short_flat_candles()) is None
+
+    def test_macd0lag_is_not_called_when_the_ma50_is_flat(self, mocker):
+        spy = mocker.patch(
+            "services.indicator_service.macd0lag", return_value=(1.0, 0.0)
+        )
+        assert combo(self._short_flat_candles()) is None
+        spy.assert_not_called()
+
+    def test_macd0lag_is_called_when_a_direction_is_scored(self, mocker):
+        with open("tests/services/files/combo_buy_daily_cac.obj", "r") as f:
+            candles = eval(
+                f.read(),
+                {"datetime": datetime, "Candle": Candle, "UnitTime": UnitTime},
+            )
+        spy = mocker.patch(
+            "services.indicator_service.macd0lag", return_value=(1.0, 0.0)
+        )
+        signal = combo(candles)
+        assert signal is not None
+        spy.assert_called_once()
+        assert signal.details["macd"] is True
 
 
 class TestIsFarFromLevels:


### PR DESCRIPTION
The buy and sell halves of combo() were exact mirrors, ~137 of its 168
lines. Two of the three defects fixed in #682 were one-sided drift
between halves meant to be identical (.higher used against the ma50
support on the buy side, 0.995 vs 0.9995 on the sell side), so the
duplication is what let them hide. Both directions now run through one
_combo_for_direction body where sign flips every comparison.

macd0lag was computed up front but feeds a single scoring criterion, so
it moves behind a lazy property on the new _ComboContext. It needs 235
candles where the rest of combo needs 60, and the eager call meant a
short history raised SaxoException instead of returning None - an
exception that run_detection_for_asset catches after six detectors have
run and before store_alerts, silently discarding every alert already
collected for that asset. Rejected candle sets are also 20-25x faster
now, unchanged when a signal is actually scored.

Verified behaviour-preserving by diffing the old and new implementations
over 508 sliding candle windows from the recorded fixtures: no
divergence, and the only two differences are short histories that used
to raise and now correctly return None.

Also renames the bollinger locals to say which band and which offset they
hold (bb_last/bb25_1/bb_first -> bb25/bb25_previous), makes
is_price_within_bands take outer/inner as keyword-only since silently
swapping two adjacent floats is the shape of the bug just fixed, types
macd0lag's return, and corrects its documented candle minimum to 235.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F5cqHxv1EJW3Br3u8GJ6P3