### PR TITLE
feat: add mm7 break detection to the alerting system

### DIFF
--- a/frontend/src/components/AlertCard.tsx
+++ b/frontend/src/components/AlertCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { AlertItem } from '../services/api';
 import { getTradingViewUrl } from '../utils/tradingview';
+import { getAlertTypeLabel } from '../utils/alertLabels';
 import { assetDetailsService } from '../services/api';
 import './AlertCard.css';
 
@@ -26,13 +27,6 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
     });
   };
 
-  const formatAlertType = (type: string): string => {
-    return type
-      .split('_')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  };
-
   const getAgeLabel = (hours: number): string => {
     if (hours < 1) return 'Just now';
     if (hours === 1) return '1 hour ago';
@@ -42,7 +36,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
     return `${days} days ago`;
   };
 
-  const formatMA50Slope = (slope: unknown): string => {
+  const formatSignedPercent = (slope: unknown): string => {
     // Handle null, undefined, or non-numeric values
     if (slope === null || slope === undefined || slope === '') {
       return 'N/A';
@@ -101,6 +95,27 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
   // Extract MA50 slope from alert data
   const ma50Slope = alert.data?.ma50_slope;
 
+  // Directional alerts (mm7_break, combo) carry which way the signal points;
+  // mm7_break also carries how far price closed past the average.
+  const direction = alert.data?.direction;
+  const distancePct = alert.data?.distance_pct;
+
+  const formatDirection = (value: unknown): string => {
+    const label = String(value);
+    const distance =
+      distancePct === null || distancePct === undefined
+        ? ''
+        : ` (${formatSignedPercent(distancePct)})`;
+    return `${label}${distance}`;
+  };
+
+  const getDirectionClass = (value: unknown): string => {
+    const label = String(value).toLowerCase();
+    if (label === 'buy') return 'ma50-slope-positive';
+    if (label === 'sell') return 'ma50-slope-negative';
+    return 'ma50-slope-neutral';
+  };
+
   const handleExcludeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -131,7 +146,7 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
     <div className="alert-card">
       <div className="alert-card-header">
         <div className="alert-card-type">
-          <span className="alert-type-badge">{formatAlertType(alert.alert_type)}</span>
+          <span className="alert-type-badge">{getAlertTypeLabel(alert.alert_type)}</span>
         </div>
         <div className="alert-card-header-right">
           <span className="age-label">{getAgeLabel(alert.age_hours)}</span>
@@ -163,9 +178,17 @@ export const AlertCard: React.FC<AlertCardProps> = ({ alert, onExclude }) => {
         <div className="alert-card-ma50">
           <span className="ma50-label">MA50 Slope:</span>
           <span className={`ma50-value ${getMA50SlopeClass(ma50Slope)}`}>
-            {formatMA50Slope(ma50Slope)}
+            {formatSignedPercent(ma50Slope)}
           </span>
         </div>
+        {direction !== null && direction !== undefined && (
+          <div className="alert-card-ma50">
+            <span className="ma50-label">Direction:</span>
+            <span className={`ma50-value ${getDirectionClass(direction)}`}>
+              {formatDirection(direction)}
+            </span>
+          </div>
+        )}
         <div className="alert-card-timestamp">
           <span className="timestamp">{formatDate(alert.date)}</span>
         </div>

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -4,23 +4,8 @@ import type { AlertItem } from '../services/api';
 import { alertService } from '../services/api';
 import { AlertGroup } from '../components/AlertGroup';
 import { groupAlertsByAsset, processAlerts } from '../utils/alertFilters';
+import { getAlertTypeLabel } from '../utils/alertLabels';
 import './Alerts.css';
-
-// Alert type display name mapping
-const ALERT_TYPE_LABELS: Record<string, string> = {
-  congestion20: 'Congestion 20',
-  congestion100: 'Congestion 100',
-  combo: 'Combo',
-  double_top: 'Double Top',
-  double_inside_bar: 'Double Inside Bar',
-  containing_candle: 'Containing Candle',
-  mm50_touch: 'MM50 Touch',
-  mm7_break: 'MM7 Break',
-};
-
-const getAlertTypeLabel = (type: string): string => {
-  return ALERT_TYPE_LABELS[type] || type;
-};
 
 export function Alerts() {
   const [alerts, setAlerts] = useState<AlertItem[]>([]);

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -14,6 +14,8 @@ const ALERT_TYPE_LABELS: Record<string, string> = {
   double_top: 'Double Top',
   double_inside_bar: 'Double Inside Bar',
   containing_candle: 'Containing Candle',
+  mm50_touch: 'MM50 Touch',
+  mm7_break: 'MM7 Break',
 };
 
 const getAlertTypeLabel = (type: string): string => {

--- a/frontend/src/utils/alertLabels.ts
+++ b/frontend/src/utils/alertLabels.ts
@@ -1,0 +1,20 @@
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  congestion20: 'Congestion 20',
+  congestion100: 'Congestion 100',
+  combo: 'Combo',
+  double_top: 'Double Top',
+  double_bottom: 'Double Bottom',
+  double_inside_bar: 'Double Inside Bar',
+  containing_candle: 'Containing Candle',
+  mm50_touch: 'MM50 Touch',
+  mm7_break: 'MM7 Break',
+};
+
+const titleCase = (type: string): string =>
+  type
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+export const getAlertTypeLabel = (type: string): string =>
+  ALERT_TYPE_LABELS[type] || titleCase(type);

--- a/model/enum.py
+++ b/model/enum.py
@@ -124,6 +124,7 @@ class AlertType(EnumWithGetValue):
     DOUBLE_INSIDE_BAR = "double_inside_bar"
     CONTAINING_CANDLE = "containing_candle"
     MM50_TOUCH = "mm50_touch"
+    MM7_BREAK = "mm7_break"
 
 
 class Exchange(EnumWithGetValue):

--- a/saxo_order/commands/alerting.py
+++ b/saxo_order/commands/alerting.py
@@ -371,6 +371,25 @@ async def run_detection_for_asset(
             )
         )
 
+    mm7_break_result = detect(
+        AlertType.MM7_BREAK, partial(indicator_service.mm7_break, candles)
+    )
+    if mm7_break_result is not None:
+        asset_alerts.append(
+            Alert(
+                alert_type=AlertType.MM7_BREAK,
+                date=datetime.datetime.now(),
+                data={
+                    **mm7_break_result,
+                    "ma50_slope": ma50_slope,
+                },
+                asset_code=asset_code,
+                asset_description=asset_description,
+                exchange=exchange,
+                country_code=country_code,
+            )
+        )
+
     # Store what was found even if some detector above could not run
     if len(asset_alerts) > 0:
         try:

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -28,6 +28,16 @@ bearish thesis or as "trend-aligned" with a negative slope. If you see \
 mm50_touch alongside a claimed bearish setup, that combination is internally \
 inconsistent, not "confluence that overrides a conflict" - treat it as a red \
 flag on the bearish read, not a supporting signal.
+- mm7_break: the close crossing through the 7-period moving average, with a \
+direction ("Buy" = reclaim from below, "Sell" = breakdown from above). This \
+is a SHORT-TERM TIMING trigger, not a thesis: it says the last few days \
+changed character, nothing about where the stock is headed over weeks. Weigh \
+it by how it sits against ma50_slope: a break in the SAME direction as the \
+slope is a \
+continuation trigger and counts as real directional evidence; a break AGAINST \
+the slope is an early warning on an intact trend, NOT a reversal - do not \
+promote it to a reversal thesis on its own. mm7_break alone, with no other \
+directional pattern, is never enough for "high" no matter how clean the break.
 - congestion20 and congestion100: the SAME underlying consolidation detector \
 run at two different lookback windows (20 vs 100 candles). If both fire \
 together, count them as ONE point of confluence, not two - they are not \

--- a/services/alert_triage_service.py
+++ b/services/alert_triage_service.py
@@ -146,6 +146,15 @@ FALLBACK_MODEL = "deterministic-fallback"
 # when counting confluence in the deterministic fallback.
 _PATTERN_FAMILY = {AlertType.CONGESTION100: AlertType.CONGESTION20}
 
+# Short-term timing triggers. They say the last few candles changed character,
+# not where the asset is headed, so they can sharpen a setup that other
+# patterns already establish but must never be the pattern that promotes an
+# asset to HIGH on their own account. The prompt tells the reasoning path the
+# same thing; without this the fallback would quietly disagree with it and
+# promote every WATCH asset that also happens to cross its MM7 - which, given
+# how ordinary a cross is, would be most of them.
+_TIMING_PATTERNS = {AlertType.MM7_BREAK}
+
 
 class TriageAgent:
     def __init__(
@@ -210,7 +219,7 @@ class TriageAgent:
         ordered = sorted(
             grouped.values(),
             key=lambda entry: (
-                len(self._pattern_families(entry["patterns"])),
+                len(self._structural_families(entry["patterns"])),
                 self._abs_slope(entry["ma50_slope"]),
             ),
             reverse=True,
@@ -247,11 +256,11 @@ class TriageAgent:
         )
 
     def _fallback_conviction(self, entry: Dict[str, Any]) -> Conviction:
-        family_count = len(self._pattern_families(entry["patterns"]))
-        if family_count >= 2:
+        structural_count = len(self._structural_families(entry["patterns"]))
+        if structural_count >= 2:
             return Conviction.HIGH
         if (
-            family_count == 1
+            structural_count >= 1
             and self._abs_slope(entry["ma50_slope"]) >= self.slope_threshold
         ):
             return Conviction.WATCH
@@ -261,11 +270,16 @@ class TriageAgent:
         patterns = ", ".join(p.value for p in entry["patterns"])
         slope = entry["ma50_slope"]
         slope_text = f", slope {slope:.1f}%" if slope is not None else ""
-        family_count = len(self._pattern_families(entry["patterns"]))
-        return f"{family_count} pattern(s): {patterns}{slope_text}"
+        structural_count = len(self._structural_families(entry["patterns"]))
+        return f"{structural_count} pattern(s): {patterns}{slope_text}"
 
     def _pattern_families(self, patterns: List[AlertType]) -> set[AlertType]:
         return {_PATTERN_FAMILY.get(p, p) for p in patterns}
+
+    def _structural_families(
+        self, patterns: List[AlertType]
+    ) -> set[AlertType]:
+        return self._pattern_families(patterns) - _TIMING_PATTERNS
 
     def _abs_slope(self, slope: Optional[float]) -> float:
         return abs(slope) if slope is not None else 0.0

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -148,6 +148,13 @@ def mm50_touch(candles: List[Candle]) -> Optional[Dict[str, float]]:
 
 
 def _mm7_at(candles: List[Candle], offset: int) -> float:
+    """
+    The MM7 as it stood at candles[offset], i.e. that candle and the 6 older
+    ones. Newest is index 0, so dropping the first `offset` entries walks
+    backwards in time and `mobile_average` then reads the 7 newest of what
+    remains - candles[offset:offset+7]. Same idiom as mm50_touch's
+    mobile_average(candles[10:], 50) for the MA50 of 10 candles ago.
+    """
     return mobile_average(candles[offset:], MM7_PERIOD)
 
 

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy
 
@@ -103,6 +103,16 @@ def mobile_average(candles: List[Candle], period: int) -> float:
 MM50_TOUCH_PROXIMITY = 0.01
 MM50_TOUCH_SLOPE_MIN = 3.0
 
+MM7_PERIOD = 7
+# A close that merely grazes the average is not a break: price has to clear it
+# by a margin to count.
+MM7_BREAK_MIN_DISTANCE = 0.005
+# ...and it has to flip a short-term run rather than cross back and forth. A
+# raw cross fires on a large share of the universe every day, which would
+# drown the daily digest instead of informing it.
+MM7_BREAK_MIN_STREAK = 3
+MM7_BREAK_MIN_CANDLES = MM7_PERIOD + MM7_BREAK_MIN_STREAK
+
 COMBO_MA50_SLOPE_MIN = 3.0
 COMBO_MA50_SLOPE_STRONG = 10.0
 COMBO_BB_FLAT_SLOPE_MAX = 5.0
@@ -134,6 +144,68 @@ def mm50_touch(candles: List[Candle]) -> Optional[Dict[str, float]]:
         "ma50": ma50_last,
         "distance_pct": (close - ma50_last) / ma50_last * 100,
         "slope": slope,
+    }
+
+
+def _mm7_at(candles: List[Candle], offset: int) -> float:
+    return mobile_average(candles[offset:], MM7_PERIOD)
+
+
+def _mm7_streak(candles: List[Candle], direction: Direction) -> int:
+    """
+    Number of consecutive candles before the break that closed on the side the
+    price is leaving. Stops as soon as the history runs short of a full MM7.
+    """
+    streak = 0
+    offset = 1
+    while len(candles) - offset >= MM7_PERIOD:
+        mm7 = _mm7_at(candles, offset)
+        close = candles[offset].close
+        on_previous_side = (
+            close >= mm7 if direction == Direction.SELL else close <= mm7
+        )
+        if not on_previous_side:
+            break
+        streak += 1
+        offset += 1
+    return streak
+
+
+def mm7_break(candles: List[Candle]) -> Optional[Dict[str, Any]]:
+    """
+    Detect the last candle closing through the 7-period mobile average.
+
+    A break is a short-term timing signal, not a thesis: it only fires when
+    the close clears the average by MM7_BREAK_MIN_DISTANCE and the previous
+    MM7_BREAK_MIN_STREAK candles all closed on the other side, so chop around
+    a flat average stays silent.
+    """
+    if len(candles) < MM7_BREAK_MIN_CANDLES:
+        return None
+
+    mm7 = _mm7_at(candles, 0)
+    close = candles[0].close
+    distance = (close - mm7) / mm7
+
+    if distance < -MM7_BREAK_MIN_DISTANCE:
+        direction = Direction.SELL
+    elif distance > MM7_BREAK_MIN_DISTANCE:
+        direction = Direction.BUY
+    else:
+        return None
+
+    streak = _mm7_streak(candles, direction)
+    if streak < MM7_BREAK_MIN_STREAK:
+        return None
+
+    return {
+        "close": close,
+        "mm7": mm7,
+        "previous_close": candles[1].close,
+        "previous_mm7": _mm7_at(candles, 1),
+        "distance_pct": distance * 100,
+        "direction": direction.value,
+        "streak": streak,
     }
 
 

--- a/specs/027-mm7-break-alert/plan.md
+++ b/specs/027-mm7-break-alert/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: MM7 Break Alert
+
+**Branch**: `027-mm7-break-alert` (developed on `claude/triage-agent-ma7-alerting-mypata`) | **Date**: 2026-08-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/027-mm7-break-alert/spec.md`
+
+## Summary
+
+Add a new `AlertType` (`MM7_BREAK`) emitted during the existing daily alerting pipeline when the latest daily close crosses decisively through the 7-period moving average — more than 0.5% clear of it — after at least 3 prior candles closed on the other side. The detector is a pure function in `services/indicator_service.py`, wired into `run_detection_for_asset` the same way `mm50_touch` is, and carries its direction (`Direction.BUY` reclaim / `Direction.SELL` breakdown) inside the alert `data` rather than splitting into two alert types.
+
+The load-bearing part is not the detector — it is the qualifier and the prompt. A raw MA7 cross fires on a large share of the universe every day; unqualified, it would arrive in the triage payload as background rather than evidence and make the digest worse, not better. So the detector gates on distance **and** streak, and `TRIAGE_SYSTEM_PROMPT` gains a pattern-semantics entry (like `mm50_touch` and `double_top` already have) that fixes MM7 as a short-term timing trigger read against the *sign* of `ma50_slope`, never sufficient alone for "high" conviction.
+
+DynamoDB persistence, the alerts API, and the deterministic triage fallback are already generic over `AlertType` and need no changes. The frontend needs one entry in its label map, which is a hand-maintained dictionary rather than a derived helper.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend — one label map entry)
+**Primary Dependencies**: existing — `services/indicator_service.py` (`mobile_average`), `saxo_order/commands/alerting.py` (`run_detection_for_asset`, `_safe_detect`), `services/alert_triage_service.py` (`TRIAGE_SYSTEM_PROMPT`), `model.Alert`, `model.AlertType`, `model.Direction`, `client/aws_client.py` (`DynamoDBClient.store_alerts`). **No new dependency.**
+**Storage**: AWS DynamoDB `alerts` table (existing, schema unchanged — `data` is a free-form `Dict[str, Any]`, same-type-same-date dedup)
+**Testing**: pytest with `unittest.mock` (`tests/services/test_indicator_service.py`, `tests/saxo_order/commands/test_alerting.py`)
+**Target Platform**: AWS Lambda (scheduled EventBridge, daily) + on-demand FastAPI endpoint (`POST /api/alerts/run`)
+**Project Type**: web (backend + frontend) — this feature is backend plus one frontend constant
+**Performance Goals**: No measurable regression. The detector is O(period × streak) on candles already in memory — bounded by 10 × 7 close reads per asset, effectively free next to the Saxo fetch.
+**Constraints**: Must reuse the candle series already loaded for each asset (no extra Saxo API calls). Must skip silently below 10 candles. Must not fire often enough to dilute the digest — the binding constraint, and the one that cannot be verified before a live run (spec SC-003).
+**Scale/Scope**: ~700 instruments scanned per daily run (French stocks via Saxo `/ref/v1/instruments` + `followup-stocks.json`). Target match rate: a handful per day, same order as the other detectors.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Layered Architecture Discipline | ✅ Pass | Detection is a pure function on `List[Candle]` in `services/`; orchestration stays in `saxo_order/commands/alerting.py`; the enum stays in `model/enum.py`. No client internals touched. The frontend change is a constant in the page that already owns the label map. |
+| II. Clean Code First | ✅ Pass | Direction reuses the existing `Direction` enum rather than a `"up"`/`"down"` string (CLAUDE.md rule). Thresholds are named constants next to the `MM50_TOUCH_*` ones, not magic numbers. No `assert` in production code. Comments explain *why* the qualifier exists, not what the code does. |
+| III. Configuration-Driven Design | ✅ Pass | `MM7_BREAK_MIN_DISTANCE` / `MM7_BREAK_MIN_STREAK` are module constants, not config: they define the alert's identity, and changing them means a different alert. Consistent with `MM50_TOUCH_PROXIMITY`. No new credentials or environment variables. |
+| IV. Safe Deployment Practices | ✅ Pass | Ships via the existing `./deploy.sh` flow; Lambda and EventBridge schedule unchanged. Conventional commits (`feat:`, `docs:`). Additive — no existing alert type changes behavior. |
+| V. Domain Model Integrity | ✅ Pass | Uses `Candle` objects with newest at index 0 throughout; the MM7 at offset *i* is `mobile_average(candles[i:], 7)`, which respects that ordering. `Alert` already carries `exchange`; no country-code-based exchange inference (CLAUDE.md rule) — a Saxo asset without a country code stays a Saxo asset. |
+
+**Result**: All gates pass. Complexity Tracking intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-mm7-break-alert/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+└── tasks.md             # Task breakdown
+```
+
+`research.md`, `data-model.md`, and `contracts/` are omitted deliberately: no new data model (the alert `data` payload is a free-form dict on an unchanged table), no new API contract (the alerts endpoints are generic over `AlertType`), and no open research question — the one real unknown, the live hit rate, is answerable only by running the job, and is tracked as spec SC-003 rather than as desk research.
+
+### Source Code (repository root)
+
+Existing Python backend + React frontend. No new directories.
+
+```text
+model/
+└── enum.py                   # +1 member: AlertType.MM7_BREAK
+
+services/
+├── indicator_service.py      # +constants MM7_PERIOD, MM7_BREAK_MIN_DISTANCE,
+│                             #  MM7_BREAK_MIN_STREAK, MM7_BREAK_MIN_CANDLES
+│                             # +_mm7_at, _mm7_streak, mm7_break
+└── alert_triage_service.py   # +pattern-semantics entry in TRIAGE_SYSTEM_PROMPT
+
+saxo_order/commands/
+└── alerting.py               # +1 detection block in run_detection_for_asset
+
+frontend/src/pages/
+└── Alerts.tsx                # +ALERT_TYPE_LABELS entries (mm7_break, mm50_touch)
+
+api/                          # (no change — generic over AlertType.value)
+client/aws_client.py          # (no change — data is Dict[str, Any])
+
+tests/
+├── services/test_indicator_service.py    # +detector tests
+└── saxo_order/commands/test_alerting.py  # +pipeline emission tests
+```
+
+**Structure Decision**: Backend-only change plus one frontend constant. Layering is preserved: pure detection in `services/indicator_service.py`, orchestration in `saxo_order/commands/alerting.py`, vocabulary in `model/enum.py`. The alerts API and DynamoDB schema are untouched because they are already generic over `AlertType`.
+
+## Key Design Decisions
+
+1. **One alert type, direction in `data`** — rather than `MM7_BREAK_UP` / `MM7_BREAK_DOWN`. Follows `COMBO`, which stores `direction` in its payload. Keeps the UI filter list and the triage pattern vocabulary from doubling, and lets the triage prompt state the semantics once.
+
+2. **The MM7 is evaluated at each candle's own offset**, not held fixed at today's value. `_mm7_streak` compares `candles[i].close` against `mobile_average(candles[i:], 7)`, so "the prior candles closed on the other side" means what it says on each of those days, rather than measuring the past against an average it could not have known.
+
+3. **Distance is exclusive, the streak inclusive.** A break must *clear* 0.5%; exactly 3 qualifying prior candles is enough. A prior close exactly equal to its MM7 counts as still on that side — a candle sitting on the average has not left it.
+
+4. **The streak counter stops when history runs out** rather than raising. With the 10-candle minimum an asset can reach but not exceed the required streak, which is why `MM7_BREAK_MIN_CANDLES` is derived (`MM7_PERIOD + MM7_BREAK_MIN_STREAK`) rather than written as a literal.
+
+5. **No change to the deterministic triage fallback.** MM7 forms its own pattern family in `_PATTERN_FAMILY`, and one family alone already caps at `watch` — so FR-010 (never "high" on an MM7 break alone) holds on the fallback path without new code. This was verified against `_fallback_conviction`, not assumed.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| The 0.5% / 3-candle thresholds are calibrated from the shape of neighbouring detectors, not from measured hit rates. Too loose and MM7 dominates every digest. | Both are named constants in one file, so re-tuning is a one-line change. Spec SC-003 makes the live hit rate an explicit acceptance check on the first runs rather than an assumption. |
+| An LLM prompt change is not covered by a deterministic test — FR-009/FR-010 are verified by reading the digest, not by CI. | The fallback path is deterministic and *is* covered. The prompt states the constraint explicitly ("never enough for high") rather than relying on the model's judgment of an undescribed pattern. |
+| A short-term signal added to a payload previously dominated by structural patterns could shift the agent's overall ranking behavior. | The prompt entry frames MM7 as a timing trigger subordinate to trend context, so it can strengthen or weaken an existing thesis but not create one. |
+
+## Complexity Tracking
+
+> No constitution violations. Section intentionally empty.

--- a/specs/027-mm7-break-alert/plan.md
+++ b/specs/027-mm7-break-alert/plan.md
@@ -67,8 +67,10 @@ services/
 saxo_order/commands/
 └── alerting.py               # +1 detection block in run_detection_for_asset
 
-frontend/src/pages/
-└── Alerts.tsx                # +ALERT_TYPE_LABELS entries (mm7_break, mm50_touch)
+frontend/src/
+├── utils/alertLabels.ts      # NEW — single getAlertTypeLabel for every surface
+├── pages/Alerts.tsx          # uses the shared helper (map moved out)
+└── components/AlertCard.tsx  # uses the shared helper; +Direction row (SC-005)
 
 api/                          # (no change — generic over AlertType.value)
 client/aws_client.py          # (no change — data is Dict[str, Any])
@@ -90,7 +92,7 @@ tests/
 
 4. **The streak counter stops when history runs out** rather than raising. With the 10-candle minimum an asset can reach but not exceed the required streak, which is why `MM7_BREAK_MIN_CANDLES` is derived (`MM7_PERIOD + MM7_BREAK_MIN_STREAK`) rather than written as a literal.
 
-5. **No change to the deterministic triage fallback.** MM7 forms its own pattern family in `_PATTERN_FAMILY`, and one family alone already caps at `watch` — so FR-010 (never "high" on an MM7 break alone) holds on the fallback path without new code. This was verified against `_fallback_conviction`, not assumed.
+5. **Timing patterns are excluded from the fallback confluence count.** The first cut concluded the fallback needed no change: MM7 forms its own family, and one family alone caps at `watch`, so FR-010 held for a lone break. That checked half the case. An asset already firing one structural pattern reached `family_count >= 2` once MM7 co-fired, and was promoted `watch` → `high` — and since crossing an MM7 is ordinary, that inflates the fallback `high` tier systematically rather than occasionally. `_TIMING_PATTERNS` now excludes MM7 from the count (FR-013), so the fallback agrees with what the prompt tells the reasoning path. The `watch` gate moved from `family_count == 1` to `structural_count >= 1` at the same time, so a co-firing asset keeps its previous tier instead of falling through to `noise`.
 
 ## Risks
 

--- a/specs/027-mm7-break-alert/spec.md
+++ b/specs/027-mm7-break-alert/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: MM7 Break Alert
+
+**Feature Branch**: `027-mm7-break-alert`
+**Created**: 2026-08-01
+**Status**: Implemented
+**Input**: User description: "I want to improve the triage agent. Breaking a ma7 is a strong short term indicator. We should add it in the alerting system."
+
+## Clarifications
+
+### Session 2026-08-01
+
+- Q: Which MA7 breaks should fire an alert? → A: Both directions (bullish reclaim and bearish breakdown), with the direction carried in the alert data.
+- Q: How strict should the qualifier be, so MM7 does not flood the daily digest? → A: Distance **and** streak — the close must clear the MM7 by ~0.5% AND the previous 3 candles must all have closed on the other side.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Detect a short-term change of character (Priority: P1)
+
+A trader wants to be notified when an asset's latest daily close crosses through its 7-period moving average, in either direction, after a run of candles held on the other side. Breaking the MM7 is the earliest structural sign that the short-term run has changed character — a breakdown warns that an advance is stalling, a reclaim marks a possible short-term entry.
+
+**Why this priority**: This is the detection itself. Without it there is no signal, and the rest of the feature has nothing to deliver.
+
+**Independent Test**: Run the alerting workflow against an asset whose latest close sits more than 0.5% below its MM7 while the three prior candles all closed at or above their own MM7. Verify an alert of the new type is produced with a bearish direction, stored, and surfaced.
+
+**Acceptance Scenarios**:
+
+1. **Given** an asset with at least 10 daily candles whose latest close is 4% below its MM7 and whose 3 prior candles each closed at or above their MM7, **When** the alerting workflow runs, **Then** an alert of the new "MM7 break" type is emitted with a bearish (Sell) direction.
+2. **Given** the mirror situation — latest close 5% above its MM7, 3 prior candles each closed at or below their MM7 — **When** the alerting workflow runs, **Then** an alert of the new type is emitted with a bullish (Buy) direction.
+3. **Given** an asset whose latest close is 0.4% below its MM7 (a graze, inside the distance threshold), **When** the alerting workflow runs, **Then** no alert of the new type is emitted.
+4. **Given** an asset whose closes alternate above and below the MM7 (chop, so the prior run is shorter than 3 candles), **When** the alerting workflow runs, **Then** no alert of the new type is emitted even if the latest close clears the distance threshold.
+5. **Given** an asset with fewer than 10 candles, **When** the alerting workflow runs, **Then** no alert of the new type is emitted and the workflow continues processing the remaining assets without error.
+
+---
+
+### User Story 2 - Triage weighs the break correctly (Priority: P1)
+
+The trader wants the triage agent to treat an MM7 break as what it is — a short-term timing trigger — rather than promoting it to a standalone thesis. A break in the same direction as the medium-term trend is a continuation trigger; a break against it is an early warning on an intact trend, not a reversal call.
+
+**Why this priority**: Equal to P1 detection. The stated motivation for the feature is improving the triage agent, and a directional pattern added to the payload without semantics would be mis-weighted — the existing prompt already documents the meaning of every other pattern for exactly this reason. Adding MM7 blind would degrade the digest rather than improve it.
+
+**Independent Test**: Submit a triage payload containing an asset whose only pattern is an MM7 break, on a flat trend. Verify the agent does not return it as "high" conviction. Submit a second payload where the MM7 break direction agrees with a strongly-inclined MA50 slope alongside another directional pattern, and verify it ranks above the isolated case.
+
+**Acceptance Scenarios**:
+
+1. **Given** an asset whose only alert is an MM7 break, **When** the digest is produced, **Then** that asset is never assigned "high" conviction on the strength of the break alone.
+2. **Given** an MM7 break whose direction agrees with the sign of the asset's MA50 slope, **When** the digest is produced, **Then** the rationale treats it as a continuation trigger and counts it as directional evidence.
+3. **Given** an MM7 break whose direction opposes the sign of the asset's MA50 slope, **When** the digest is produced, **Then** the rationale treats it as an early warning on an intact trend and does not describe it as a confirmed reversal.
+
+---
+
+### User Story 3 - View the new alert alongside existing alerts (Priority: P2)
+
+The trader wants the new alert delivered through the channels already in use — the Slack digest, the alerts API, and the alerts UI — so it needs no separate workflow to monitor.
+
+**Why this priority**: Delivery layer. The detection is useless if it is not visible where the trader already looks, but it depends on P1 existing first.
+
+**Independent Test**: Trigger detection on an asset meeting the conditions, then verify the alert appears in the alerts UI list with a readable label and in the on-demand `POST /api/alerts/run` JSON response.
+
+**Acceptance Scenarios**:
+
+1. **Given** an asset that produced an MM7 break, **When** the alerts UI page renders, **Then** the alert is displayed with a human-readable label rather than its raw type string.
+2. **Given** the on-demand `POST /api/alerts/run` endpoint is called on a matching asset, **When** the response is returned, **Then** the JSON includes the new alert with its data payload, in the same shape as other alerts.
+
+---
+
+### Edge Cases
+
+- **Insufficient history**: Fewer than 10 candles (7 for the average plus the 3-candle streak) means the break cannot be established; the alert MUST be silently skipped and the scan MUST continue with the other assets.
+- **Graze**: A close that crosses the MM7 but stays within the distance threshold is not a break. Crossing alone is too common to be evidence.
+- **Chop**: Price oscillating around a flat MM7 produces crossings on most days. The streak requirement is what excludes them; without it the alert would fire on a large share of the universe daily and dilute the digest.
+- **Streak counting runs out of history**: When counting the prior run reaches the point where a full MM7 can no longer be computed, counting stops there. An asset with exactly 10 candles can therefore reach — but not exceed — the minimum streak.
+- **Both directions on the same asset**: Mutually exclusive by construction; a single close cannot be more than 0.5% above and below the same average.
+- **Duplicate detection**: One alert of this type per asset per day, consistent with the deduplication policy applied to the other alert types.
+- **Asset without country code**: A Binance asset (no country code) MUST be eligible for this alert like any other, as long as its candle history supports the computation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recognize a new alert type representing "the latest close broke through the 7-period moving average" as a first-class member of the `AlertType` enum, with a stable string value usable across DynamoDB persistence, Slack output, and API responses.
+- **FR-002**: System MUST detect this alert during the existing per-asset detection pipeline (`run_detection_for_asset`), reusing the candle series already loaded for that asset — no extra Saxo API calls.
+- **FR-003**: System MUST compute the 7-period average with the existing `mobile_average` function, evaluated at the offset of the candle being judged.
+- **FR-004**: System MUST emit the alert when **both** of the following hold:
+  - The latest close clears the current MM7 by **more than 0.5%** in absolute distance (below it for a bearish break, above it for a bullish one).
+  - The **3 candles preceding it** each closed on the opposite side of their own MM7 (at or above for a bearish break, at or below for a bullish one).
+- **FR-005**: System MUST assign each emitted alert a direction using the existing `Direction` enum — `Sell` for a breakdown from above, `Buy` for a reclaim from below — carried inside the alert data rather than split across two alert types.
+- **FR-006**: System MUST NOT emit the alert when fewer than 10 candles are available; the asset MUST be skipped without aborting the scan, and a detector that cannot run MUST NOT prevent the other detectors' alerts from being stored.
+- **FR-007**: Each emitted alert MUST carry, at minimum: latest close, current MM7 value, previous close, previous MM7 value, signed distance percentage, direction, the observed streak length, and the asset's MA50 slope (the field the alerts UI sorts on).
+- **FR-008**: System MUST deduplicate emitted alerts of the new type using the existing same-alert-type-same-date rule.
+- **FR-009**: The triage agent's pattern semantics MUST describe the new alert as a short-term timing trigger, read against the **sign** of the MA50 slope: agreeing = continuation trigger and genuine directional evidence; opposing = early warning on an intact trend, explicitly not a reversal thesis.
+- **FR-010**: The triage agent MUST NOT assign "high" conviction to an asset whose only evidence is an MM7 break, however clean the break.
+- **FR-011**: The alerts UI MUST render the new alert type with a human-readable label, without breaking the layout used by the other alert types.
+- **FR-012**: The new alert MUST be eligible on all assets currently processed by the alerting pipeline (French stocks fetched from Saxo, follow-up stocks, and Binance assets).
+
+### Key Entities
+
+- **MM7 Break Alert**: A new member of the `AlertType` enum. Conceptually it represents "the latest close crossed decisively through the 7-period moving average, ending a run of at least 3 candles on the other side". It carries close, MM7, previous close, previous MM7, signed distance %, direction, streak length, and MA50 slope as its data payload, and lives alongside CONGESTION20, CONGESTION100, COMBO, DOUBLE_TOP, DOUBLE_BOTTOM, DOUBLE_INSIDE_BAR, CONTAINING_CANDLE, and MM50_TOUCH in the alerts table.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a hand-curated test set of assets that broke their MM7 decisively after a run on the other side, every one produces the alert with the correct direction — no false negatives.
+- **SC-002**: On a hand-curated test set of assets that only grazed the MM7 or that chopped around it, none produces the alert — no false positives.
+- **SC-003**: The share of scanned assets carrying an MM7 break on a normal trading day stays low enough that the alert reads as evidence rather than background — comparable in order of magnitude to the other detectors, not a large fraction of the universe. This is the criterion to re-check on the first live runs; the distance and streak thresholds are the levers if it is exceeded.
+- **SC-004**: The daily alerting job shows no measurable regression in duration or error rate versus the previous run, since the detector reuses the already-loaded candles.
+- **SC-005**: A reader of the Slack digest or the alerts UI can tell at a glance which direction the break went and how far price cleared the average.
+
+## Assumptions
+
+- The 0.5% distance threshold is **exclusive** (a break must clear it, not merely equal it) and the 3-candle streak is **inclusive** (exactly 3 qualifying candles is enough).
+- The "other side" test for the prior candles is inclusive of touching the average: a close exactly equal to its MM7 counts as being on that side and does not interrupt the streak. A candle sitting exactly on the average has not left the side it came from.
+- Both thresholds are derived from the shape of the existing detectors rather than from measured hit rates on the live universe; they are expected to be re-tuned after the first live runs (see SC-003) and are therefore expressed as named constants.
+- This alert applies to daily candles, consistent with every other alert type produced by the alerting job. Other unit times are out of scope.
+- This is a detection + delivery feature. It does not place orders, create workflows, or modify any trading behavior.
+- The feature reuses the existing alerting pipeline, DynamoDB `alerts` table, Slack delivery, alerts API, and alerts UI — no new infrastructure.
+- The deterministic triage fallback needs no change: the new alert forms its own pattern family, and a single family already caps at "watch" there, satisfying FR-010 on the fallback path as well.

--- a/specs/027-mm7-break-alert/spec.md
+++ b/specs/027-mm7-break-alert/spec.md
@@ -89,7 +89,8 @@ The trader wants the new alert delivered through the channels already in use —
 - **FR-008**: System MUST deduplicate emitted alerts of the new type using the existing same-alert-type-same-date rule.
 - **FR-009**: The triage agent's pattern semantics MUST describe the new alert as a short-term timing trigger, read against the **sign** of the MA50 slope: agreeing = continuation trigger and genuine directional evidence; opposing = early warning on an intact trend, explicitly not a reversal thesis.
 - **FR-010**: The triage agent MUST NOT assign "high" conviction to an asset whose only evidence is an MM7 break, however clean the break.
-- **FR-011**: The alerts UI MUST render the new alert type with a human-readable label, without breaking the layout used by the other alert types.
+- **FR-011**: The alerts UI MUST render the new alert type with a human-readable label, without breaking the layout used by the other alert types. The label MUST be the same wherever the alert type is displayed — filter list and alert card alike.
+- **FR-013**: The deterministic triage fallback MUST NOT let an MM7 break contribute to the confluence count that promotes an asset to "high". An asset that fired one structural pattern before MUST NOT change tier merely because it also broke its MM7.
 - **FR-012**: The new alert MUST be eligible on all assets currently processed by the alerting pipeline (French stocks fetched from Saxo, follow-up stocks, and Binance assets).
 
 ### Key Entities
@@ -104,7 +105,7 @@ The trader wants the new alert delivered through the channels already in use —
 - **SC-002**: On a hand-curated test set of assets that only grazed the MM7 or that chopped around it, none produces the alert — no false positives.
 - **SC-003**: The share of scanned assets carrying an MM7 break on a normal trading day stays low enough that the alert reads as evidence rather than background — comparable in order of magnitude to the other detectors, not a large fraction of the universe. This is the criterion to re-check on the first live runs; the distance and streak thresholds are the levers if it is exceeded.
 - **SC-004**: The daily alerting job shows no measurable regression in duration or error rate versus the previous run, since the detector reuses the already-loaded candles.
-- **SC-005**: A reader of the Slack digest or the alerts UI can tell at a glance which direction the break went and how far price cleared the average.
+- **SC-005**: A reader of the Slack digest or the alerts UI can tell at a glance which direction the break went and how far price cleared the average — without expanding the raw data payload.
 
 ## Assumptions
 
@@ -114,4 +115,5 @@ The trader wants the new alert delivered through the channels already in use —
 - This alert applies to daily candles, consistent with every other alert type produced by the alerting job. Other unit times are out of scope.
 - This is a detection + delivery feature. It does not place orders, create workflows, or modify any trading behavior.
 - The feature reuses the existing alerting pipeline, DynamoDB `alerts` table, Slack delivery, alerts API, and alerts UI — no new infrastructure.
-- The deterministic triage fallback needs no change: the new alert forms its own pattern family, and a single family already caps at "watch" there, satisfying FR-010 on the fallback path as well.
+- `distance_pct` is measured against an MM7 that includes the breaking candle, so the breaking close drags the average ~1/7 of the way toward itself and the measured distance is systematically smaller than the distance from the pre-break average. This matches how `mm50_touch` measures proximity, and makes the 0.5% gate slightly stricter than the plain reading of "clear the average by 0.5%". It is a factor when re-tuning under SC-003; the payload carries `previous_mm7` for anyone who wants the other measure.
+- The deterministic triage fallback treats MM7 as a timing trigger excluded from the confluence count (FR-013). A lone MM7 break therefore lands in "noise" on the fallback path — with reasoning unavailable, a bare timing trigger is not actionable — while the alert itself is still stored and shown in the UI.

--- a/specs/027-mm7-break-alert/tasks.md
+++ b/specs/027-mm7-break-alert/tasks.md
@@ -66,6 +66,14 @@ result; feed it a graze and a chop series and confirm `None`.
   `None` on a graze inside the distance threshold, `None` on chop that breaks
   the streak, `None` below the candle minimum (SC-001, SC-002). **Done**: 5
   tests in `TestMm7Break`, using the file's existing `_make_candles` helper.
+- [x] **T014** [P] [US1] Pin the threshold boundaries the spec calls out as
+  assumptions. **Done**: 4 more tests — exactly 0.5% returns `None` (exclusive)
+  with a companion that fires just past it on the same shape, so the distance
+  gate is isolated from the streak; a 2-candle prior run returns `None` (the
+  chop test only ever produced a 1-candle run, so `MM7_BREAK_MIN_STREAK` was
+  never exercised from below); and a strictly one-sided run fires, since both
+  happy-path tests satisfied the streak only through the equality branch.
+  Raised in review of PR #693.
 - [x] **T005** [US1] Wire the detector into `run_detection_for_asset` in
   `saxo_order/commands/alerting.py`, after the `MM50_TOUCH` block and before the
   `store_alerts` call, going through the existing `detect(...)` /`_safe_detect`
@@ -101,12 +109,21 @@ alongside another directional pattern must rank above it.
   on an intact trend, explicitly not a reversal); never sufficient alone for
   "high" (FR-009, FR-010). **Done**: written to the same line-width convention
   as the surrounding prompt text.
-- [x] **T008** [US2] Confirm the deterministic fallback satisfies FR-010
-  without code changes — `_PATTERN_FAMILY` leaves `MM7_BREAK` its own family and
-  `_fallback_conviction` caps a single family at `watch`. **Done**: verified by
-  reading `_fallback_conviction`, not assumed. No change required, which is why
-  no fallback test was added — the existing single-family test already covers
-  the path.
+- [x] **T008** [US2] ~~Confirm the deterministic fallback satisfies FR-010
+  without code changes.~~ **Superseded by T011 — the original conclusion was
+  wrong.** It checked only the lone-MM7 case (1 family → `watch`, FR-010 holds)
+  and missed the co-firing case: an asset with one existing family that also
+  breaks its MM7 reached `family_count >= 2` and was promoted `watch` → `high`.
+  Raised in review of PR #693.
+- [x] **T011** [US2] Exclude timing patterns from the fallback confluence count
+  in `services/alert_triage_service.py` (FR-013): add `_TIMING_PATTERNS =
+  {AlertType.MM7_BREAK}` and `_structural_families()`, and use the structural
+  count in `_fallback_conviction`, `_fallback_rationale`, and the ranking sort.
+  **Done**: the `watch` gate moved from `family_count == 1` to
+  `structural_count >= 1` so an asset that co-fires MM7 keeps the tier it had
+  before this feature rather than dropping to `noise` through the `== 1` test.
+  3 tests added to `tests/services/test_alert_triage_service.py` (no promotion
+  on co-fire, lone MM7 → `noise`, two structural patterns still → `high`).
 
 ---
 
@@ -115,12 +132,27 @@ alongside another directional pattern must rank above it.
 **Goal**: the alert reads clearly wherever the trader already looks.
 
 - [x] **T009** [P] [US3] Add `mm7_break: 'MM7 Break'` to `ALERT_TYPE_LABELS` in
-  `frontend/src/pages/Alerts.tsx` (FR-011). **Done**: `mm50_touch: 'MM50 Touch'`
-  was missing from the same map and was added in the same edit — without it that
-  alert rendered as its raw type string. No API, DynamoDB, or Slack change is
-  needed: the alerts endpoints are generic over `AlertType.value`, `data` is a
-  free-form dict, and `format_slack_digest` renders triaged assets rather than
-  enumerating alert types.
+  `frontend/src/pages/Alerts.tsx` (FR-011). **Done**, but the note that it fixed
+  `mm50_touch` "everywhere" was wrong: that map feeds only the filter dropdown.
+  See T012. No API, DynamoDB, or Slack change is needed: the alerts endpoints
+  are generic over `AlertType.value`, `data` is a free-form dict, and
+  `format_slack_digest` renders triaged assets rather than enumerating alert
+  types.
+- [x] **T012** [US3] Extract the label map into
+  `frontend/src/utils/alertLabels.ts` as a single exported `getAlertTypeLabel`,
+  and use it in both `Alerts.tsx` and `AlertCard.tsx` (FR-011). **Done**: the
+  card had its own `formatAlertType` that title-cased the raw value, so the
+  filter said "MM7 Break" while the badge said "Mm7 Break". The helper falls
+  back to title-casing for unmapped types, so no alert type can regress to raw
+  snake_case. `double_bottom` was missing from the map and was added. Raised in
+  review of PR #693.
+- [x] **T013** [US3] Surface `direction` and `distance_pct` on the alert card in
+  `frontend/src/components/AlertCard.tsx` (SC-005). **Done**: a Direction row
+  beside the MA50 slope, coloured green for `Buy` / red for `Sell`, showing the
+  signed distance beside it. Previously both fields were only visible by
+  expanding the raw JSON dump, so SC-005 was not met by the UI. The row is
+  generic over any alert carrying `direction`, so `combo` gains it too. Raised
+  in review of PR #693.
 
 ---
 

--- a/specs/027-mm7-break-alert/tasks.md
+++ b/specs/027-mm7-break-alert/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: MM7 Break Alert
+
+**Input**: Design documents from `/specs/027-mm7-break-alert/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md)
+
+**Tests**: included. Detector thresholds are arithmetic on candles with no UI
+to eyeball, the constitution's testing standards apply, and the spec's SC-001 /
+SC-002 (no false negatives on decisive breaks, no false positives on grazes and
+chop) map one-to-one onto unit tests.
+
+**Status**: T001-T009 are **done** — implemented, reviewed against the
+constitution, committed on `claude/triage-agent-ma7-alerting-mypata`, and
+pushed. T010 is the one open task: it needs a live run and cannot be closed
+from the repo.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different files, no dependency on another
+  incomplete task.
+- **[Story]**: US1 (P1, detect the break), US2 (P1, triage weighs it
+  correctly), US3 (P2, visible in the existing channels).
+
+---
+
+## Phase 1: Foundation — shared vocabulary
+
+**Purpose**: the enum member every later phase refers to. Changes no behavior
+on its own.
+
+- [x] **T001** Add `MM7_BREAK = "mm7_break"` to the `AlertType` enum in
+  `model/enum.py`, after `MM50_TOUCH`, keeping the snake_case lowercase value
+  convention. **Done**: single additive member; the value is the string that
+  reaches DynamoDB, the API, and the UI label map.
+
+**Checkpoint**: US1 and US3 can begin.
+
+---
+
+## Phase 2: User Story 1 — Detect the break (P1) 🎯 MVP
+
+**Goal**: emit an `MM7_BREAK` alert when the latest close clears its MM7 by more
+than 0.5% and the 3 prior candles each closed on the other side.
+
+**Independent Test**: feed `mm7_break` a series whose last close is 4% below a
+7-MA that the 3 prior candles closed above, and confirm a `Direction.SELL`
+result; feed it a graze and a chop series and confirm `None`.
+
+- [x] **T002** [US1] Add the constants `MM7_PERIOD = 7`,
+  `MM7_BREAK_MIN_DISTANCE = 0.005`, `MM7_BREAK_MIN_STREAK = 3`, and the derived
+  `MM7_BREAK_MIN_CANDLES = MM7_PERIOD + MM7_BREAK_MIN_STREAK` to
+  `services/indicator_service.py`, beside the `MM50_TOUCH_*` constants
+  (plan §Key Design Decisions 4; FR-004). **Done**: the minimum candle count is
+  derived rather than a literal `10`, so re-tuning the streak cannot silently
+  desync the history requirement.
+- [x] **T003** [US1] Implement `_mm7_at`, `_mm7_streak`, and
+  `mm7_break(candles) -> Optional[Dict[str, Any]]` in
+  `services/indicator_service.py` (FR-003, FR-004, FR-005, FR-006, FR-007).
+  Pure function, no I/O, no input mutation. Returns `close`, `mm7`,
+  `previous_close`, `previous_mm7`, `distance_pct`, `direction`, `streak`.
+  **Done**: direction uses `Direction.SELL` / `Direction.BUY` from the existing
+  enum rather than a `"up"`/`"down"` string (CLAUDE.md); the MM7 is evaluated at
+  each candle's own offset (plan §Key Design Decisions 2); `_mm7_streak` stops
+  when history runs short instead of raising.
+- [x] **T004** [P] [US1] Add detector unit tests to
+  `tests/services/test_indicator_service.py`: bearish break, bullish reclaim,
+  `None` on a graze inside the distance threshold, `None` on chop that breaks
+  the streak, `None` below the candle minimum (SC-001, SC-002). **Done**: 5
+  tests in `TestMm7Break`, using the file's existing `_make_candles` helper.
+- [x] **T005** [US1] Wire the detector into `run_detection_for_asset` in
+  `saxo_order/commands/alerting.py`, after the `MM50_TOUCH` block and before the
+  `store_alerts` call, going through the existing `detect(...)` /`_safe_detect`
+  wrapper so a detector that cannot run never costs the other detectors their
+  alerts (FR-002, FR-006). Merge `ma50_slope` into the alert `data` (FR-007).
+  Depends on T001, T003. **Done**: mirrors the `MM50_TOUCH` block exactly; no
+  extra Saxo call — reuses the candles already loaded by `_build_candles`.
+- [x] **T006** [P] [US1] Add pipeline tests to
+  `tests/saxo_order/commands/test_alerting.py`: the alert is emitted with the
+  expected direction, payload fields, and `ma50_slope`, and `store_alerts` is
+  awaited; no alert when price hugs a flat average. **Done**: 2 tests in
+  `TestRunDetectionForAssetMM7Break`, reusing the file's `patched_alerting`
+  fixture.
+
+**Checkpoint**: the detector fires and persists — US1 is independently
+shippable at this point.
+
+---
+
+## Phase 3: User Story 2 — Triage weighs the break correctly (P1)
+
+**Goal**: the agent treats MM7 as a short-term timing trigger, not a thesis.
+
+**Independent Test**: an asset whose only pattern is an MM7 break on a flat
+trend must not come back "high"; the same break agreeing with a steep slope
+alongside another directional pattern must rank above it.
+
+- [x] **T007** [US2] Add the `mm7_break` pattern-semantics entry to
+  `TRIAGE_SYSTEM_PROMPT` in `services/alert_triage_service.py`, in the same
+  block as the `mm50_touch` and `double_top` entries: directional but
+  short-term; weighed against the **sign** of `ma50_slope` (agreeing =
+  continuation trigger and real directional evidence, opposing = early warning
+  on an intact trend, explicitly not a reversal); never sufficient alone for
+  "high" (FR-009, FR-010). **Done**: written to the same line-width convention
+  as the surrounding prompt text.
+- [x] **T008** [US2] Confirm the deterministic fallback satisfies FR-010
+  without code changes — `_PATTERN_FAMILY` leaves `MM7_BREAK` its own family and
+  `_fallback_conviction` caps a single family at `watch`. **Done**: verified by
+  reading `_fallback_conviction`, not assumed. No change required, which is why
+  no fallback test was added — the existing single-family test already covers
+  the path.
+
+---
+
+## Phase 4: User Story 3 — Visible in the existing channels (P2)
+
+**Goal**: the alert reads clearly wherever the trader already looks.
+
+- [x] **T009** [P] [US3] Add `mm7_break: 'MM7 Break'` to `ALERT_TYPE_LABELS` in
+  `frontend/src/pages/Alerts.tsx` (FR-011). **Done**: `mm50_touch: 'MM50 Touch'`
+  was missing from the same map and was added in the same edit — without it that
+  alert rendered as its raw type string. No API, DynamoDB, or Slack change is
+  needed: the alerts endpoints are generic over `AlertType.value`, `data` is a
+  free-form dict, and `format_slack_digest` renders triaged assets rather than
+  enumerating alert types.
+
+---
+
+## Phase 5: Acceptance — live calibration
+
+- [ ] **T010** Check the first live runs against spec **SC-003**: count how many
+  scanned assets carry an `mm7_break` per day. If the count is a large fraction
+  of the universe rather than a handful, raise `MM7_BREAK_MIN_DISTANCE` and/or
+  `MM7_BREAK_MIN_STREAK` (both single-line changes in
+  `services/indicator_service.py`) and re-check. **Open** — the thresholds were
+  calibrated from the shape of the neighbouring detectors, not from measured hit
+  rates, so this is the real acceptance evidence for the feature, not a
+  formality. It cannot be closed from the repo.
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (T001) ─┬─> Phase 2 (T002-T006) ─> Phase 5 (T010)
+                ├─> Phase 3 (T007-T008)
+                └─> Phase 4 (T009)
+```
+
+- **T003 → T002**; **T005 → T001, T003**; **T006 → T005**.
+- Phases 3 and 4 depend only on T001 and are independent of Phase 2 and of each
+  other.
+- T010 depends on Phase 2 being deployed, not merely merged.
+
+## Parallel opportunities
+
+- T004 and T006 are test files independent of each other.
+- T007 (prompt) and T009 (frontend label) touch different files and neither
+  blocks the other.
+
+## MVP scope
+
+**Phases 1-2 (T001-T006) are the MVP** — the alert fires, carries its direction,
+and persists. Phase 3 is what makes the feature deliver on its stated
+motivation (improving the triage agent) rather than merely adding a row to the
+alerts table; it is P1 for that reason. Phase 4 is cosmetic. Phase 5 is the only
+thing that can confirm the thresholds were set right.

--- a/tests/saxo_order/commands/test_alerting.py
+++ b/tests/saxo_order/commands/test_alerting.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from model import AlertType, Candle, UnitTime
+from model import AlertType, Candle, Direction, UnitTime
 from saxo_order.commands.alerting import run_detection_for_asset
 from utils.exception import SaxoException
 
@@ -146,6 +146,66 @@ class TestRunDetectionForAssetMM50Touch:
         assert len(mm50_alerts) == 1
         assert mm50_alerts[0].country_code is None
         assert mm50_alerts[0].exchange == "binance"
+
+
+class TestRunDetectionForAssetMM7Break:
+
+    async def test_emits_mm7_break_when_conditions_met(self, patched_alerting):
+        # close 95 under a 7-MA near 99.3, after 3 candles closing above it
+        candles = _make_candles([95.0] + [100.0] * 9)
+        patched_alerting.patch(
+            "saxo_order.commands.alerting._build_candles",
+            return_value=candles,
+        )
+        saxo_client = MagicMock()
+        dynamodb_client = MagicMock()
+        dynamodb_client.store_alerts = AsyncMock()
+
+        alerts = await run_detection_for_asset(
+            asset_code="TST",
+            country_code="xpar",
+            exchange="saxo",
+            asset_description="Test Asset",
+            saxo_uic=12345,
+            saxo_client=saxo_client,
+            dynamodb_client=dynamodb_client,
+        )
+
+        mm7_alerts = [a for a in alerts if a.alert_type == AlertType.MM7_BREAK]
+        assert len(mm7_alerts) == 1
+        data = mm7_alerts[0].data
+        assert data["direction"] == Direction.SELL.value
+        assert data["close"] == 95.0
+        assert data["distance_pct"] < 0
+        assert data["streak"] >= 3
+        assert "mm7" in data
+        assert "ma50_slope" in data
+        assert mm7_alerts[0].asset_code == "TST"
+        dynamodb_client.store_alerts.assert_awaited_once()
+
+    async def test_no_mm7_break_when_price_hugs_the_average(
+        self, patched_alerting
+    ):
+        candles = _make_candles([100.0] * 60)
+        patched_alerting.patch(
+            "saxo_order.commands.alerting._build_candles",
+            return_value=candles,
+        )
+        saxo_client = MagicMock()
+        dynamodb_client = MagicMock()
+        dynamodb_client.store_alerts = AsyncMock()
+
+        alerts = await run_detection_for_asset(
+            asset_code="FLAT",
+            country_code="xpar",
+            exchange="saxo",
+            asset_description="Flat Asset",
+            saxo_uic=12345,
+            saxo_client=saxo_client,
+            dynamodb_client=dynamodb_client,
+        )
+
+        assert all(a.alert_type != AlertType.MM7_BREAK for a in alerts)
 
 
 class TestStockDeduplication:

--- a/tests/services/test_alert_triage_service.py
+++ b/tests/services/test_alert_triage_service.py
@@ -229,6 +229,46 @@ def test_fallback_treats_congestion20_and_100_as_one_family() -> None:
     assert asset.rank is None
 
 
+def test_fallback_does_not_let_mm7_break_promote_to_high() -> None:
+    # mm7_break is a short-term timing trigger, and crossing the MM7 is
+    # ordinary - if it counted toward confluence it would promote every
+    # single-pattern WATCH asset that happened to cross, inflating the tier
+    # the prompt explicitly tells the reasoning path not to inflate.
+    alerts = [
+        _alert("SAN", AlertType.CONGESTION20, 3.0),
+        _alert("SAN", AlertType.MM7_BREAK, 3.0),
+    ]
+    digest = TriageAgent(
+        FailingAnthropicClient(), slope_threshold=1.0
+    ).synthesize(alerts)
+
+    asset = digest.triaged_assets[0]
+    assert asset.conviction == Conviction.WATCH
+    assert "mm7_break" in asset.rationale
+
+
+def test_fallback_treats_a_lone_mm7_break_as_noise() -> None:
+    alerts = [_alert("SAN", AlertType.MM7_BREAK, 8.0)]
+    digest = TriageAgent(
+        FailingAnthropicClient(), slope_threshold=1.0
+    ).synthesize(alerts)
+
+    asset = digest.triaged_assets[0]
+    assert asset.conviction == Conviction.NOISE
+    assert asset.rank is None
+
+
+def test_fallback_still_promotes_two_structural_patterns() -> None:
+    alerts = [
+        _alert("SAN", AlertType.DOUBLE_TOP, -2.3),
+        _alert("SAN", AlertType.MM50_TOUCH, -2.3),
+        _alert("SAN", AlertType.MM7_BREAK, -2.3),
+    ]
+    digest = TriageAgent(FailingAnthropicClient()).synthesize(alerts)
+
+    assert digest.triaged_assets[0].conviction == Conviction.HIGH
+
+
 def test_fallback_slope_threshold_is_configurable() -> None:
     alerts = [_alert("TTE", AlertType.CONGESTION20, 1.5)]
 

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -1092,3 +1092,39 @@ class TestMm7Break:
 
     def test_none_when_not_enough_candles(self):
         assert mm7_break(_make_candles([95.0] + [100.0] * 8)) is None
+
+    def test_none_at_exactly_the_distance_threshold(self):
+        # mm7 is exactly 100.0 and the close exactly 0.5% under it, so the
+        # threshold is exclusive: clearing it is required, equalling it is not
+        # enough. The streak is satisfied here - the companion test below
+        # fires on the same shape once the close moves past the threshold -
+        # so this pins the distance gate alone.
+        candles = _make_candles([99.5, 100.5] + [100.0] * 8)
+
+        assert mm7_break(candles) is None
+
+    def test_fires_just_past_the_distance_threshold(self):
+        result = mm7_break(_make_candles([99.4, 100.5] + [100.0] * 8))
+
+        assert result is not None
+        assert result["distance_pct"] < -0.5
+
+    def test_none_when_the_prior_run_is_one_candle_short(self):
+        # candles 1 and 2 close above their own MM7, candle 3 closes below
+        # its own - a 2-candle run, one short of MM7_BREAK_MIN_STREAK
+        candles = _make_candles([90.0, 101.0, 101.0, 99.0] + [100.0] * 9)
+
+        assert mm7_break(candles) is None
+
+    def test_fires_on_a_strictly_one_sided_run(self):
+        # every prior close is strictly above its own MM7 - the happy-path
+        # tests above satisfy the streak through the equality branch only
+        candles = _make_candles(
+            [80.0, 106.0, 105.0, 104.0, 103.0, 102.0, 101.0, 100.0, 99.0, 98.0]
+        )
+
+        result = mm7_break(candles)
+
+        assert result is not None
+        assert result["direction"] == Direction.SELL.value
+        assert result["streak"] >= 3

--- a/tests/services/test_indicator_service.py
+++ b/tests/services/test_indicator_service.py
@@ -26,6 +26,7 @@ from services.indicator_service import (
     is_far_from_levels,
     is_price_within_bands,
     macd0lag,
+    mm7_break,
     mm50_touch,
     number_of_day_between_dates,
     slope_percentage,
@@ -1055,3 +1056,39 @@ class TestAdx:
         # period * 3 = 42 required; 41 is one short
         with pytest.raises(SaxoException):
             adx(_trending_daily(41))
+
+
+class TestMm7Break:
+
+    def test_breakdown_below_average(self):
+        # close 95 against a 7-MA near 99.3 → ~-4.3%, after 3 candles above
+        result = mm7_break(_make_candles([95.0] + [100.0] * 9))
+
+        assert result is not None
+        assert result["direction"] == Direction.SELL.value
+        assert result["close"] == 95.0
+        assert result["distance_pct"] < 0
+        assert result["streak"] >= 3
+
+    def test_reclaim_above_average(self):
+        result = mm7_break(_make_candles([105.0] + [100.0] * 9))
+
+        assert result is not None
+        assert result["direction"] == Direction.BUY.value
+        assert result["distance_pct"] > 0
+        assert result["streak"] >= 3
+
+    def test_none_when_close_only_grazes_the_average(self):
+        # ~-0.43%, inside MM7_BREAK_MIN_DISTANCE
+        assert mm7_break(_make_candles([99.5] + [100.0] * 9)) is None
+
+    def test_none_when_price_chops_around_the_average(self):
+        # alternating closes → the previous candles never hold one side
+        candles = _make_candles(
+            [90.0, 100.0, 95.0, 100.0, 95.0, 100.0, 95.0, 100.0, 95.0, 100.0]
+        )
+
+        assert mm7_break(candles) is None
+
+    def test_none_when_not_enough_candles(self):
+        assert mm7_break(_make_candles([95.0] + [100.0] * 8)) is None


### PR DESCRIPTION
Breaking the 7-period moving average flags a short-term change of
character, which the daily scan had no detector for.

A raw MA7 cross fires on a large share of the universe every day, so the
detector qualifies it: the close has to clear the average by 0.5% and the
previous 3 candles must all have closed on the other side. That keeps
chop around a flat average out of the digest, the same way mm50_touch
gates on proximity and slope.

The triage prompt gets the pattern semantics it needs to weigh it: a
short-term timing trigger, not a thesis, read against the sign of
ma50_slope, and never enough on its own for a "high" conviction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RgW8qZTKpHXDcuc9H5yQLK