### PR TITLE
test: gate golden regeneration and decouple the market fixture

### DIFF
--- a/api/services/backtest/__init__.py
+++ b/api/services/backtest/__init__.py
@@ -26,6 +26,7 @@ from api.services.backtest.calendar import (
     is_today_not_yet_closed,
     paris_reference_window_utc,
     paris_session_end_utc,
+    paris_session_start_utc,
     session_key,
 )
 from api.services.backtest.candles import candle_date
@@ -57,6 +58,7 @@ __all__ = [
     "overnight_gap",
     "paris_reference_window_utc",
     "paris_session_end_utc",
+    "paris_session_start_utc",
     "resolve_parameters",
     "session_key",
 ]

--- a/tests/api/services/backtest/market_fixture.py
+++ b/tests/api/services/backtest/market_fixture.py
@@ -1,9 +1,16 @@
 """Deterministic synthetic market for the backtest golden tests.
 
-Builds reproducible H1 / 5-minute / daily candle series from a seeded RNG so
-a full BacktestService run can be snapshotted and compared across a
-refactor. Every series is a pure function of (instrument, date), so the
-snapshot is stable regardless of the order or range a test asks for.
+Draws one seeded 5-minute price path per (instrument, day) across the
+widest session any backtest trades, and serves whatever timeframe and
+window a caller asks for by aggregating it. Every series is a pure
+function of (instrument, date), so the snapshot is stable regardless of
+the order or range a test asks for.
+
+Deliberately knows nothing about strategies. It used to answer in the
+shapes the strategies of the day happened to ask for - one H1 reference
+candle, a post-10:00 5-minute scan - which meant a backtest with a new
+shape could not be added without editing the market, and a combo
+definition saw 21 candles where its indicator needed 235.
 """
 
 import datetime
@@ -12,8 +19,11 @@ import random
 from typing import List, Tuple
 from unittest.mock import MagicMock
 
-from api.services.backtest import paris_reference_window_utc
-from model import Candle, EUMarket, UnitTime
+from api.services.backtest import (
+    paris_session_end_utc,
+    paris_session_start_utc,
+)
+from model import Candle, DaxCfdMarket, UnitTime
 from services.candles_service import CandlesService
 
 # (base price, 5-minute step sigma) per instrument. GER40's sigma is scaled
@@ -31,15 +41,12 @@ NO_DATA_DATES = {datetime.date(2026, 3, 11), datetime.date(2026, 4, 8)}
 GOLDEN_START = datetime.date(2026, 3, 2)
 GOLDEN_END = datetime.date(2026, 4, 30)
 
-H1_STEPS = 12
-SESSION_STEPS = 90
+# Resolution the day's price path is drawn at - the finest any backtest
+# asks for. Everything coarser is aggregated from it.
+BASE_HORIZON = 5
 
-# Minutes per candle for the timeframes the combo backtests run on.
-COMBO_HORIZONS = {UnitTime.M5: 5, UnitTime.M15: 15, UnitTime.H1: 60}
-
-# Shortest window only a combo backtest asks for. Its 02:00-22:00 day is
-# 20 hours; the widest a session backtest asks for is 10:00-22:00 (12).
-COMBO_WINDOW_MIN = datetime.timedelta(hours=15)
+# Minutes per candle for each timeframe a backtest can request.
+HORIZONS = {UnitTime.M5: 5, UnitTime.M15: 15, UnitTime.H1: 60}
 
 
 def _rng(instrument: str, d: datetime.date, tag: str) -> random.Random:
@@ -79,35 +86,29 @@ def _session_open_price(instrument: str, d: datetime.date) -> float:
     return base + drift + noise
 
 
-def h1_reference_candle(instrument: str, d: datetime.date) -> Candle:
-    """The 9h-10h reference candle, aggregated from the first hour's walk."""
+def base_bars(instrument: str, d: datetime.date) -> List[Candle]:
+    """The day's price path as 5-minute candles across the widest session
+    any backtest trades (02:00-22:00 Paris).
+
+    One path per (instrument, day), sampled - never re-drawn - by
+    `candles_in_window`. This is what keeps the fixture a *market* rather
+    than a set of answers shaped like the questions the current
+    strategies happen to ask: a new strategy on a new timeframe reads the
+    same prices as every existing one, and adding it touches nothing
+    here.
+    """
     _, sigma = INSTRUMENT_PROFILE[instrument]
+    session_start = paris_session_start_utc(d, DaxCfdMarket())
+    session_end = paris_session_end_utc(d, DaxCfdMarket())
+    steps = int((session_end - session_start).total_seconds() // 60) // (
+        BASE_HORIZON
+    )
     bars = _walk(
-        _rng(instrument, d, "h1"),
+        _rng(instrument, d, "base"),
         _session_open_price(instrument, d),
         sigma,
-        H1_STEPS,
+        steps,
     )
-    start, _ = paris_reference_window_utc(d, EUMarket())
-    return Candle(
-        lower=round(min(bar[2] for bar in bars), 2),
-        higher=round(max(bar[1] for bar in bars), 2),
-        open=bars[0][0],
-        close=bars[-1][3],
-        ut=UnitTime.H1,
-        date=start,
-    )
-
-
-def m5_session_candles(instrument: str, d: datetime.date) -> List[Candle]:
-    """The post-10h session as 5-minute candles, continuing from the
-    reference candle's close."""
-    _, sigma = INSTRUMENT_PROFILE[instrument]
-    reference = h1_reference_candle(instrument, d)
-    bars = _walk(
-        _rng(instrument, d, "m5"), reference.close, sigma, SESSION_STEPS
-    )
-    _, session_start = paris_reference_window_utc(d, EUMarket())
     return [
         Candle(
             lower=bar[2],
@@ -115,10 +116,53 @@ def m5_session_candles(instrument: str, d: datetime.date) -> List[Candle]:
             open=bar[0],
             close=bar[3],
             ut=UnitTime.M5,
-            date=session_start + datetime.timedelta(minutes=5 * index),
+            date=session_start
+            + datetime.timedelta(minutes=BASE_HORIZON * index),
         )
         for index, bar in enumerate(bars)
     ]
+
+
+def candles_in_window(
+    instrument: str,
+    d: datetime.date,
+    ut: UnitTime,
+    start: datetime.datetime,
+    end: datetime.datetime,
+) -> List[Candle]:
+    """The day's base path aggregated to `ut` and cut to [start, end).
+
+    Buckets are anchored to midnight rather than to the window, so the
+    same clock minute always falls in the same candle whatever window it
+    is asked for - a 09:00-10:00 request and a 02:00-22:00 request agree
+    on the 09:00 hourly candle.
+    """
+    horizon = HORIZONS.get(ut, BASE_HORIZON)
+    buckets: dict = {}
+    for bar in base_bars(instrument, d):
+        if bar.date is None or not (start <= bar.date < end):
+            continue
+        minute_of_day = bar.date.hour * 60 + bar.date.minute
+        key = minute_of_day // horizon
+        buckets.setdefault(key, []).append(bar)
+
+    candles = []
+    for key in sorted(buckets):
+        group = buckets[key]
+        candles.append(
+            Candle(
+                lower=round(min(bar.lower for bar in group), 2),
+                higher=round(max(bar.higher for bar in group), 2),
+                open=group[0].open,
+                close=group[-1].close,
+                ut=ut,
+                date=datetime.datetime.combine(
+                    group[0].date.date(), datetime.time()
+                )
+                + datetime.timedelta(minutes=key * horizon),
+            )
+        )
+    return candles
 
 
 def daily_candles(
@@ -156,70 +200,19 @@ def daily_candles(
     return candles
 
 
-def timeframe_session_candles(
-    instrument: str,
-    d: datetime.date,
-    ut: UnitTime,
-    start: datetime.datetime,
-    end: datetime.datetime,
-) -> List[Candle]:
-    """A session's worth of candles at an arbitrary timeframe, for the
-    combo backtests - which read a whole day at 5m, 15m or H1 rather than
-    a reference candle plus a 5-minute scan.
-
-    Drifting rather than driftless: a pure random walk almost never
-    produces the sloping ma50 the combo indicator requires, so the golden
-    market would exercise the strategy's plumbing and none of its rules.
-    The drift alternates by day so both directions are covered.
-    """
-    horizon = COMBO_HORIZONS[ut]
-    steps = max(1, int((end - start).total_seconds() // (60 * horizon)))
-    base, sigma = INSTRUMENT_PROFILE[instrument]
-    rng = _rng(instrument, d, f"combo-{ut.value}")
-    drift = (1 if d.toordinal() % 2 else -1) * sigma * 0.35
-    price = _session_open_price(instrument, d)
-    candles: List[Candle] = []
-    for index in range(steps):
-        open_price = price
-        close = open_price + drift + rng.gauss(0, sigma)
-        candles.append(
-            Candle(
-                lower=round(
-                    min(open_price, close) - abs(rng.gauss(0, sigma / 2)), 2
-                ),
-                higher=round(
-                    max(open_price, close) + abs(rng.gauss(0, sigma / 2)), 2
-                ),
-                open=round(open_price, 2),
-                close=round(close, 2),
-                ut=ut,
-                date=start + datetime.timedelta(minutes=horizon * index),
-            )
-        )
-        price = close
-    return candles
-
-
 def golden_candles_service() -> MagicMock:
     """A CandlesService stub serving the synthetic market."""
     service = MagicMock(spec=CandlesService)
 
     def get_candles_in_window(code, ut, horizon, start, end):
+        """Whatever the caller asks for, sampled from the day's one price
+        path. Nothing here branches on which strategy is asking - that
+        coupling is what made this fixture need editing every time a
+        backtest with a new shape was added."""
         trading_date = start.date()
         if trading_date in NO_DATA_DATES:
             return []
-        # Only a combo backtest asks for a whole 02:00-22:00 DAX CFD day
-        # (20 hours). The session backtests ask for the 1-hour reference
-        # window and then a post-10:00 5-minute scan of at most 12 hours,
-        # so the width of the window is what separates them - not the
-        # timeframe, which M5 shares.
-        if end - start >= COMBO_WINDOW_MIN:
-            return timeframe_session_candles(
-                code, trading_date, ut, start, end
-            )
-        if ut == UnitTime.H1:
-            return [h1_reference_candle(code, trading_date)]
-        return m5_session_candles(code, trading_date)
+        return candles_in_window(code, trading_date, ut, start, end)
 
     def build_candles(code, ut, market, count, reference):
         return daily_candles(code, reference.date(), count)

--- a/tests/api/services/backtest/test_backtest_golden.py
+++ b/tests/api/services/backtest/test_backtest_golden.py
@@ -10,6 +10,16 @@ net that proves behavior is unchanged.
 Regenerate the snapshot only when a behavior change is intended:
 
     poetry run python -m tests.api.services.backtest.test_backtest_golden
+
+That writes new definitions freely but REFUSES to change one already in
+the file, printing what moved instead. Changing a shipped definition
+needs its code named:
+
+    ... test_backtest_golden --accept G9H,B9HTC
+
+Regenerating makes this file pass by construction, so the gate is the
+only thing standing between "I regenerated it" and a silent behavior
+change nobody reviewed.
 """
 
 import dataclasses
@@ -41,27 +51,10 @@ GOLDEN_FILE = (
 # miss/no-op, so the golden run always exercises the fetch path.
 NO_CACHE_CLIENT = DynamoDBClient(dynamodb_resource=None)
 
-# Day the detail snapshot is taken on. Picked because every definition
-# resolves it to a traded day, so the per-trade detail is non-trivial.
-DETAIL_DATE = datetime.date(2026, 3, 3)
-
-# Definitions the synthetic market cannot make trade, and why. Listed
-# rather than silently skipped: an empty snapshot proves nothing about
-# the definition, so each entry here is a known gap in the net.
-#
-# C1H: the combo indicator fires only 5 times across the whole golden
-# range at H1, and FR-C10 declines both entries those produce. That is
-# the strategy behaving as specified, not a fixture problem - a combo
-# buys a pullback towards the ma50, and in a trending market the ma50
-# sits *above* the mm20, so TP1 is already behind the entry. Worth
-# re-checking against real GER40 data before reading anything into an
-# H1 run.
-NO_TRADE_ON_GOLDEN_MARKET = {"C1H"}
-
-# The combo backtests hold positions for days, so a trade opened before
-# DETAIL_DATE and closed after it leaves that day showing none - correct
-# under FR-C15's entry-day attribution, not a missing result.
-NO_DETAIL_DAY_TRADE = {"C5M", "C15M", "C1H"}
+# Day the detail snapshot is taken on. Picked because every definition -
+# including the three combo ones, whose positions can span days - resolves
+# it to a traded day, so the per-trade detail is non-trivial everywhere.
+DETAIL_DATE = datetime.date(2026, 4, 10)
 
 
 def _service() -> BacktestService:
@@ -168,16 +161,10 @@ async def test_golden_market_actually_produces_trades(snapshot):
     """Guards the net itself: a snapshot of all-zero runs would pass every
     comparison while testing nothing."""
     for code, entry in snapshot.items():
-        if code in NO_TRADE_ON_GOLDEN_MARKET:
-            continue
         assert entry["run"]["summary"]["number_of_trades"] > 0, (
             f"{code} produced no trades - the golden market is not "
             "exercising the strategy"
         )
-
-    for code, entry in snapshot.items():
-        if code in NO_DETAIL_DAY_TRADE:
-            continue
         assert entry["day_detail"][
             "trades"
         ], f"{code} has no trades on the detail day {DETAIL_DATE}"
@@ -195,22 +182,139 @@ async def test_golden_market_actually_produces_trades(snapshot):
     ), "no two-lot aggregate trade in the double take-profit detail day"
 
 
-def _regenerate() -> None:
+def _summary_line(code: str, entry: Dict[str, Any]) -> str:
+    summary = entry["run"]["summary"]
+    return (
+        f"{code}: {summary['number_of_days']} days, "
+        f"{summary['number_of_trades']} trades, "
+        f"result {summary['final_result']}, "
+        f"exits {sorted(entry['exit_reasons'])}"
+    )
+
+
+def _describe_change(
+    code: str, before: Dict[str, Any], after: Dict[str, Any]
+) -> str:
+    """What moved for one definition, in the terms a reviewer judges a
+    strategy change in: trade count, result and the exit mix."""
+    old_summary = before["run"]["summary"]
+    new_summary = after["run"]["summary"]
+    fields = (
+        "number_of_trades",
+        "number_of_winning_positions",
+        "number_of_losing_positions",
+        "number_of_be",
+        "final_result",
+    )
+    moved = [
+        f"      {field}: {old_summary[field]} -> {new_summary[field]}"
+        for field in fields
+        if old_summary[field] != new_summary[field]
+    ]
+    if set(before["exit_reasons"]) != set(after["exit_reasons"]):
+        moved.append(
+            f"      exits: {sorted(before['exit_reasons'])} -> "
+            f"{sorted(after['exit_reasons'])}"
+        )
+    if not moved:
+        moved.append(
+            "      summary identical - the per-day rows or per-trade "
+            "detail moved"
+        )
+    return f"    {code}\n" + "\n".join(moved)
+
+
+def _regenerate(accepted: set) -> int:
+    """Rewrite the snapshot, refusing to change an existing definition
+    that was not named on the command line.
+
+    The whole value of this file is that it fails when behavior moves -
+    and regenerating makes it pass by construction. So a regeneration
+    that would silently rewrite a shipped definition's numbers is the one
+    thing that must not be one keystroke away. Adding a definition is
+    free; changing one has to be said out loud.
+    """
     import asyncio
+    import logging
+
+    # NO_CACHE_CLIENT logs a warning per cache call, which is two per
+    # definition per day - tens of thousands of lines burying the one
+    # thing this command exists to show.
+    logging.disable(logging.WARNING)
+
+    snapshot = asyncio.run(_build_snapshot())
+    golden = (
+        json.loads(GOLDEN_FILE.read_text()) if GOLDEN_FILE.exists() else {}
+    )
+
+    added = sorted(set(snapshot) - set(golden))
+    removed = sorted(set(golden) - set(snapshot))
+    changed = sorted(
+        code
+        for code in set(golden) & set(snapshot)
+        if golden[code] != snapshot[code]
+    )
+    unauthorized = [
+        code
+        for code in changed
+        if code not in accepted and "all" not in accepted
+    ]
+
+    if unauthorized:
+        print(
+            "REFUSED: these definitions already exist in the snapshot and "
+            "their results changed:\n"
+        )
+        for code in unauthorized:
+            print(_describe_change(code, golden[code], snapshot[code]))
+        print(
+            "\nIf the change is intended, name them:\n"
+            f"    python -m {__spec__.name} --accept "
+            f"{','.join(unauthorized)}\n"
+            "If it is not, this is the regression the snapshot exists to "
+            "catch - fix the code, not the file."
+        )
+        return 1
 
     GOLDEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    snapshot = asyncio.run(_build_snapshot())
     GOLDEN_FILE.write_text(json.dumps(snapshot, indent=2, sort_keys=True))
     print(f"Wrote {GOLDEN_FILE}")
+    if added:
+        print(f"  added: {', '.join(added)}")
+    if removed:
+        print(f"  removed: {', '.join(removed)}")
+    if changed:
+        print(f"  changed (accepted): {', '.join(changed)}")
+        for code in changed:
+            print(_describe_change(code, golden[code], snapshot[code]))
+    if not (added or removed or changed):
+        print("  no change")
     for code, entry in snapshot.items():
-        summary = entry["run"]["summary"]
-        print(
-            f"  {code}: {summary['number_of_days']} days, "
-            f"{summary['number_of_trades']} trades, "
-            f"result {summary['final_result']}, "
-            f"exits {sorted(entry['exit_reasons'])}"
-        )
+        print(f"  {_summary_line(code, entry)}")
+    return 0
 
 
 if __name__ == "__main__":
-    _regenerate()
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate the backtest golden snapshot. New definitions are "
+            "written freely; changing an existing one requires naming it."
+        )
+    )
+    parser.add_argument(
+        "--accept",
+        default="",
+        help=(
+            "Comma-separated definition codes whose results may change, "
+            "or 'all'."
+        ),
+    )
+    args = parser.parse_args()
+    sys.exit(
+        _regenerate(
+            {code.strip() for code in args.accept.split(",") if code.strip()}
+        )
+    )

--- a/tests/api/services/backtest/test_golden_regeneration.py
+++ b/tests/api/services/backtest/test_golden_regeneration.py
@@ -1,0 +1,145 @@
+"""The regeneration gate.
+
+Regenerating the golden snapshot makes it pass by construction, so the
+gate is the only thing between "I regenerated it" and a behavior change
+nobody reviewed. It therefore needs testing itself - an unguarded
+regenerate looks identical to a guarded one right up until it silently
+rewrites a shipped definition's numbers.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tests.api.services.backtest import test_backtest_golden as golden
+
+
+def entry(trades, result, exits=("stop_loss",)):
+    return {
+        "run": {
+            "summary": {
+                "number_of_days": 42,
+                "number_of_trades": trades,
+                "number_of_winning_positions": trades,
+                "number_of_losing_positions": 0,
+                "number_of_be": 0,
+                "final_result": result,
+            }
+        },
+        "exit_reasons": {name: {"count": 1} for name in exits},
+    }
+
+
+@pytest.fixture
+def golden_file(tmp_path):
+    path = tmp_path / "backtest_golden.json"
+    with patch.object(golden, "GOLDEN_FILE", path):
+        yield path
+
+
+def regenerate(built, accepted=frozenset()):
+    async def _build():
+        return built
+
+    with patch.object(golden, "_build_snapshot", _build):
+        return golden._regenerate(set(accepted))
+
+
+class TestUnchangedAndNew:
+    def test_an_identical_rebuild_writes_and_succeeds(self, golden_file):
+        snapshot = {"B9H": entry(10, 100.0)}
+        golden_file.write_text(json.dumps(snapshot))
+        assert regenerate(snapshot) == 0
+
+    def test_a_new_definition_needs_no_permission(self, golden_file):
+        """Adding a backtest is the common case and must stay one
+        command - it changes nothing that already existed."""
+        golden_file.write_text(json.dumps({"B9H": entry(10, 100.0)}))
+        built = {"B9H": entry(10, 100.0), "C5M": entry(5, 50.0)}
+        assert regenerate(built) == 0
+        assert set(json.loads(golden_file.read_text())) == {"B9H", "C5M"}
+
+    def test_a_missing_file_is_written_from_scratch(self, golden_file):
+        assert regenerate({"B9H": entry(10, 100.0)}) == 0
+        assert golden_file.exists()
+
+
+class TestChangedDefinitions:
+    def test_a_changed_definition_is_refused(self, golden_file):
+        golden_file.write_text(json.dumps({"B9H": entry(10, 100.0)}))
+        assert regenerate({"B9H": entry(11, 250.0)}) == 1
+
+    def test_the_file_is_left_untouched_when_refused(self, golden_file):
+        """The refusal has to be total: a half-written file would be
+        worse than either outcome."""
+        before = json.dumps({"B9H": entry(10, 100.0)})
+        golden_file.write_text(before)
+        regenerate({"B9H": entry(11, 250.0)})
+        assert golden_file.read_text() == before
+
+    def test_naming_it_allows_the_change(self, golden_file):
+        golden_file.write_text(json.dumps({"B9H": entry(10, 100.0)}))
+        assert regenerate({"B9H": entry(11, 250.0)}, {"B9H"}) == 0
+        assert (
+            json.loads(golden_file.read_text())["B9H"]["run"]["summary"][
+                "final_result"
+            ]
+            == 250.0
+        )
+
+    def test_naming_a_different_one_does_not_help(self, golden_file):
+        golden_file.write_text(
+            json.dumps({"B9H": entry(10, 100.0), "G9H": entry(8, 80.0)})
+        )
+        built = {"B9H": entry(11, 250.0), "G9H": entry(8, 80.0)}
+        assert regenerate(built, {"G9H"}) == 1
+
+    def test_all_accepts_everything(self, golden_file):
+        golden_file.write_text(
+            json.dumps({"B9H": entry(10, 100.0), "G9H": entry(8, 80.0)})
+        )
+        built = {"B9H": entry(11, 250.0), "G9H": entry(9, 90.0)}
+        assert regenerate(built, {"all"}) == 0
+
+    def test_a_change_outside_the_summary_is_still_caught(self, golden_file):
+        """Two runs can agree on every summary figure and still differ in
+        the per-day rows or a trade's exit price - the snapshot compares
+        the whole entry, so the gate must too."""
+        before = entry(10, 100.0)
+        after = entry(10, 100.0)
+        after["run"]["days"] = [{"date": "2026-03-02"}]
+        golden_file.write_text(json.dumps({"B9H": before}))
+        assert regenerate({"B9H": after}) == 1
+
+
+class TestRefusalMessage:
+    def test_it_names_the_definition_and_what_moved(self, golden_file, capsys):
+        golden_file.write_text(json.dumps({"B9H": entry(10, 100.0)}))
+        regenerate({"B9H": entry(11, 250.0)})
+        out = capsys.readouterr().out
+        assert "B9H" in out
+        assert "number_of_trades: 10 -> 11" in out
+        assert "final_result: 100.0 -> 250.0" in out
+
+    def test_it_prints_the_command_that_would_accept_it(
+        self, golden_file, capsys
+    ):
+        golden_file.write_text(json.dumps({"B9H": entry(10, 100.0)}))
+        regenerate({"B9H": entry(11, 250.0)})
+        assert "--accept B9H" in capsys.readouterr().out
+
+    def test_it_reports_an_exit_mix_change(self, golden_file, capsys):
+        golden_file.write_text(
+            json.dumps({"B9H": entry(10, 100.0, ("stop_loss",))})
+        )
+        regenerate({"B9H": entry(10, 100.0, ("take_profit",))})
+        assert "exits:" in capsys.readouterr().out
+
+    def test_it_says_so_when_only_the_detail_moved(self, golden_file, capsys):
+        before = entry(10, 100.0)
+        after = entry(10, 100.0)
+        after["run"]["days"] = [{"date": "2026-03-02"}]
+        golden_file.write_text(json.dumps({"B9H": before}))
+        regenerate({"B9H": after})
+        assert "summary identical" in capsys.readouterr().out

--- a/tests/api/services/files/backtest_golden.json
+++ b/tests/api/services/files/backtest_golden.json
@@ -2,57 +2,48 @@
   "B9H": {
     "day_detail": {
       "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 8210.29,
-      "h1_low": 8156.04,
-      "h1_open": 8163.75,
+      "date": "2026-04-10",
+      "h1_high": 8257.77,
+      "h1_low": 8205.86,
+      "h1_open": 8228.06,
       "status": "traded",
       "trades": [
         {
           "direction": "Sell",
-          "entry_price": 8199.13,
-          "entry_time": "2026-03-03T10:10:00",
-          "exit_price": 8249.13,
+          "entry_price": 8252.23,
+          "entry_time": "2026-04-10T08:40:00",
+          "exit_price": 8215.86,
+          "exit_reason": "take_profit",
+          "exit_time": "2026-04-10T08:50:00",
+          "points": 36.37
+        },
+        {
+          "direction": "Buy",
+          "entry_price": 8207.83,
+          "entry_time": "2026-04-10T09:15:00",
+          "exit_price": 8157.83,
           "exit_reason": "stop_loss",
-          "exit_time": "2026-03-03T10:50:00",
+          "exit_time": "2026-04-10T09:50:00",
           "points": -50.0
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 8198.03,
-          "entry_time": "2026-03-03T14:25:00",
-          "exit_price": 8209.74,
-          "exit_reason": "break_even",
-          "exit_time": "2026-03-03T14:40:00",
-          "points": -11.71
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 8200.41,
-          "entry_time": "2026-03-03T16:20:00",
-          "exit_price": 8202.5,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": -2.09
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 16,
-        "points": -11.71
+        "count": 15,
+        "points": 0.0
       },
       "end_of_day": {
         "count": 9,
-        "points": -96.8
+        "points": 33.01
       },
       "stop_loss": {
-        "count": 24,
-        "points": -1200.0
+        "count": 22,
+        "points": -1100.0
       },
       "take_profit": {
-        "count": 28,
-        "points": 690.87
+        "count": 35,
+        "points": 995.86
       }
     },
     "run": {
@@ -60,179 +51,179 @@
         {
           "adx14": 20.68693,
           "date": "2026-03-02",
-          "h1_high": 8188.37,
-          "h1_low": 8122.91,
-          "h1_open": 8149.33,
+          "h1_high": 8249.27,
+          "h1_low": 8207.32,
+          "h1_open": 8219.98,
           "mm50_slope": 9.6931,
-          "overnight_gap": 37.38,
-          "points": 41.19,
+          "overnight_gap": 108.03,
+          "points": -33.36,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 20.95587,
           "date": "2026-03-03",
-          "h1_high": 8210.29,
-          "h1_low": 8156.04,
-          "h1_open": 8163.75,
+          "h1_high": 8189.63,
+          "h1_low": 8150.29,
+          "h1_open": 8157.89,
           "mm50_slope": 9.86739,
-          "overnight_gap": 37.67,
-          "points": -63.8,
+          "overnight_gap": 31.81,
+          "points": 44.44,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 20.48374,
           "date": "2026-03-04",
-          "h1_high": 8184.15,
-          "h1_low": 8147.73,
-          "h1_open": 8172.07,
+          "h1_high": 8137.59,
+          "h1_low": 8078.93,
+          "h1_open": 8134.64,
           "mm50_slope": 9.80478,
-          "overnight_gap": 58.73,
+          "overnight_gap": 21.3,
+          "points": 26.81,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 20.44942,
+          "date": "2026-03-05",
+          "h1_high": 8200.33,
+          "h1_low": 8140.44,
+          "h1_open": 8170.71,
+          "mm50_slope": 9.96555,
+          "overnight_gap": 22.29,
+          "points": 46.91,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 20.41755,
+          "date": "2026-03-06",
+          "h1_high": 8181.29,
+          "h1_low": 8114.21,
+          "h1_open": 8126.48,
+          "mm50_slope": 10.27915,
+          "overnight_gap": -43.64,
+          "points": 52.4,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.24072,
+          "date": "2026-03-09",
+          "h1_high": 8028.93,
+          "h1_low": 7967.91,
+          "h1_open": 8024.74,
+          "mm50_slope": 10.60541,
+          "overnight_gap": -200.45,
+          "points": 58.74,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 22.0051,
+          "date": "2026-03-10",
+          "h1_high": 8293.56,
+          "h1_low": 8246.14,
+          "h1_open": 8290.89,
+          "mm50_slope": 10.84467,
+          "overnight_gap": 70.66,
+          "points": 15.15,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 20.49304,
+          "date": "2026-03-12",
+          "h1_high": 8331.16,
+          "h1_low": 8290.64,
+          "h1_open": 8325.33,
+          "mm50_slope": 11.36425,
+          "overnight_gap": 106.48,
           "points": -50.0,
           "status": "traded",
           "trade_count": 1
         },
         {
-          "adx14": 20.44942,
-          "date": "2026-03-05",
-          "h1_high": 8180.62,
-          "h1_low": 8136.36,
-          "h1_open": 8161.75,
-          "mm50_slope": 9.96555,
-          "overnight_gap": 13.33,
-          "points": -76.79,
+          "adx14": 19.16377,
+          "date": "2026-03-13",
+          "h1_high": 8158.97,
+          "h1_low": 8121.52,
+          "h1_open": 8142.99,
+          "mm50_slope": 11.29678,
+          "overnight_gap": -47.97,
+          "points": 33.14,
           "status": "traded",
           "trade_count": 3
         },
         {
-          "adx14": 20.41755,
-          "date": "2026-03-06",
-          "h1_high": 8204.18,
-          "h1_low": 8161.76,
-          "h1_open": 8173.53,
-          "mm50_slope": 10.27915,
-          "overnight_gap": 3.41,
-          "points": 14.93,
+          "adx14": 18.32441,
+          "date": "2026-03-16",
+          "h1_high": 8158.36,
+          "h1_low": 8104.68,
+          "h1_open": 8148.02,
+          "mm50_slope": 11.11456,
+          "overnight_gap": -41.74,
+          "points": -50.0,
           "status": "traded",
           "trade_count": 2
         },
         {
-          "adx14": 21.24072,
-          "date": "2026-03-09",
-          "h1_high": 8265.96,
-          "h1_low": 8182.01,
-          "h1_open": 8185.7,
-          "mm50_slope": 10.60541,
-          "overnight_gap": -39.49,
-          "points": 66.57,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.0051,
-          "date": "2026-03-10",
-          "h1_high": 8245.96,
-          "h1_low": 8179.04,
-          "h1_open": 8188.62,
-          "mm50_slope": 10.84467,
-          "overnight_gap": -31.61,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 20.49304,
-          "date": "2026-03-12",
-          "h1_high": 8214.87,
-          "h1_low": 8174.34,
-          "h1_open": 8179.78,
-          "mm50_slope": 11.36425,
-          "overnight_gap": -39.07,
-          "points": 102.87,
-          "status": "traded",
-          "trade_count": 5
-        },
-        {
-          "adx14": 19.16377,
-          "date": "2026-03-13",
-          "h1_high": 8228.38,
-          "h1_low": 8182.93,
-          "h1_open": 8211.85,
-          "mm50_slope": 11.29678,
-          "overnight_gap": 20.89,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 18.32441,
-          "date": "2026-03-16",
-          "h1_high": 8318.61,
-          "h1_low": 8230.5,
-          "h1_open": 8232.2,
-          "mm50_slope": 11.11456,
-          "overnight_gap": 42.44,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
           "adx14": 17.81651,
           "date": "2026-03-17",
-          "h1_high": 8243.02,
-          "h1_low": 8189.2,
-          "h1_open": 8234.87,
+          "h1_high": 8122.9,
+          "h1_low": 8086.55,
+          "h1_open": 8120.44,
           "mm50_slope": 11.14787,
-          "overnight_gap": 11.41,
-          "points": -30.61,
+          "overnight_gap": -103.02,
+          "points": -64.37,
           "status": "traded",
           "trade_count": 4
         },
         {
           "adx14": 17.78505,
           "date": "2026-03-18",
-          "h1_high": 8268.3,
-          "h1_low": 8224.98,
-          "h1_open": 8228.04,
+          "h1_high": 8405.39,
+          "h1_low": 8371.01,
+          "h1_open": 8381.74,
           "mm50_slope": 11.55919,
-          "overnight_gap": -15.73,
+          "overnight_gap": 137.97,
+          "points": -50.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 16.90666,
+          "date": "2026-03-19",
+          "h1_high": 8403.05,
+          "h1_low": 8361.17,
+          "h1_open": 8388.69,
+          "mm50_slope": 11.62155,
+          "overnight_gap": 199.32,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 16.90666,
-          "date": "2026-03-19",
-          "h1_high": 8294.26,
-          "h1_low": 8237.42,
-          "h1_open": 8246.62,
-          "mm50_slope": 11.62155,
-          "overnight_gap": 57.25,
-          "points": -50.0,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
           "adx14": 16.2186,
           "date": "2026-03-20",
-          "h1_high": 8278.91,
-          "h1_low": 8239.33,
-          "h1_open": 8249.41,
+          "h1_high": 8287.69,
+          "h1_low": 8232.28,
+          "h1_open": 8280.96,
           "mm50_slope": 11.65741,
-          "overnight_gap": 15.91,
-          "points": 46.86,
-          "status": "traded",
-          "trade_count": 3
+          "overnight_gap": 47.46,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 15.5797,
           "date": "2026-03-23",
-          "h1_high": 8352.57,
-          "h1_low": 8260.85,
-          "h1_open": 8265.0,
+          "h1_high": 8318.72,
+          "h1_low": 8212.42,
+          "h1_open": 8310.42,
           "mm50_slope": 11.58693,
-          "overnight_gap": 37.09,
+          "overnight_gap": 82.51,
           "points": -50.0,
           "status": "traded",
           "trade_count": 2
@@ -240,23 +231,23 @@
         {
           "adx14": 15.70278,
           "date": "2026-03-24",
-          "h1_high": 8289.21,
-          "h1_low": 8248.08,
-          "h1_open": 8265.37,
+          "h1_high": 8418.62,
+          "h1_low": 8377.73,
+          "h1_open": 8410.46,
           "mm50_slope": 11.53444,
-          "overnight_gap": -18.47,
-          "points": 0.71,
+          "overnight_gap": 126.62,
+          "points": -50.0,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 14.89564,
           "date": "2026-03-25",
-          "h1_high": 8284.13,
-          "h1_low": 8231.82,
-          "h1_open": 8260.45,
+          "h1_high": 8315.32,
+          "h1_low": 8263.2,
+          "h1_open": 8297.67,
           "mm50_slope": 11.4428,
-          "overnight_gap": 31.38,
+          "overnight_gap": 68.6,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -264,251 +255,251 @@
         {
           "adx14": 14.18962,
           "date": "2026-03-26",
-          "h1_high": 8288.32,
-          "h1_low": 8231.81,
-          "h1_open": 8283.36,
+          "h1_high": 8309.55,
+          "h1_low": 8266.57,
+          "h1_open": 8289.78,
           "mm50_slope": 11.07488,
-          "overnight_gap": 50.28,
-          "points": -50.0,
+          "overnight_gap": 56.7,
+          "points": 33.65,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 4
         },
         {
           "adx14": 14.03143,
           "date": "2026-03-27",
-          "h1_high": 8291.96,
-          "h1_low": 8252.34,
-          "h1_open": 8263.06,
+          "h1_high": 8251.99,
+          "h1_low": 8171.41,
+          "h1_open": 8178.17,
           "mm50_slope": 11.00619,
-          "overnight_gap": 4.92,
-          "points": -73.66,
+          "overnight_gap": -79.97,
+          "points": -18.85,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 13.88454,
           "date": "2026-03-30",
-          "h1_high": 8324.42,
-          "h1_low": 8242.38,
-          "h1_open": 8284.58,
+          "h1_high": 8368.06,
+          "h1_low": 8302.63,
+          "h1_open": 8363.27,
           "mm50_slope": 10.92699,
-          "overnight_gap": 20.4,
-          "points": -50.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 14.49578,
-          "date": "2026-03-31",
-          "h1_high": 8312.67,
-          "h1_low": 8274.44,
-          "h1_open": 8280.54,
-          "mm50_slope": 10.85907,
-          "overnight_gap": 13.6,
-          "points": -50.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 15.78292,
-          "date": "2026-04-01",
-          "h1_high": 8288.31,
-          "h1_low": 8228.67,
-          "h1_open": 8273.13,
-          "mm50_slope": 10.87899,
-          "overnight_gap": -48.78,
-          "points": 0.0,
+          "overnight_gap": 99.09,
+          "points": -60.1,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 14.49578,
+          "date": "2026-03-31",
+          "h1_high": 8108.54,
+          "h1_low": 8064.18,
+          "h1_open": 8091.77,
+          "mm50_slope": 10.85907,
+          "overnight_gap": -175.17,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 15.78292,
+          "date": "2026-04-01",
+          "h1_high": 8321.68,
+          "h1_low": 8270.57,
+          "h1_open": 8298.51,
+          "mm50_slope": 10.87899,
+          "overnight_gap": -23.4,
+          "points": 66.3,
+          "status": "traded",
+          "trade_count": 5
+        },
+        {
           "adx14": 16.74136,
           "date": "2026-04-02",
-          "h1_high": 8295.76,
-          "h1_low": 8255.05,
-          "h1_open": 8286.47,
+          "h1_high": 8326.92,
+          "h1_low": 8293.85,
+          "h1_open": 8304.98,
           "mm50_slope": 10.9077,
-          "overnight_gap": -47.31,
-          "points": -22.24,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 17.63134,
-          "date": "2026-04-03",
-          "h1_high": 8298.51,
-          "h1_low": 8259.28,
-          "h1_open": 8279.15,
-          "mm50_slope": 10.73672,
-          "overnight_gap": -3.28,
-          "points": -63.81,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 18.09061,
-          "date": "2026-04-06",
-          "h1_high": 8324.57,
-          "h1_low": 8282.14,
-          "h1_open": 8302.14,
-          "mm50_slope": 10.3997,
-          "overnight_gap": 32.93,
+          "overnight_gap": -28.8,
           "points": -50.0,
           "status": "traded",
           "trade_count": 1
         },
         {
+          "adx14": 17.63134,
+          "date": "2026-04-03",
+          "h1_high": 8492.93,
+          "h1_low": 8424.6,
+          "h1_open": 8453.67,
+          "mm50_slope": 10.73672,
+          "overnight_gap": 171.24,
+          "points": 43.78,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 18.09061,
+          "date": "2026-04-06",
+          "h1_high": 8397.8,
+          "h1_low": 8336.16,
+          "h1_open": 8389.25,
+          "mm50_slope": 10.3997,
+          "overnight_gap": 120.04,
+          "points": 82.72,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
           "adx14": 19.04471,
           "date": "2026-04-07",
-          "h1_high": 8322.97,
-          "h1_low": 8273.32,
-          "h1_open": 8293.31,
+          "h1_high": 8345.36,
+          "h1_low": 8253.71,
+          "h1_open": 8272.45,
           "mm50_slope": 10.04915,
-          "overnight_gap": -7.81,
-          "points": -20.83,
+          "overnight_gap": -28.67,
+          "points": -85.37,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 17.1495,
           "date": "2026-04-09",
-          "h1_high": 8305.19,
-          "h1_low": 8269.47,
-          "h1_open": 8290.06,
+          "h1_high": 8383.93,
+          "h1_low": 8312.27,
+          "h1_open": 8370.56,
           "mm50_slope": 9.81201,
-          "overnight_gap": -24.98,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 55.52,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 16.14678,
           "date": "2026-04-10",
-          "h1_high": 8323.78,
-          "h1_low": 8269.91,
-          "h1_open": 8303.98,
+          "h1_high": 8257.77,
+          "h1_low": 8205.86,
+          "h1_open": 8228.06,
           "mm50_slope": 9.64887,
-          "overnight_gap": 1.49,
-          "points": 16.15,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 15.00886,
-          "date": "2026-04-13",
-          "h1_high": 8297.34,
-          "h1_low": 8246.44,
-          "h1_open": 8290.73,
-          "mm50_slope": 9.59832,
-          "overnight_gap": -4.61,
-          "points": 30.43,
+          "overnight_gap": -74.43,
+          "points": -13.63,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 15.00886,
+          "date": "2026-04-13",
+          "h1_high": 8448.72,
+          "h1_low": 8412.57,
+          "h1_open": 8441.84,
+          "mm50_slope": 9.59832,
+          "overnight_gap": 146.5,
+          "points": -16.71,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
           "adx14": 14.29026,
           "date": "2026-04-14",
-          "h1_high": 8318.01,
-          "h1_low": 8268.99,
-          "h1_open": 8286.19,
+          "h1_high": 8407.59,
+          "h1_low": 8352.95,
+          "h1_open": 8366.52,
           "mm50_slope": 9.41662,
-          "overnight_gap": 3.99,
-          "points": -46.8,
+          "overnight_gap": 84.32,
+          "points": -11.97,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 13.6722,
           "date": "2026-04-15",
-          "h1_high": 8305.94,
-          "h1_low": 8274.54,
-          "h1_open": 8293.46,
+          "h1_high": 8504.86,
+          "h1_low": 8428.95,
+          "h1_open": 8477.1,
           "mm50_slope": 8.86139,
-          "overnight_gap": 18.43,
-          "points": -34.34,
+          "overnight_gap": 202.07,
+          "points": 53.7,
           "status": "traded",
-          "trade_count": 5
+          "trade_count": 1
         },
         {
           "adx14": 12.85521,
           "date": "2026-04-16",
-          "h1_high": 8324.92,
-          "h1_low": 8266.02,
-          "h1_open": 8291.12,
+          "h1_high": 8457.27,
+          "h1_low": 8411.94,
+          "h1_open": 8413.24,
           "mm50_slope": 8.68907,
-          "overnight_gap": -0.46,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 121.66,
+          "points": -53.4,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 12.8341,
           "date": "2026-04-17",
-          "h1_high": 8442.55,
-          "h1_low": 8292.28,
-          "h1_open": 8299.95,
+          "h1_high": 8181.44,
+          "h1_low": 8117.51,
+          "h1_open": 8137.46,
           "mm50_slope": 8.46736,
-          "overnight_gap": 44.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 12.81451,
-          "date": "2026-04-20",
-          "h1_high": 8335.96,
-          "h1_low": 8272.06,
-          "h1_open": 8307.42,
-          "mm50_slope": 8.30536,
-          "overnight_gap": 15.55,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.19065,
-          "date": "2026-04-21",
-          "h1_high": 8321.65,
-          "h1_low": 8285.08,
-          "h1_open": 8300.03,
-          "mm50_slope": 8.25474,
-          "overnight_gap": 25.08,
-          "points": -28.95,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 12.26575,
-          "date": "2026-04-22",
-          "h1_high": 8323.46,
-          "h1_low": 8265.86,
-          "h1_open": 8287.11,
-          "mm50_slope": 8.51329,
-          "overnight_gap": -69.62,
-          "points": -4.65,
+          "overnight_gap": -117.83,
+          "points": 0.0,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 12.81451,
+          "date": "2026-04-20",
+          "h1_high": 8281.77,
+          "h1_low": 8235.88,
+          "h1_open": 8237.19,
+          "mm50_slope": 8.30536,
+          "overnight_gap": -54.68,
+          "points": 19.95,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 13.19065,
+          "date": "2026-04-21",
+          "h1_high": 8243.22,
+          "h1_low": 8192.15,
+          "h1_open": 8239.62,
+          "mm50_slope": 8.25474,
+          "overnight_gap": -35.33,
+          "points": -80.86,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 12.26575,
+          "date": "2026-04-22",
+          "h1_high": 8359.24,
+          "h1_low": 8304.9,
+          "h1_open": 8325.26,
+          "mm50_slope": 8.51329,
+          "overnight_gap": -31.47,
+          "points": -50.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
           "adx14": 11.40692,
           "date": "2026-04-23",
-          "h1_high": 8308.41,
-          "h1_low": 8266.02,
-          "h1_open": 8278.3,
+          "h1_high": 8531.65,
+          "h1_low": 8487.01,
+          "h1_open": 8492.82,
           "mm50_slope": 8.12217,
-          "overnight_gap": -3.47,
-          "points": -20.87,
+          "overnight_gap": 211.05,
+          "points": 74.64,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 4
         },
         {
           "adx14": 11.21079,
           "date": "2026-04-24",
-          "h1_high": 8326.9,
-          "h1_low": 8282.97,
-          "h1_open": 8284.49,
+          "h1_high": 8231.91,
+          "h1_low": 8179.15,
+          "h1_open": 8204.49,
           "mm50_slope": 7.98984,
-          "overnight_gap": 11.84,
+          "overnight_gap": -68.16,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -516,63 +507,63 @@
         {
           "adx14": 11.00451,
           "date": "2026-04-27",
-          "h1_high": 8302.38,
-          "h1_low": 8254.31,
-          "h1_open": 8282.64,
+          "h1_high": 8476.21,
+          "h1_low": 8430.83,
+          "h1_open": 8468.26,
           "mm50_slope": 7.80263,
-          "overnight_gap": 1.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 186.75,
+          "points": 32.88,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.62359,
           "date": "2026-04-28",
-          "h1_high": 8332.03,
-          "h1_low": 8265.38,
-          "h1_open": 8270.99,
+          "h1_high": 8400.25,
+          "h1_low": 8333.87,
+          "h1_open": 8335.96,
           "mm50_slope": 7.50181,
-          "overnight_gap": -10.1,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 54.87,
+          "points": 33.67,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 10.59239,
           "date": "2026-04-29",
-          "h1_high": 8312.44,
-          "h1_low": 8255.53,
-          "h1_open": 8294.86,
+          "h1_high": 8345.08,
+          "h1_low": 8303.84,
+          "h1_open": 8332.16,
           "mm50_slope": 7.41922,
-          "overnight_gap": -42.58,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -5.28,
+          "points": 48.61,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.56341,
           "date": "2026-04-30",
-          "h1_high": 8323.96,
-          "h1_low": 8256.05,
-          "h1_open": 8265.02,
+          "h1_high": 8319.7,
+          "h1_low": 8237.88,
+          "h1_open": 8242.43,
           "mm50_slope": 7.24457,
-          "overnight_gap": -12.2,
-          "points": -100.0,
+          "overnight_gap": -34.79,
+          "points": -50.0,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 2
         }
       ],
       "summary": {
-        "average_loss": 40.625,
-        "average_win": 23.9334,
+        "average_loss": 45.9685,
+        "average_win": 28.1013,
         "definition_code": "B9H",
         "end_date": "2026-04-30",
-        "final_result": -617.64,
-        "number_of_be": 16,
+        "final_result": -71.13,
+        "number_of_be": 15,
         "number_of_days": 42,
-        "number_of_losing_positions": 32,
-        "number_of_trades": 77,
-        "number_of_winning_positions": 29,
+        "number_of_losing_positions": 26,
+        "number_of_trades": 81,
+        "number_of_winning_positions": 40,
         "start_date": "2026-03-02"
       }
     }
@@ -580,61 +571,52 @@
   "B9HTC": {
     "day_detail": {
       "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 8210.29,
-      "h1_low": 8156.04,
-      "h1_open": 8163.75,
+      "date": "2026-04-10",
+      "h1_high": 8257.77,
+      "h1_low": 8205.86,
+      "h1_open": 8228.06,
       "status": "traded",
       "trades": [
         {
           "direction": "Sell",
-          "entry_price": 8199.13,
-          "entry_time": "2026-03-03T10:10:00",
-          "exit_price": 8249.13,
-          "exit_reason": "stop_loss",
-          "exit_time": "2026-03-03T10:50:00",
-          "points": -50.0
+          "entry_price": 8252.23,
+          "entry_time": "2026-04-10T08:40:00",
+          "exit_price": 8215.86,
+          "exit_reason": "take_profit",
+          "exit_time": "2026-04-10T08:50:00",
+          "points": 36.37
         },
         {
-          "direction": "Sell",
-          "entry_price": 8198.03,
-          "entry_time": "2026-03-03T14:25:00",
-          "exit_price": 8209.74,
-          "exit_reason": "break_even",
-          "exit_time": "2026-03-03T14:40:00",
-          "points": -11.71
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 8200.41,
-          "entry_time": "2026-03-03T16:20:00",
-          "exit_price": 8202.5,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": -2.09
+          "direction": "Buy",
+          "entry_price": 8207.83,
+          "entry_time": "2026-04-10T09:15:00",
+          "exit_price": 8163.68,
+          "exit_reason": "time_cut",
+          "exit_time": "2026-04-10T09:45:00",
+          "points": -44.15
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
         "count": 16,
-        "points": -11.71
+        "points": 0.0
       },
       "end_of_day": {
         "count": 7,
-        "points": -54.98
+        "points": 99.24
       },
       "stop_loss": {
-        "count": 18,
-        "points": -900.0
+        "count": 14,
+        "points": -700.0
       },
       "take_profit": {
-        "count": 28,
-        "points": 692.85
+        "count": 33,
+        "points": 930.11
       },
       "time_cut": {
-        "count": 11,
-        "points": -261.03
+        "count": 13,
+        "points": -265.07
       }
     },
     "run": {
@@ -642,179 +624,179 @@
         {
           "adx14": 20.68693,
           "date": "2026-03-02",
-          "h1_high": 8188.37,
-          "h1_low": 8122.91,
-          "h1_open": 8149.33,
+          "h1_high": 8249.27,
+          "h1_low": 8207.32,
+          "h1_open": 8219.98,
           "mm50_slope": 9.6931,
-          "overnight_gap": 37.38,
-          "points": 41.19,
+          "overnight_gap": 108.03,
+          "points": 2.45,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 20.95587,
           "date": "2026-03-03",
-          "h1_high": 8210.29,
-          "h1_low": 8156.04,
-          "h1_open": 8163.75,
+          "h1_high": 8189.63,
+          "h1_low": 8150.29,
+          "h1_open": 8157.89,
           "mm50_slope": 9.86739,
-          "overnight_gap": 37.67,
-          "points": -63.8,
+          "overnight_gap": 31.81,
+          "points": 44.44,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 20.48374,
           "date": "2026-03-04",
-          "h1_high": 8184.15,
-          "h1_low": 8147.73,
-          "h1_open": 8172.07,
+          "h1_high": 8137.59,
+          "h1_low": 8078.93,
+          "h1_open": 8134.64,
           "mm50_slope": 9.80478,
-          "overnight_gap": 58.73,
+          "overnight_gap": 21.3,
+          "points": 26.81,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 20.44942,
+          "date": "2026-03-05",
+          "h1_high": 8200.33,
+          "h1_low": 8140.44,
+          "h1_open": 8170.71,
+          "mm50_slope": 9.96555,
+          "overnight_gap": 22.29,
+          "points": -21.24,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 20.41755,
+          "date": "2026-03-06",
+          "h1_high": 8181.29,
+          "h1_low": 8114.21,
+          "h1_open": 8126.48,
+          "mm50_slope": 10.27915,
+          "overnight_gap": -43.64,
+          "points": 52.4,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.24072,
+          "date": "2026-03-09",
+          "h1_high": 8028.93,
+          "h1_low": 7967.91,
+          "h1_open": 8024.74,
+          "mm50_slope": 10.60541,
+          "overnight_gap": -200.45,
+          "points": 58.74,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 22.0051,
+          "date": "2026-03-10",
+          "h1_high": 8293.56,
+          "h1_low": 8246.14,
+          "h1_open": 8290.89,
+          "mm50_slope": 10.84467,
+          "overnight_gap": 70.66,
+          "points": 53.34,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 20.49304,
+          "date": "2026-03-12",
+          "h1_high": 8331.16,
+          "h1_low": 8290.64,
+          "h1_open": 8325.33,
+          "mm50_slope": 11.36425,
+          "overnight_gap": 106.48,
           "points": -50.0,
           "status": "traded",
           "trade_count": 1
         },
         {
-          "adx14": 20.44942,
-          "date": "2026-03-05",
-          "h1_high": 8180.62,
-          "h1_low": 8136.36,
-          "h1_open": 8161.75,
-          "mm50_slope": 9.96555,
-          "overnight_gap": 13.33,
-          "points": -76.79,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 20.41755,
-          "date": "2026-03-06",
-          "h1_high": 8204.18,
-          "h1_low": 8161.76,
-          "h1_open": 8173.53,
-          "mm50_slope": 10.27915,
-          "overnight_gap": 3.41,
-          "points": 14.93,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.24072,
-          "date": "2026-03-09",
-          "h1_high": 8265.96,
-          "h1_low": 8182.01,
-          "h1_open": 8185.7,
-          "mm50_slope": 10.60541,
-          "overnight_gap": -39.49,
-          "points": 66.57,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.0051,
-          "date": "2026-03-10",
-          "h1_high": 8245.96,
-          "h1_low": 8179.04,
-          "h1_open": 8188.62,
-          "mm50_slope": 10.84467,
-          "overnight_gap": -31.61,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 20.49304,
-          "date": "2026-03-12",
-          "h1_high": 8214.87,
-          "h1_low": 8174.34,
-          "h1_open": 8179.78,
-          "mm50_slope": 11.36425,
-          "overnight_gap": -39.07,
-          "points": 102.87,
-          "status": "traded",
-          "trade_count": 5
-        },
-        {
           "adx14": 19.16377,
           "date": "2026-03-13",
-          "h1_high": 8228.38,
-          "h1_low": 8182.93,
-          "h1_open": 8211.85,
+          "h1_high": 8158.97,
+          "h1_low": 8121.52,
+          "h1_open": 8142.99,
           "mm50_slope": 11.29678,
-          "overnight_gap": 20.89,
-          "points": 0.0,
+          "overnight_gap": -47.97,
+          "points": 33.14,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 3
         },
         {
           "adx14": 18.32441,
           "date": "2026-03-16",
-          "h1_high": 8318.61,
-          "h1_low": 8230.5,
-          "h1_open": 8232.2,
+          "h1_high": 8158.36,
+          "h1_low": 8104.68,
+          "h1_open": 8148.02,
           "mm50_slope": 11.11456,
-          "overnight_gap": 42.44,
-          "points": 0.0,
+          "overnight_gap": -41.74,
+          "points": -50.0,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 17.81651,
           "date": "2026-03-17",
-          "h1_high": 8243.02,
-          "h1_low": 8189.2,
-          "h1_open": 8234.87,
+          "h1_high": 8122.9,
+          "h1_low": 8086.55,
+          "h1_open": 8120.44,
           "mm50_slope": 11.14787,
-          "overnight_gap": 11.41,
-          "points": -68.19,
+          "overnight_gap": -103.02,
+          "points": -62.06,
           "status": "traded",
-          "trade_count": 6
+          "trade_count": 4
         },
         {
           "adx14": 17.78505,
           "date": "2026-03-18",
-          "h1_high": 8268.3,
-          "h1_low": 8224.98,
-          "h1_open": 8228.04,
+          "h1_high": 8405.39,
+          "h1_low": 8371.01,
+          "h1_open": 8381.74,
           "mm50_slope": 11.55919,
-          "overnight_gap": -15.73,
+          "overnight_gap": 137.97,
+          "points": -50.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 16.90666,
+          "date": "2026-03-19",
+          "h1_high": 8403.05,
+          "h1_low": 8361.17,
+          "h1_open": 8388.69,
+          "mm50_slope": 11.62155,
+          "overnight_gap": 199.32,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 16.90666,
-          "date": "2026-03-19",
-          "h1_high": 8294.26,
-          "h1_low": 8237.42,
-          "h1_open": 8246.62,
-          "mm50_slope": 11.62155,
-          "overnight_gap": 57.25,
-          "points": -29.46,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
           "adx14": 16.2186,
           "date": "2026-03-20",
-          "h1_high": 8278.91,
-          "h1_low": 8239.33,
-          "h1_open": 8249.41,
+          "h1_high": 8287.69,
+          "h1_low": 8232.28,
+          "h1_open": 8280.96,
           "mm50_slope": 11.65741,
-          "overnight_gap": 15.91,
-          "points": 46.86,
-          "status": "traded",
-          "trade_count": 3
+          "overnight_gap": 47.46,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 15.5797,
           "date": "2026-03-23",
-          "h1_high": 8352.57,
-          "h1_low": 8260.85,
-          "h1_open": 8265.0,
+          "h1_high": 8318.72,
+          "h1_low": 8212.42,
+          "h1_open": 8310.42,
           "mm50_slope": 11.58693,
-          "overnight_gap": 37.09,
+          "overnight_gap": 82.51,
           "points": -50.0,
           "status": "traded",
           "trade_count": 2
@@ -822,23 +804,23 @@
         {
           "adx14": 15.70278,
           "date": "2026-03-24",
-          "h1_high": 8289.21,
-          "h1_low": 8248.08,
-          "h1_open": 8265.37,
+          "h1_high": 8418.62,
+          "h1_low": 8377.73,
+          "h1_open": 8410.46,
           "mm50_slope": 11.53444,
-          "overnight_gap": -18.47,
-          "points": 40.91,
+          "overnight_gap": 126.62,
+          "points": -32.16,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 14.89564,
           "date": "2026-03-25",
-          "h1_high": 8284.13,
-          "h1_low": 8231.82,
-          "h1_open": 8260.45,
+          "h1_high": 8315.32,
+          "h1_low": 8263.2,
+          "h1_open": 8297.67,
           "mm50_slope": 11.4428,
-          "overnight_gap": 31.38,
+          "overnight_gap": 68.6,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -846,251 +828,251 @@
         {
           "adx14": 14.18962,
           "date": "2026-03-26",
-          "h1_high": 8288.32,
-          "h1_low": 8231.81,
-          "h1_open": 8283.36,
+          "h1_high": 8309.55,
+          "h1_low": 8266.57,
+          "h1_open": 8289.78,
           "mm50_slope": 11.07488,
-          "overnight_gap": 50.28,
-          "points": -50.0,
+          "overnight_gap": 56.7,
+          "points": 33.65,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 4
         },
         {
           "adx14": 14.03143,
           "date": "2026-03-27",
-          "h1_high": 8291.96,
-          "h1_low": 8252.34,
-          "h1_open": 8263.06,
+          "h1_high": 8251.99,
+          "h1_low": 8171.41,
+          "h1_open": 8178.17,
           "mm50_slope": 11.00619,
-          "overnight_gap": 4.92,
-          "points": -73.66,
+          "overnight_gap": -79.97,
+          "points": -18.85,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 13.88454,
           "date": "2026-03-30",
-          "h1_high": 8324.42,
-          "h1_low": 8242.38,
-          "h1_open": 8284.58,
+          "h1_high": 8368.06,
+          "h1_low": 8302.63,
+          "h1_open": 8363.27,
           "mm50_slope": 10.92699,
-          "overnight_gap": 20.4,
-          "points": -0.91,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 14.49578,
-          "date": "2026-03-31",
-          "h1_high": 8312.67,
-          "h1_low": 8274.44,
-          "h1_open": 8280.54,
-          "mm50_slope": 10.85907,
-          "overnight_gap": 13.6,
-          "points": -50.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 15.78292,
-          "date": "2026-04-01",
-          "h1_high": 8288.31,
-          "h1_low": 8228.67,
-          "h1_open": 8273.13,
-          "mm50_slope": 10.87899,
-          "overnight_gap": -48.78,
-          "points": 0.0,
+          "overnight_gap": 99.09,
+          "points": -60.1,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 14.49578,
+          "date": "2026-03-31",
+          "h1_high": 8108.54,
+          "h1_low": 8064.18,
+          "h1_open": 8091.77,
+          "mm50_slope": 10.85907,
+          "overnight_gap": -175.17,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 15.78292,
+          "date": "2026-04-01",
+          "h1_high": 8321.68,
+          "h1_low": 8270.57,
+          "h1_open": 8298.51,
+          "mm50_slope": 10.87899,
+          "overnight_gap": -23.4,
+          "points": 66.3,
+          "status": "traded",
+          "trade_count": 5
+        },
+        {
           "adx14": 16.74136,
           "date": "2026-04-02",
-          "h1_high": 8295.76,
-          "h1_low": 8255.05,
-          "h1_open": 8286.47,
+          "h1_high": 8326.92,
+          "h1_low": 8293.85,
+          "h1_open": 8304.98,
           "mm50_slope": 10.9077,
-          "overnight_gap": -47.31,
-          "points": -46.57,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 17.63134,
-          "date": "2026-04-03",
-          "h1_high": 8298.51,
-          "h1_low": 8259.28,
-          "h1_open": 8279.15,
-          "mm50_slope": 10.73672,
-          "overnight_gap": -3.28,
-          "points": -63.81,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 18.09061,
-          "date": "2026-04-06",
-          "h1_high": 8324.57,
-          "h1_low": 8282.14,
-          "h1_open": 8302.14,
-          "mm50_slope": 10.3997,
-          "overnight_gap": 32.93,
+          "overnight_gap": -28.8,
           "points": -50.0,
           "status": "traded",
           "trade_count": 1
         },
         {
+          "adx14": 17.63134,
+          "date": "2026-04-03",
+          "h1_high": 8492.93,
+          "h1_low": 8424.6,
+          "h1_open": 8453.67,
+          "mm50_slope": 10.73672,
+          "overnight_gap": 171.24,
+          "points": 43.78,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 18.09061,
+          "date": "2026-04-06",
+          "h1_high": 8397.8,
+          "h1_low": 8336.16,
+          "h1_open": 8389.25,
+          "mm50_slope": 10.3997,
+          "overnight_gap": 120.04,
+          "points": 82.72,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
           "adx14": 19.04471,
           "date": "2026-04-07",
-          "h1_high": 8322.97,
-          "h1_low": 8273.32,
-          "h1_open": 8293.31,
+          "h1_high": 8345.36,
+          "h1_low": 8253.71,
+          "h1_open": 8272.45,
           "mm50_slope": 10.04915,
-          "overnight_gap": -7.81,
-          "points": -20.83,
+          "overnight_gap": -28.67,
+          "points": -50.34,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 17.1495,
           "date": "2026-04-09",
-          "h1_high": 8305.19,
-          "h1_low": 8269.47,
-          "h1_open": 8290.06,
+          "h1_high": 8383.93,
+          "h1_low": 8312.27,
+          "h1_open": 8370.56,
           "mm50_slope": 9.81201,
-          "overnight_gap": -24.98,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 55.52,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 16.14678,
           "date": "2026-04-10",
-          "h1_high": 8323.78,
-          "h1_low": 8269.91,
-          "h1_open": 8303.98,
+          "h1_high": 8257.77,
+          "h1_low": 8205.86,
+          "h1_open": 8228.06,
           "mm50_slope": 9.64887,
-          "overnight_gap": 1.49,
-          "points": 16.15,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 15.00886,
-          "date": "2026-04-13",
-          "h1_high": 8297.34,
-          "h1_low": 8246.44,
-          "h1_open": 8290.73,
-          "mm50_slope": 9.59832,
-          "overnight_gap": -4.61,
-          "points": 30.43,
+          "overnight_gap": -74.43,
+          "points": -7.78,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 15.00886,
+          "date": "2026-04-13",
+          "h1_high": 8448.72,
+          "h1_low": 8412.57,
+          "h1_open": 8441.84,
+          "mm50_slope": 9.59832,
+          "overnight_gap": 146.5,
+          "points": 20.73,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
           "adx14": 14.29026,
           "date": "2026-04-14",
-          "h1_high": 8318.01,
-          "h1_low": 8268.99,
-          "h1_open": 8286.19,
+          "h1_high": 8407.59,
+          "h1_low": 8352.95,
+          "h1_open": 8366.52,
           "mm50_slope": 9.41662,
-          "overnight_gap": 3.99,
-          "points": -46.8,
+          "overnight_gap": 84.32,
+          "points": -11.97,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 13.6722,
           "date": "2026-04-15",
-          "h1_high": 8305.94,
-          "h1_low": 8274.54,
-          "h1_open": 8293.46,
+          "h1_high": 8504.86,
+          "h1_low": 8428.95,
+          "h1_open": 8477.1,
           "mm50_slope": 8.86139,
-          "overnight_gap": 18.43,
-          "points": -32.71,
+          "overnight_gap": 202.07,
+          "points": 53.7,
           "status": "traded",
-          "trade_count": 6
+          "trade_count": 1
         },
         {
           "adx14": 12.85521,
           "date": "2026-04-16",
-          "h1_high": 8324.92,
-          "h1_low": 8266.02,
-          "h1_open": 8291.12,
+          "h1_high": 8457.27,
+          "h1_low": 8411.94,
+          "h1_open": 8413.24,
           "mm50_slope": 8.68907,
-          "overnight_gap": -0.46,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 121.66,
+          "points": -72.85,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 12.8341,
           "date": "2026-04-17",
-          "h1_high": 8442.55,
-          "h1_low": 8292.28,
-          "h1_open": 8299.95,
+          "h1_high": 8181.44,
+          "h1_low": 8117.51,
+          "h1_open": 8137.46,
           "mm50_slope": 8.46736,
-          "overnight_gap": 44.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -117.83,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 12.81451,
           "date": "2026-04-20",
-          "h1_high": 8335.96,
-          "h1_low": 8272.06,
-          "h1_open": 8307.42,
+          "h1_high": 8281.77,
+          "h1_low": 8235.88,
+          "h1_open": 8237.19,
           "mm50_slope": 8.30536,
-          "overnight_gap": 15.55,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -54.68,
+          "points": 19.95,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 13.19065,
           "date": "2026-04-21",
-          "h1_high": 8321.65,
-          "h1_low": 8285.08,
-          "h1_open": 8300.03,
+          "h1_high": 8243.22,
+          "h1_low": 8192.15,
+          "h1_open": 8239.62,
           "mm50_slope": 8.25474,
-          "overnight_gap": 25.08,
-          "points": -28.95,
+          "overnight_gap": -35.33,
+          "points": -51.88,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 12.26575,
           "date": "2026-04-22",
-          "h1_high": 8323.46,
-          "h1_low": 8265.86,
-          "h1_open": 8287.11,
+          "h1_high": 8359.24,
+          "h1_low": 8304.9,
+          "h1_open": 8325.26,
           "mm50_slope": 8.51329,
-          "overnight_gap": -69.62,
-          "points": -4.65,
+          "overnight_gap": -31.47,
+          "points": -67.17,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 11.40692,
           "date": "2026-04-23",
-          "h1_high": 8308.41,
-          "h1_low": 8266.02,
-          "h1_open": 8278.3,
+          "h1_high": 8531.65,
+          "h1_low": 8487.01,
+          "h1_open": 8492.82,
           "mm50_slope": 8.12217,
-          "overnight_gap": -3.47,
-          "points": -20.87,
+          "overnight_gap": 211.05,
+          "points": 74.64,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 4
         },
         {
           "adx14": 11.21079,
           "date": "2026-04-24",
-          "h1_high": 8326.9,
-          "h1_low": 8282.97,
-          "h1_open": 8284.49,
+          "h1_high": 8231.91,
+          "h1_low": 8179.15,
+          "h1_open": 8204.49,
           "mm50_slope": 7.98984,
-          "overnight_gap": 11.84,
+          "overnight_gap": -68.16,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1098,63 +1080,63 @@
         {
           "adx14": 11.00451,
           "date": "2026-04-27",
-          "h1_high": 8302.38,
-          "h1_low": 8254.31,
-          "h1_open": 8282.64,
+          "h1_high": 8476.21,
+          "h1_low": 8430.83,
+          "h1_open": 8468.26,
           "mm50_slope": 7.80263,
-          "overnight_gap": 1.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 186.75,
+          "points": 32.88,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.62359,
           "date": "2026-04-28",
-          "h1_high": 8332.03,
-          "h1_low": 8265.38,
-          "h1_open": 8270.99,
+          "h1_high": 8400.25,
+          "h1_low": 8333.87,
+          "h1_open": 8335.96,
           "mm50_slope": 7.50181,
-          "overnight_gap": -10.1,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 54.87,
+          "points": 33.67,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 10.59239,
           "date": "2026-04-29",
-          "h1_high": 8312.44,
-          "h1_low": 8255.53,
-          "h1_open": 8294.86,
+          "h1_high": 8345.08,
+          "h1_low": 8303.84,
+          "h1_open": 8332.16,
           "mm50_slope": 7.41922,
-          "overnight_gap": -42.58,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -5.28,
+          "points": 48.61,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.56341,
           "date": "2026-04-30",
-          "h1_high": 8323.96,
-          "h1_low": 8256.05,
-          "h1_open": 8265.02,
+          "h1_high": 8319.7,
+          "h1_low": 8237.88,
+          "h1_open": 8242.43,
           "mm50_slope": 7.24457,
-          "overnight_gap": -12.2,
-          "points": -66.78,
+          "overnight_gap": -34.79,
+          "points": -11.27,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 2
         }
       ],
       "summary": {
-        "average_loss": 34.8346,
-        "average_win": 24.0017,
+        "average_loss": 34.2766,
+        "average_win": 27.85,
         "definition_code": "B9HTC",
         "end_date": "2026-04-30",
-        "final_result": -534.87,
+        "final_result": 64.28,
         "number_of_be": 16,
         "number_of_days": 42,
-        "number_of_losing_positions": 35,
-        "number_of_trades": 80,
-        "number_of_winning_positions": 29,
+        "number_of_losing_positions": 29,
+        "number_of_trades": 83,
+        "number_of_winning_positions": 38,
         "start_date": "2026-03-02"
       }
     }
@@ -1162,57 +1144,48 @@
   "B9HWS": {
     "day_detail": {
       "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 8210.29,
-      "h1_low": 8156.04,
-      "h1_open": 8163.75,
+      "date": "2026-04-10",
+      "h1_high": 8257.77,
+      "h1_low": 8205.86,
+      "h1_open": 8228.06,
       "status": "traded",
       "trades": [
         {
           "direction": "Sell",
-          "entry_price": 8199.13,
-          "entry_time": "2026-03-03T10:10:00",
-          "exit_price": 8217.54,
+          "entry_price": 8252.23,
+          "entry_time": "2026-04-10T08:40:00",
+          "exit_price": 8215.86,
+          "exit_reason": "take_profit",
+          "exit_time": "2026-04-10T08:50:00",
+          "points": 36.37
+        },
+        {
+          "direction": "Buy",
+          "entry_price": 8207.83,
+          "entry_time": "2026-04-10T09:15:00",
+          "exit_price": 8200.08,
           "exit_reason": "stop_loss",
-          "exit_time": "2026-03-03T10:40:00",
-          "points": -18.41
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 8198.03,
-          "entry_time": "2026-03-03T14:25:00",
-          "exit_price": 8209.74,
-          "exit_reason": "break_even",
-          "exit_time": "2026-03-03T14:40:00",
-          "points": -11.71
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 8200.41,
-          "entry_time": "2026-03-03T16:20:00",
-          "exit_price": 8202.5,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": -2.09
+          "exit_time": "2026-04-10T09:20:00",
+          "points": -7.75
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 14,
-        "points": -11.71
+        "count": 12,
+        "points": 0.0
       },
       "end_of_day": {
-        "count": 4,
-        "points": -4.51
+        "count": 5,
+        "points": 129.83
       },
       "stop_loss": {
-        "count": 41,
-        "points": -611.14
+        "count": 48,
+        "points": -762.43
       },
       "take_profit": {
-        "count": 14,
-        "points": 356.29
+        "count": 20,
+        "points": 592.4
       }
     },
     "run": {
@@ -1220,143 +1193,143 @@
         {
           "adx14": 20.68693,
           "date": "2026-03-02",
-          "h1_high": 8188.37,
-          "h1_low": 8122.91,
-          "h1_open": 8149.33,
+          "h1_high": 8249.27,
+          "h1_low": 8207.32,
+          "h1_open": 8219.98,
           "mm50_slope": 9.6931,
-          "overnight_gap": 37.38,
-          "points": 36.87,
+          "overnight_gap": 108.03,
+          "points": -7.96,
           "status": "traded",
           "trade_count": 3
         },
         {
           "adx14": 20.95587,
           "date": "2026-03-03",
-          "h1_high": 8210.29,
-          "h1_low": 8156.04,
-          "h1_open": 8163.75,
+          "h1_high": 8189.63,
+          "h1_low": 8150.29,
+          "h1_open": 8157.89,
           "mm50_slope": 9.86739,
-          "overnight_gap": 37.67,
-          "points": -32.21,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 20.48374,
-          "date": "2026-03-04",
-          "h1_high": 8184.15,
-          "h1_low": 8147.73,
-          "h1_open": 8172.07,
-          "mm50_slope": 9.80478,
-          "overnight_gap": 58.73,
+          "overnight_gap": 31.81,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 20.44942,
-          "date": "2026-03-05",
-          "h1_high": 8180.62,
-          "h1_low": 8136.36,
-          "h1_open": 8161.75,
-          "mm50_slope": 9.96555,
-          "overnight_gap": 13.33,
-          "points": -16.19,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 20.41755,
-          "date": "2026-03-06",
-          "h1_high": 8204.18,
-          "h1_low": 8161.76,
-          "h1_open": 8173.53,
-          "mm50_slope": 10.27915,
-          "overnight_gap": 3.41,
-          "points": -4.91,
+          "adx14": 20.48374,
+          "date": "2026-03-04",
+          "h1_high": 8137.59,
+          "h1_low": 8078.93,
+          "h1_open": 8134.64,
+          "mm50_slope": 9.80478,
+          "overnight_gap": 21.3,
+          "points": 40.2,
           "status": "traded",
           "trade_count": 4
         },
         {
+          "adx14": 20.44942,
+          "date": "2026-03-05",
+          "h1_high": 8200.33,
+          "h1_low": 8140.44,
+          "h1_open": 8170.71,
+          "mm50_slope": 9.96555,
+          "overnight_gap": 22.29,
+          "points": -22.33,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 20.41755,
+          "date": "2026-03-06",
+          "h1_high": 8181.29,
+          "h1_low": 8114.21,
+          "h1_open": 8126.48,
+          "mm50_slope": 10.27915,
+          "overnight_gap": -43.64,
+          "points": 52.4,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
           "adx14": 21.24072,
           "date": "2026-03-09",
-          "h1_high": 8265.96,
-          "h1_low": 8182.01,
-          "h1_open": 8185.7,
+          "h1_high": 8028.93,
+          "h1_low": 7967.91,
+          "h1_open": 8024.74,
           "mm50_slope": 10.60541,
-          "overnight_gap": -39.49,
-          "points": -30.45,
+          "overnight_gap": -200.45,
+          "points": 58.74,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 22.0051,
           "date": "2026-03-10",
-          "h1_high": 8245.96,
-          "h1_low": 8179.04,
-          "h1_open": 8188.62,
+          "h1_high": 8293.56,
+          "h1_low": 8246.14,
+          "h1_open": 8290.89,
           "mm50_slope": 10.84467,
-          "overnight_gap": -31.61,
+          "overnight_gap": 70.66,
+          "points": 5.14,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 20.49304,
+          "date": "2026-03-12",
+          "h1_high": 8331.16,
+          "h1_low": 8290.64,
+          "h1_open": 8325.33,
+          "mm50_slope": 11.36425,
+          "overnight_gap": 106.48,
+          "points": -55.12,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 19.16377,
+          "date": "2026-03-13",
+          "h1_high": 8158.97,
+          "h1_low": 8121.52,
+          "h1_open": 8142.99,
+          "mm50_slope": 11.29678,
+          "overnight_gap": -47.97,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 20.49304,
-          "date": "2026-03-12",
-          "h1_high": 8214.87,
-          "h1_low": 8174.34,
-          "h1_open": 8179.78,
-          "mm50_slope": 11.36425,
-          "overnight_gap": -39.07,
-          "points": 95.54,
-          "status": "traded",
-          "trade_count": 6
-        },
-        {
-          "adx14": 19.16377,
-          "date": "2026-03-13",
-          "h1_high": 8228.38,
-          "h1_low": 8182.93,
-          "h1_open": 8211.85,
-          "mm50_slope": 11.29678,
-          "overnight_gap": 20.89,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
           "adx14": 18.32441,
           "date": "2026-03-16",
-          "h1_high": 8318.61,
-          "h1_low": 8230.5,
-          "h1_open": 8232.2,
+          "h1_high": 8158.36,
+          "h1_low": 8104.68,
+          "h1_open": 8148.02,
           "mm50_slope": 11.11456,
-          "overnight_gap": 42.44,
-          "points": -11.65,
+          "overnight_gap": -41.74,
+          "points": -102.71,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 5
         },
         {
           "adx14": 17.81651,
           "date": "2026-03-17",
-          "h1_high": 8243.02,
-          "h1_low": 8189.2,
-          "h1_open": 8234.87,
+          "h1_high": 8122.9,
+          "h1_low": 8086.55,
+          "h1_open": 8120.44,
           "mm50_slope": 11.14787,
-          "overnight_gap": 11.41,
-          "points": -38.87,
-          "status": "traded",
-          "trade_count": 6
+          "overnight_gap": -103.02,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 17.78505,
           "date": "2026-03-18",
-          "h1_high": 8268.3,
-          "h1_low": 8224.98,
-          "h1_open": 8228.04,
+          "h1_high": 8405.39,
+          "h1_low": 8371.01,
+          "h1_open": 8381.74,
           "mm50_slope": 11.55919,
-          "overnight_gap": -15.73,
+          "overnight_gap": 137.97,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1364,23 +1337,23 @@
         {
           "adx14": 16.90666,
           "date": "2026-03-19",
-          "h1_high": 8294.26,
-          "h1_low": 8237.42,
-          "h1_open": 8246.62,
+          "h1_high": 8403.05,
+          "h1_low": 8361.17,
+          "h1_open": 8388.69,
           "mm50_slope": 11.62155,
-          "overnight_gap": 57.25,
-          "points": -16.79,
-          "status": "traded",
-          "trade_count": 2
+          "overnight_gap": 199.32,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 16.2186,
           "date": "2026-03-20",
-          "h1_high": 8278.91,
-          "h1_low": 8239.33,
-          "h1_open": 8249.41,
+          "h1_high": 8287.69,
+          "h1_low": 8232.28,
+          "h1_open": 8280.96,
           "mm50_slope": 11.65741,
-          "overnight_gap": 15.91,
+          "overnight_gap": 47.46,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1388,35 +1361,35 @@
         {
           "adx14": 15.5797,
           "date": "2026-03-23",
-          "h1_high": 8352.57,
-          "h1_low": 8260.85,
-          "h1_open": 8265.0,
+          "h1_high": 8318.72,
+          "h1_low": 8212.42,
+          "h1_open": 8310.42,
           "mm50_slope": 11.58693,
-          "overnight_gap": 37.09,
-          "points": -6.41,
+          "overnight_gap": 82.51,
+          "points": -22.44,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 15.70278,
           "date": "2026-03-24",
-          "h1_high": 8289.21,
-          "h1_low": 8248.08,
-          "h1_open": 8265.37,
+          "h1_high": 8418.62,
+          "h1_low": 8377.73,
+          "h1_open": 8410.46,
           "mm50_slope": 11.53444,
-          "overnight_gap": -18.47,
-          "points": 31.21,
+          "overnight_gap": 126.62,
+          "points": -15.01,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 1
         },
         {
           "adx14": 14.89564,
           "date": "2026-03-25",
-          "h1_high": 8284.13,
-          "h1_low": 8231.82,
-          "h1_open": 8260.45,
+          "h1_high": 8315.32,
+          "h1_low": 8263.2,
+          "h1_open": 8297.67,
           "mm50_slope": 11.4428,
-          "overnight_gap": 31.38,
+          "overnight_gap": 68.6,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1424,47 +1397,47 @@
         {
           "adx14": 14.18962,
           "date": "2026-03-26",
-          "h1_high": 8288.32,
-          "h1_low": 8231.81,
-          "h1_open": 8283.36,
+          "h1_high": 8309.55,
+          "h1_low": 8266.57,
+          "h1_open": 8289.78,
           "mm50_slope": 11.07488,
-          "overnight_gap": 50.28,
-          "points": -28.25,
+          "overnight_gap": 56.7,
+          "points": 2.95,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 5
         },
         {
           "adx14": 14.03143,
           "date": "2026-03-27",
-          "h1_high": 8291.96,
-          "h1_low": 8252.34,
-          "h1_open": 8263.06,
+          "h1_high": 8251.99,
+          "h1_low": 8171.41,
+          "h1_open": 8178.17,
           "mm50_slope": 11.00619,
-          "overnight_gap": 4.92,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.88454,
-          "date": "2026-03-30",
-          "h1_high": 8324.42,
-          "h1_low": 8242.38,
-          "h1_open": 8284.58,
-          "mm50_slope": 10.92699,
-          "overnight_gap": 20.4,
-          "points": -20.12,
+          "overnight_gap": -79.97,
+          "points": -18.85,
           "status": "traded",
           "trade_count": 1
         },
         {
+          "adx14": 13.88454,
+          "date": "2026-03-30",
+          "h1_high": 8368.06,
+          "h1_low": 8302.63,
+          "h1_open": 8363.27,
+          "mm50_slope": 10.92699,
+          "overnight_gap": 99.09,
+          "points": -45.72,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
           "adx14": 14.49578,
           "date": "2026-03-31",
-          "h1_high": 8312.67,
-          "h1_low": 8274.44,
-          "h1_open": 8280.54,
+          "h1_high": 8108.54,
+          "h1_low": 8064.18,
+          "h1_open": 8091.77,
           "mm50_slope": 10.85907,
-          "overnight_gap": 13.6,
+          "overnight_gap": -175.17,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1472,203 +1445,203 @@
         {
           "adx14": 15.78292,
           "date": "2026-04-01",
-          "h1_high": 8288.31,
-          "h1_low": 8228.67,
-          "h1_open": 8273.13,
+          "h1_high": 8321.68,
+          "h1_low": 8270.57,
+          "h1_open": 8298.51,
           "mm50_slope": 10.87899,
-          "overnight_gap": -48.78,
-          "points": -31.75,
+          "overnight_gap": -23.4,
+          "points": -13.37,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 8
         },
         {
           "adx14": 16.74136,
           "date": "2026-04-02",
-          "h1_high": 8295.76,
-          "h1_low": 8255.05,
-          "h1_open": 8286.47,
+          "h1_high": 8326.92,
+          "h1_low": 8293.85,
+          "h1_open": 8304.98,
           "mm50_slope": 10.9077,
-          "overnight_gap": -47.31,
-          "points": 10.31,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 17.63134,
-          "date": "2026-04-03",
-          "h1_high": 8298.51,
-          "h1_low": 8259.28,
-          "h1_open": 8279.15,
-          "mm50_slope": 10.73672,
-          "overnight_gap": -3.28,
+          "overnight_gap": -28.8,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
+          "adx14": 17.63134,
+          "date": "2026-04-03",
+          "h1_high": 8492.93,
+          "h1_low": 8424.6,
+          "h1_open": 8453.67,
+          "mm50_slope": 10.73672,
+          "overnight_gap": 171.24,
+          "points": -20.9,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
           "adx14": 18.09061,
           "date": "2026-04-06",
-          "h1_high": 8324.57,
-          "h1_low": 8282.14,
-          "h1_open": 8302.14,
+          "h1_high": 8397.8,
+          "h1_low": 8336.16,
+          "h1_open": 8389.25,
           "mm50_slope": 10.3997,
-          "overnight_gap": 32.93,
-          "points": -23.21,
+          "overnight_gap": 120.04,
+          "points": 82.72,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 19.04471,
           "date": "2026-04-07",
-          "h1_high": 8322.97,
-          "h1_low": 8273.32,
-          "h1_open": 8293.31,
+          "h1_high": 8345.36,
+          "h1_low": 8253.71,
+          "h1_open": 8272.45,
           "mm50_slope": 10.04915,
-          "overnight_gap": -7.81,
-          "points": -53.23,
+          "overnight_gap": -28.67,
+          "points": -21.0,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 2
         },
         {
           "adx14": 17.1495,
           "date": "2026-04-09",
-          "h1_high": 8305.19,
-          "h1_low": 8269.47,
-          "h1_open": 8290.06,
+          "h1_high": 8383.93,
+          "h1_low": 8312.27,
+          "h1_open": 8370.56,
           "mm50_slope": 9.81201,
-          "overnight_gap": -24.98,
+          "overnight_gap": 55.52,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 16.14678,
+          "date": "2026-04-10",
+          "h1_high": 8257.77,
+          "h1_low": 8205.86,
+          "h1_open": 8228.06,
+          "mm50_slope": 9.64887,
+          "overnight_gap": -74.43,
+          "points": 28.62,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 15.00886,
+          "date": "2026-04-13",
+          "h1_high": 8448.72,
+          "h1_low": 8412.57,
+          "h1_open": 8441.84,
+          "mm50_slope": 9.59832,
+          "overnight_gap": 146.5,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 16.14678,
-          "date": "2026-04-10",
-          "h1_high": 8323.78,
-          "h1_low": 8269.91,
-          "h1_open": 8303.98,
-          "mm50_slope": 9.64887,
-          "overnight_gap": 1.49,
-          "points": -35.84,
-          "status": "traded",
-          "trade_count": 4
-        },
-        {
-          "adx14": 15.00886,
-          "date": "2026-04-13",
-          "h1_high": 8297.34,
-          "h1_low": 8246.44,
-          "h1_open": 8290.73,
-          "mm50_slope": 9.59832,
-          "overnight_gap": -4.61,
-          "points": 25.05,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
           "adx14": 14.29026,
           "date": "2026-04-14",
-          "h1_high": 8318.01,
-          "h1_low": 8268.99,
-          "h1_open": 8286.19,
+          "h1_high": 8407.59,
+          "h1_low": 8352.95,
+          "h1_open": 8366.52,
           "mm50_slope": 9.41662,
-          "overnight_gap": 3.99,
-          "points": -17.77,
+          "overnight_gap": 84.32,
+          "points": 16.12,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 13.6722,
           "date": "2026-04-15",
-          "h1_high": 8305.94,
-          "h1_low": 8274.54,
-          "h1_open": 8293.46,
+          "h1_high": 8504.86,
+          "h1_low": 8428.95,
+          "h1_open": 8477.1,
           "mm50_slope": 8.86139,
-          "overnight_gap": 18.43,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 202.07,
+          "points": 53.7,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 12.85521,
           "date": "2026-04-16",
-          "h1_high": 8324.92,
-          "h1_low": 8266.02,
-          "h1_open": 8291.12,
+          "h1_high": 8457.27,
+          "h1_low": 8411.94,
+          "h1_open": 8413.24,
           "mm50_slope": 8.68907,
-          "overnight_gap": -0.46,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 121.66,
+          "points": -35.14,
+          "status": "traded",
+          "trade_count": 6
         },
         {
           "adx14": 12.8341,
           "date": "2026-04-17",
-          "h1_high": 8442.55,
-          "h1_low": 8292.28,
-          "h1_open": 8299.95,
+          "h1_high": 8181.44,
+          "h1_low": 8117.51,
+          "h1_open": 8137.46,
           "mm50_slope": 8.46736,
-          "overnight_gap": 44.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -117.83,
+          "points": -14.0,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 12.81451,
           "date": "2026-04-20",
-          "h1_high": 8335.96,
-          "h1_low": 8272.06,
-          "h1_open": 8307.42,
+          "h1_high": 8281.77,
+          "h1_low": 8235.88,
+          "h1_open": 8237.19,
           "mm50_slope": 8.30536,
-          "overnight_gap": 15.55,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -54.68,
+          "points": 8.64,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 13.19065,
           "date": "2026-04-21",
-          "h1_high": 8321.65,
-          "h1_low": 8285.08,
-          "h1_open": 8300.03,
+          "h1_high": 8243.22,
+          "h1_low": 8192.15,
+          "h1_open": 8239.62,
           "mm50_slope": 8.25474,
-          "overnight_gap": 25.08,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -35.33,
+          "points": -39.98,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 12.26575,
           "date": "2026-04-22",
-          "h1_high": 8323.46,
-          "h1_low": 8265.86,
-          "h1_open": 8287.11,
+          "h1_high": 8359.24,
+          "h1_low": 8304.9,
+          "h1_open": 8325.26,
           "mm50_slope": 8.51329,
-          "overnight_gap": -69.62,
-          "points": -4.65,
+          "overnight_gap": -31.47,
+          "points": -25.53,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 11.40692,
           "date": "2026-04-23",
-          "h1_high": 8308.41,
-          "h1_low": 8266.02,
-          "h1_open": 8278.3,
+          "h1_high": 8531.65,
+          "h1_low": 8487.01,
+          "h1_open": 8492.82,
           "mm50_slope": 8.12217,
-          "overnight_gap": -3.47,
-          "points": -55.41,
+          "overnight_gap": 211.05,
+          "points": -14.98,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 5
         },
         {
           "adx14": 11.21079,
           "date": "2026-04-24",
-          "h1_high": 8326.9,
-          "h1_low": 8282.97,
-          "h1_open": 8284.49,
+          "h1_high": 8231.91,
+          "h1_low": 8179.15,
+          "h1_open": 8204.49,
           "mm50_slope": 7.98984,
-          "overnight_gap": 11.84,
+          "overnight_gap": -68.16,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
@@ -1676,63 +1649,63 @@
         {
           "adx14": 11.00451,
           "date": "2026-04-27",
-          "h1_high": 8302.38,
-          "h1_low": 8254.31,
-          "h1_open": 8282.64,
+          "h1_high": 8476.21,
+          "h1_low": 8430.83,
+          "h1_open": 8468.26,
           "mm50_slope": 7.80263,
-          "overnight_gap": 1.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 186.75,
+          "points": 25.87,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.62359,
           "date": "2026-04-28",
-          "h1_high": 8332.03,
-          "h1_low": 8265.38,
-          "h1_open": 8270.99,
+          "h1_high": 8400.25,
+          "h1_low": 8333.87,
+          "h1_open": 8335.96,
           "mm50_slope": 7.50181,
-          "overnight_gap": -10.1,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 54.87,
+          "points": 33.67,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 10.59239,
           "date": "2026-04-29",
-          "h1_high": 8312.44,
-          "h1_low": 8255.53,
-          "h1_open": 8294.86,
+          "h1_high": 8345.08,
+          "h1_low": 8303.84,
+          "h1_open": 8332.16,
           "mm50_slope": 7.41922,
-          "overnight_gap": -42.58,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -5.28,
+          "points": 48.61,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 10.56341,
           "date": "2026-04-30",
-          "h1_high": 8323.96,
-          "h1_low": 8256.05,
-          "h1_open": 8265.02,
+          "h1_high": 8319.7,
+          "h1_low": 8237.88,
+          "h1_open": 8242.43,
           "mm50_slope": 7.24457,
-          "overnight_gap": -12.2,
-          "points": -42.34,
+          "overnight_gap": -34.79,
+          "points": -22.54,
           "status": "traded",
-          "trade_count": 5
+          "trade_count": 2
         }
       ],
       "summary": {
-        "average_loss": 14.0648,
-        "average_win": 23.966,
+        "average_loss": 15.884,
+        "average_win": 28.8892,
         "definition_code": "B9HWS",
         "end_date": "2026-04-30",
-        "final_result": -271.07,
-        "number_of_be": 14,
+        "final_result": -40.2,
+        "number_of_be": 12,
         "number_of_days": 42,
-        "number_of_losing_positions": 44,
-        "number_of_trades": 73,
-        "number_of_winning_positions": 15,
+        "number_of_losing_positions": 48,
+        "number_of_trades": 85,
+        "number_of_winning_positions": 25,
         "start_date": "2026-03-02"
       }
     }
@@ -1740,35 +1713,39 @@
   "C15M": {
     "day_detail": {
       "candle_count": 80,
-      "date": "2026-03-03",
+      "date": "2026-04-10",
       "h1_high": null,
       "h1_low": null,
       "h1_open": null,
       "status": "traded",
       "trades": [
         {
-          "direction": "Sell",
-          "entry_price": 24226.82,
-          "entry_time": "2026-03-03T13:00:00",
-          "exit_price": 24226.82,
-          "exit_reason": "break_even",
-          "exit_time": "2026-03-03T13:45:00",
-          "points": 30.775
+          "direction": "Buy",
+          "entry_price": 24755.74,
+          "entry_time": "2026-04-10T13:15:00",
+          "exit_price": 24583.88,
+          "exit_reason": "stop_loss",
+          "exit_time": "2026-04-10T14:00:00",
+          "points": -343.72
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 11,
-        "points": 324.608
+        "count": 15,
+        "points": 50.613
+      },
+      "end_of_run": {
+        "count": 3,
+        "points": 192.9975
       },
       "stop_loss": {
-        "count": 4,
-        "points": -692.64
+        "count": 9,
+        "points": -2083.02
       },
       "take_profit": {
-        "count": 6,
-        "points": 881.0666
+        "count": 3,
+        "points": 745.4847
       }
     },
     "run": {
@@ -1781,9 +1758,9 @@
           "h1_open": null,
           "mm50_slope": 9.71291,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 30.6945,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 13.32745,
@@ -1793,7 +1770,7 @@
           "h1_open": null,
           "mm50_slope": 9.86641,
           "overnight_gap": null,
-          "points": 30.775,
+          "points": 69.9355,
           "status": "traded",
           "trade_count": 1
         },
@@ -1805,9 +1782,9 @@
           "h1_open": null,
           "mm50_slope": 10.13151,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -232.58,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 13.50398,
@@ -1829,7 +1806,7 @@
           "h1_open": null,
           "mm50_slope": 10.57154,
           "overnight_gap": null,
-          "points": 276.6339,
+          "points": -261.1,
           "status": "traded",
           "trade_count": 1
         },
@@ -1841,9 +1818,9 @@
           "h1_open": null,
           "mm50_slope": 10.44738,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -379.8125,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 13.87275,
@@ -1853,9 +1830,9 @@
           "h1_open": null,
           "mm50_slope": 10.66631,
           "overnight_gap": null,
-          "points": -184.42,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 15.72043,
@@ -1865,9 +1842,9 @@
           "h1_open": null,
           "mm50_slope": 11.1303,
           "overnight_gap": null,
-          "points": -173.12,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 16.95558,
@@ -1877,9 +1854,9 @@
           "h1_open": null,
           "mm50_slope": 11.276,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 400.4941,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 16.90595,
@@ -1889,9 +1866,9 @@
           "h1_open": null,
           "mm50_slope": 11.24784,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -71.423,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 17.01098,
@@ -1901,9 +1878,9 @@
           "h1_open": null,
           "mm50_slope": 11.27264,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 90.3537,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 17.49488,
@@ -1913,9 +1890,9 @@
           "h1_open": null,
           "mm50_slope": 11.32341,
           "overnight_gap": null,
-          "points": 117.1236,
-          "status": "traded",
-          "trade_count": 3
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 18.78479,
@@ -1937,9 +1914,9 @@
           "h1_open": null,
           "mm50_slope": 11.62098,
           "overnight_gap": null,
-          "points": 67.023,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.0392,
@@ -1973,9 +1950,9 @@
           "h1_open": null,
           "mm50_slope": 11.58355,
           "overnight_gap": null,
-          "points": 121.3684,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.65692,
@@ -1985,9 +1962,9 @@
           "h1_open": null,
           "mm50_slope": 11.41358,
           "overnight_gap": null,
-          "points": 20.277,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.75476,
@@ -1997,9 +1974,9 @@
           "h1_open": null,
           "mm50_slope": 11.22718,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -201.54,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 22.05312,
@@ -2021,9 +1998,9 @@
           "h1_open": null,
           "mm50_slope": 11.08169,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 42.995,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 22.46958,
@@ -2045,9 +2022,9 @@
           "h1_open": null,
           "mm50_slope": 10.80869,
           "overnight_gap": null,
-          "points": 86.269,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 22.58099,
@@ -2057,9 +2034,9 @@
           "h1_open": null,
           "mm50_slope": 10.59234,
           "overnight_gap": null,
-          "points": 14.6415,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.24619,
@@ -2105,9 +2082,9 @@
           "h1_open": null,
           "mm50_slope": 10.59867,
           "overnight_gap": null,
-          "points": 44.4345,
+          "points": -343.72,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 22.68095,
@@ -2117,7 +2094,7 @@
           "h1_open": null,
           "mm50_slope": 10.4506,
           "overnight_gap": null,
-          "points": 36.4,
+          "points": -7.2095,
           "status": "traded",
           "trade_count": 1
         },
@@ -2153,7 +2130,7 @@
           "h1_open": null,
           "mm50_slope": 9.69627,
           "overnight_gap": null,
-          "points": 150.5487,
+          "points": -415.92,
           "status": "traded",
           "trade_count": 1
         },
@@ -2165,9 +2142,9 @@
           "h1_open": null,
           "mm50_slope": 9.48713,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -270.44,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 23.50007,
@@ -2177,9 +2154,9 @@
           "h1_open": null,
           "mm50_slope": 8.99244,
           "overnight_gap": null,
-          "points": -133.19,
-          "status": "traded",
-          "trade_count": 2
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 22.4151,
@@ -2189,9 +2166,9 @@
           "h1_open": null,
           "mm50_slope": 8.57465,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 288.2564,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 21.80969,
@@ -2201,9 +2178,9 @@
           "h1_open": null,
           "mm50_slope": 8.29582,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -170.8,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 21.85203,
@@ -2213,9 +2190,9 @@
           "h1_open": null,
           "mm50_slope": 8.1741,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -53.06,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 21.89135,
@@ -2225,9 +2202,9 @@
           "h1_open": null,
           "mm50_slope": 7.86368,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -40.385,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 20.68512,
@@ -2237,9 +2214,9 @@
           "h1_open": null,
           "mm50_slope": 7.61548,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 45.446,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 19.56505,
@@ -2249,9 +2226,9 @@
           "h1_open": null,
           "mm50_slope": 7.22627,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -157.28,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 18.49656,
@@ -2261,9 +2238,9 @@
           "h1_open": null,
           "mm50_slope": 7.12002,
           "overnight_gap": null,
-          "points": -139.43,
+          "points": -1769.42,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 17.5671,
@@ -2273,22 +2250,22 @@
           "h1_open": null,
           "mm50_slope": 6.64619,
           "overnight_gap": null,
-          "points": 177.7,
+          "points": -235.66,
           "status": "traded",
           "trade_count": 1
         }
       ],
       "summary": {
-        "average_loss": 139.4679,
-        "average_win": 80.457,
+        "average_loss": 260.6307,
+        "average_win": 93.9527,
         "definition_code": "C15M",
         "end_date": "2026-04-30",
-        "final_result": 670.4292,
+        "final_result": -3730.599,
         "number_of_be": 0,
         "number_of_days": 42,
-        "number_of_losing_positions": 5,
-        "number_of_trades": 22,
-        "number_of_winning_positions": 17,
+        "number_of_losing_positions": 19,
+        "number_of_trades": 32,
+        "number_of_winning_positions": 13,
         "start_date": "2026-03-02"
       }
     }
@@ -2296,14 +2273,37 @@
   "C1H": {
     "day_detail": {
       "candle_count": 20,
-      "date": "2026-03-03",
+      "date": "2026-04-10",
       "h1_high": null,
       "h1_low": null,
       "h1_open": null,
-      "status": "no_trade",
-      "trades": []
+      "status": "traded",
+      "trades": [
+        {
+          "direction": "Sell",
+          "entry_price": 24470.75,
+          "entry_time": "2026-04-10T05:00:00",
+          "exit_price": 24674.71,
+          "exit_reason": "stop_loss",
+          "exit_time": "2026-04-10T06:00:00",
+          "points": -407.92
+        }
+      ]
     },
-    "exit_reasons": {},
+    "exit_reasons": {
+      "break_even": {
+        "count": 6,
+        "points": 612.5955
+      },
+      "end_of_run": {
+        "count": 1,
+        "points": 726.715
+      },
+      "stop_loss": {
+        "count": 7,
+        "points": -2727.8
+      }
+    },
     "run": {
       "days": [
         {
@@ -2350,9 +2350,9 @@
           "h1_open": null,
           "mm50_slope": 10.22573,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -411.74,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 12.91783,
@@ -2458,9 +2458,9 @@
           "h1_open": null,
           "mm50_slope": 11.7235,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 55.194,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 19.98255,
@@ -2494,9 +2494,9 @@
           "h1_open": null,
           "mm50_slope": 11.63338,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -388.3485,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 21.55155,
@@ -2554,9 +2554,9 @@
           "h1_open": null,
           "mm50_slope": 11.08169,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -287.2,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 22.46958,
@@ -2590,9 +2590,9 @@
           "h1_open": null,
           "mm50_slope": 10.59234,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -251.7,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 23.24619,
@@ -2638,9 +2638,9 @@
           "h1_open": null,
           "mm50_slope": 10.59867,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -407.92,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 22.68095,
@@ -2662,9 +2662,9 @@
           "h1_open": null,
           "mm50_slope": 10.34705,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 0.6925,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 23.64665,
@@ -2710,9 +2710,9 @@
           "h1_open": null,
           "mm50_slope": 8.99244,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -639.7,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 22.4151,
@@ -2734,9 +2734,9 @@
           "h1_open": null,
           "mm50_slope": 8.29582,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -268.615,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 21.85203,
@@ -2806,22 +2806,22 @@
           "h1_open": null,
           "mm50_slope": 6.64619,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 215.5175,
+          "status": "traded",
+          "trade_count": 2
         }
       ],
       "summary": {
-        "average_loss": null,
-        "average_win": null,
+        "average_loss": 340.942,
+        "average_win": 136.9317,
         "definition_code": "C1H",
         "end_date": "2026-04-30",
-        "final_result": 0,
+        "final_result": -2383.8195,
         "number_of_be": 0,
         "number_of_days": 42,
-        "number_of_losing_positions": 0,
-        "number_of_trades": 0,
-        "number_of_winning_positions": 0,
+        "number_of_losing_positions": 9,
+        "number_of_trades": 14,
+        "number_of_winning_positions": 5,
         "start_date": "2026-03-02"
       }
     }
@@ -2829,66 +2829,35 @@
   "C5M": {
     "day_detail": {
       "candle_count": 240,
-      "date": "2026-03-03",
+      "date": "2026-04-10",
       "h1_high": null,
       "h1_low": null,
       "h1_open": null,
       "status": "traded",
       "trades": [
         {
-          "direction": "Sell",
-          "entry_price": 24499.65,
-          "entry_time": "2026-03-03T03:45:00",
-          "exit_price": 24423.3387,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T04:00:00",
-          "points": 93.2668
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 23811.07,
-          "entry_time": "2026-03-03T09:00:00",
-          "exit_price": 23686.9603,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T09:25:00",
-          "points": 173.6182
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 22850.78,
-          "entry_time": "2026-03-03T16:45:00",
-          "exit_price": 22867.4,
-          "exit_reason": "break_even",
-          "exit_time": "2026-03-03T16:55:00",
-          "points": 15.37
-        },
-        {
-          "direction": "Sell",
-          "entry_price": 22870.17,
-          "entry_time": "2026-03-03T17:05:00",
-          "exit_price": 22759.8906,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T17:20:00",
-          "points": 139.9839
+          "direction": "Buy",
+          "entry_price": 24831.81,
+          "entry_time": "2026-04-10T01:55:00",
+          "exit_price": 24744.49,
+          "exit_reason": "stop_loss",
+          "exit_time": "2026-04-10T02:00:00",
+          "points": -174.64
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 22,
-        "points": 414.738
-      },
-      "end_of_run": {
-        "count": 1,
-        "points": 22.78
+        "count": 23,
+        "points": 630.4485
       },
       "stop_loss": {
-        "count": 4,
-        "points": -590.78
+        "count": 14,
+        "points": -2428.22
       },
       "take_profit": {
-        "count": 28,
-        "points": 4464.7189
+        "count": 7,
+        "points": 1053.7939
       }
     },
     "run": {
@@ -2913,9 +2882,9 @@
           "h1_open": null,
           "mm50_slope": 9.86641,
           "overnight_gap": null,
-          "points": 422.2389,
+          "points": 49.6285,
           "status": "traded",
-          "trade_count": 4
+          "trade_count": 2
         },
         {
           "adx14": 14.13522,
@@ -2925,9 +2894,9 @@
           "h1_open": null,
           "mm50_slope": 10.13151,
           "overnight_gap": null,
-          "points": 88.7502,
+          "points": -179.26,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 13.50398,
@@ -2937,9 +2906,9 @@
           "h1_open": null,
           "mm50_slope": 10.22573,
           "overnight_gap": null,
-          "points": 148.6793,
+          "points": -252.5114,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 3
         },
         {
           "adx14": 12.91783,
@@ -2949,9 +2918,9 @@
           "h1_open": null,
           "mm50_slope": 10.57154,
           "overnight_gap": null,
-          "points": 157.8995,
+          "points": -153.6495,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 13.41297,
@@ -2961,9 +2930,9 @@
           "h1_open": null,
           "mm50_slope": 10.44738,
           "overnight_gap": null,
-          "points": 114.0726,
-          "status": "traded",
-          "trade_count": 2
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 13.87275,
@@ -2985,9 +2954,9 @@
           "h1_open": null,
           "mm50_slope": 11.1303,
           "overnight_gap": null,
-          "points": -228.4715,
-          "status": "traded",
-          "trade_count": 5
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 16.95558,
@@ -2997,9 +2966,9 @@
           "h1_open": null,
           "mm50_slope": 11.276,
           "overnight_gap": null,
-          "points": 96.3745,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 16.90595,
@@ -3009,9 +2978,9 @@
           "h1_open": null,
           "mm50_slope": 11.24784,
           "overnight_gap": null,
-          "points": -4.9615,
+          "points": 10.547,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 17.01098,
@@ -3021,9 +2990,9 @@
           "h1_open": null,
           "mm50_slope": 11.27264,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -116.21,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 17.49488,
@@ -3033,9 +3002,9 @@
           "h1_open": null,
           "mm50_slope": 11.32341,
           "overnight_gap": null,
-          "points": 281.3015,
-          "status": "traded",
-          "trade_count": 3
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 18.78479,
@@ -3045,9 +3014,9 @@
           "h1_open": null,
           "mm50_slope": 11.7235,
           "overnight_gap": null,
-          "points": 205.2579,
+          "points": 27.545,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 19.98255,
@@ -3057,9 +3026,9 @@
           "h1_open": null,
           "mm50_slope": 11.62098,
           "overnight_gap": null,
-          "points": 278.6032,
-          "status": "traded",
-          "trade_count": 3
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.0392,
@@ -3069,9 +3038,9 @@
           "h1_open": null,
           "mm50_slope": 11.91662,
           "overnight_gap": null,
-          "points": 53.734,
-          "status": "traded",
-          "trade_count": 2
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.13511,
@@ -3081,9 +3050,9 @@
           "h1_open": null,
           "mm50_slope": 11.63338,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 65.795,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 21.55155,
@@ -3105,7 +3074,7 @@
           "h1_open": null,
           "mm50_slope": 11.41358,
           "overnight_gap": null,
-          "points": -5473.42,
+          "points": 155.9336,
           "status": "traded",
           "trade_count": 1
         },
@@ -3117,9 +3086,9 @@
           "h1_open": null,
           "mm50_slope": 11.22718,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 32.347,
+          "status": "traded",
+          "trade_count": 2
         },
         {
           "adx14": 22.05312,
@@ -3141,7 +3110,7 @@
           "h1_open": null,
           "mm50_slope": 11.08169,
           "overnight_gap": null,
-          "points": 181.3311,
+          "points": 206.8529,
           "status": "traded",
           "trade_count": 1
         },
@@ -3153,9 +3122,9 @@
           "h1_open": null,
           "mm50_slope": 11.03512,
           "overnight_gap": null,
-          "points": 139.4191,
+          "points": -339.38,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 23.17763,
@@ -3165,9 +3134,9 @@
           "h1_open": null,
           "mm50_slope": 10.80869,
           "overnight_gap": null,
-          "points": 54.365,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 22.58099,
@@ -3177,9 +3146,9 @@
           "h1_open": null,
           "mm50_slope": 10.59234,
           "overnight_gap": null,
-          "points": 198.1812,
-          "status": "traded",
-          "trade_count": 2
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.24619,
@@ -3189,9 +3158,9 @@
           "h1_open": null,
           "mm50_slope": 10.91611,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 22.5415,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 23.24408,
@@ -3201,9 +3170,9 @@
           "h1_open": null,
           "mm50_slope": 11.04254,
           "overnight_gap": null,
-          "points": 462.417,
+          "points": 118.3597,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 22.53728,
@@ -3213,9 +3182,9 @@
           "h1_open": null,
           "mm50_slope": 10.57134,
           "overnight_gap": null,
-          "points": -150.081,
+          "points": -34.1695,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 3
         },
         {
           "adx14": 22.56853,
@@ -3225,7 +3194,7 @@
           "h1_open": null,
           "mm50_slope": 10.59867,
           "overnight_gap": null,
-          "points": 349.4524,
+          "points": -174.64,
           "status": "traded",
           "trade_count": 1
         },
@@ -3237,9 +3206,9 @@
           "h1_open": null,
           "mm50_slope": 10.4506,
           "overnight_gap": null,
-          "points": 36.3485,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 22.78535,
@@ -3249,9 +3218,9 @@
           "h1_open": null,
           "mm50_slope": 10.34705,
           "overnight_gap": null,
-          "points": 169.5261,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.64665,
@@ -3261,9 +3230,9 @@
           "h1_open": null,
           "mm50_slope": 9.88754,
           "overnight_gap": null,
-          "points": 39.14,
+          "points": -110.5415,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 4
         },
         {
           "adx14": 24.44644,
@@ -3297,9 +3266,9 @@
           "h1_open": null,
           "mm50_slope": 8.99244,
           "overnight_gap": null,
-          "points": 119.9885,
+          "points": 36.1045,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 22.4151,
@@ -3309,9 +3278,9 @@
           "h1_open": null,
           "mm50_slope": 8.57465,
           "overnight_gap": null,
-          "points": 127.8183,
+          "points": -134.809,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 21.80969,
@@ -3321,9 +3290,9 @@
           "h1_open": null,
           "mm50_slope": 8.29582,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -182.0327,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 21.85203,
@@ -3333,9 +3302,9 @@
           "h1_open": null,
           "mm50_slope": 8.1741,
           "overnight_gap": null,
-          "points": 196.5342,
-          "status": "traded",
-          "trade_count": 1
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.89135,
@@ -3345,9 +3314,9 @@
           "h1_open": null,
           "mm50_slope": 7.86368,
           "overnight_gap": null,
-          "points": 305.8022,
-          "status": "traded",
-          "trade_count": 5
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 20.68512,
@@ -3357,9 +3326,9 @@
           "h1_open": null,
           "mm50_slope": 7.61548,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": 50.2,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 19.56505,
@@ -3369,9 +3338,9 @@
           "h1_open": null,
           "mm50_slope": 7.22627,
           "overnight_gap": null,
-          "points": 245.2336,
+          "points": 45.474,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 18.49656,
@@ -3381,9 +3350,9 @@
           "h1_open": null,
           "mm50_slope": 7.12002,
           "overnight_gap": null,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "points": -94.192,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 17.5671,
@@ -3393,22 +3362,22 @@
           "h1_open": null,
           "mm50_slope": 6.64619,
           "overnight_gap": null,
-          "points": 199.7221,
+          "points": 206.0893,
           "status": "traded",
           "trade_count": 1
         }
       ],
       "summary": {
-        "average_loss": 697.1027,
-        "average_win": 105.3932,
+        "average_loss": 142.5548,
+        "average_win": 71.9637,
         "definition_code": "C5M",
         "end_date": "2026-04-30",
-        "final_result": -1004.2641,
+        "final_result": -765.5224,
         "number_of_be": 0,
         "number_of_days": 42,
-        "number_of_losing_positions": 9,
-        "number_of_trades": 59,
-        "number_of_winning_positions": 50,
+        "number_of_losing_positions": 19,
+        "number_of_trades": 46,
+        "number_of_winning_positions": 27,
         "start_date": "2026-03-02"
       }
     }
@@ -3416,48 +3385,57 @@
   "G9H": {
     "day_detail": {
       "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 24613.24,
-      "h1_low": 24501.23,
-      "h1_open": 24517.88,
+      "date": "2026-04-10",
+      "h1_high": 24758.39,
+      "h1_low": 24616.33,
+      "h1_open": 24625.92,
       "status": "traded",
       "trades": [
         {
-          "direction": "Buy",
-          "entry_price": 24517.98,
-          "entry_time": "2026-03-03T11:40:00",
-          "exit_price": 24603.24,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T12:05:00",
-          "points": 124.515
+          "direction": "Sell",
+          "entry_price": 24736.94,
+          "entry_time": "2026-04-10T09:30:00",
+          "exit_price": 24908.39,
+          "exit_reason": "stop_loss",
+          "exit_time": "2026-04-10T09:50:00",
+          "points": -342.9
         },
         {
           "direction": "Sell",
-          "entry_price": 24602.59,
-          "entry_time": "2026-03-03T16:10:00",
-          "exit_price": 24529.68,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": 118.265
+          "entry_price": 24742.44,
+          "entry_time": "2026-04-10T11:40:00",
+          "exit_price": 24742.44,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T12:10:00",
+          "points": 55.08
+        },
+        {
+          "direction": "Buy",
+          "entry_price": 24644.64,
+          "entry_time": "2026-04-10T14:10:00",
+          "exit_price": 24644.64,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T14:35:00",
+          "points": 42.72
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 36,
-        "points": 1232.32
+        "count": 34,
+        "points": 1011.755
       },
       "end_of_day": {
         "count": 5,
-        "points": -10.125
+        "points": -126.13
       },
       "stop_loss": {
-        "count": 11,
-        "points": -3673.12
+        "count": 13,
+        "points": -4499.96
       },
       "take_profit": {
-        "count": 24,
-        "points": 3829.895
+        "count": 21,
+        "points": 3325.72
       }
     },
     "run": {
@@ -3465,1643 +3443,1635 @@
         {
           "adx14": 13.13053,
           "date": "2026-03-02",
-          "h1_high": 24521.75,
-          "h1_low": 24298.95,
-          "h1_open": 24464.73,
+          "h1_high": 24942.59,
+          "h1_low": 24780.21,
+          "h1_open": 24833.67,
           "mm50_slope": 9.71291,
-          "overnight_gap": -46.02,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 322.92,
+          "points": -306.36,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 13.32745,
           "date": "2026-03-03",
-          "h1_high": 24613.24,
-          "h1_low": 24501.23,
-          "h1_open": 24517.88,
+          "h1_high": 25119.87,
+          "h1_low": 24962.6,
+          "h1_open": 24981.21,
           "mm50_slope": 9.86641,
-          "overnight_gap": 94.98,
-          "points": 242.78,
+          "overnight_gap": 558.31,
+          "points": -246.38,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 14.13522,
           "date": "2026-03-04",
-          "h1_high": 24517.62,
-          "h1_low": 24364.14,
-          "h1_open": 24476.26,
+          "h1_high": 24844.56,
+          "h1_low": 24643.75,
+          "h1_open": 24663.71,
           "mm50_slope": 10.13151,
-          "overnight_gap": -2.1,
-          "points": -41.46,
+          "overnight_gap": 185.35,
+          "points": -349.08,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 13.50398,
           "date": "2026-03-05",
-          "h1_high": 24579.4,
-          "h1_low": 24417.13,
-          "h1_open": 24481.37,
+          "h1_high": 24853.9,
+          "h1_low": 24728.31,
+          "h1_open": 24765.71,
           "mm50_slope": 10.22573,
-          "overnight_gap": 281.9,
-          "points": 200.565,
+          "overnight_gap": 566.24,
+          "points": 52.83,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 12.91783,
           "date": "2026-03-06",
-          "h1_high": 24590.42,
-          "h1_low": 24440.7,
-          "h1_open": 24544.45,
+          "h1_high": 24636.06,
+          "h1_low": 24525.05,
+          "h1_open": 24550.22,
           "mm50_slope": 10.57154,
-          "overnight_gap": 84.18,
-          "points": 146.88,
-          "status": "traded",
-          "trade_count": 1
+          "overnight_gap": 89.95,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 13.41297,
           "date": "2026-03-09",
-          "h1_high": 24707.74,
-          "h1_low": 24554.47,
-          "h1_open": 24565.65,
+          "h1_high": 24518.9,
+          "h1_low": 24319.28,
+          "h1_open": 24475.26,
           "mm50_slope": 10.44738,
-          "overnight_gap": 153.54,
-          "points": -349.08,
+          "overnight_gap": 63.15,
+          "points": -568.24,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 13.87275,
           "date": "2026-03-10",
-          "h1_high": 24586.37,
-          "h1_low": 24436.78,
-          "h1_open": 24582.28,
+          "h1_high": 24382.27,
+          "h1_low": 24030.68,
+          "h1_open": 24048.13,
           "mm50_slope": 10.66631,
-          "overnight_gap": -4.05,
-          "points": 260.735,
+          "overnight_gap": -538.2,
+          "points": -378.28,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 15.72043,
           "date": "2026-03-12",
-          "h1_high": 24739.95,
-          "h1_low": 24590.84,
-          "h1_open": 24670.64,
+          "h1_high": 24491.44,
+          "h1_low": 24272.31,
+          "h1_open": 24471.05,
           "mm50_slope": 11.1303,
-          "overnight_gap": 28.46,
-          "points": 279.685,
+          "overnight_gap": -171.13,
+          "points": -683.6,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 16.95558,
           "date": "2026-03-13",
-          "h1_high": 24758.3,
-          "h1_low": 24571.97,
-          "h1_open": 24629.13,
+          "h1_high": 24830.4,
+          "h1_low": 24579.71,
+          "h1_open": 24579.89,
           "mm50_slope": 11.276,
-          "overnight_gap": -59.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -108.37,
+          "points": 108.315,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 16.90595,
           "date": "2026-03-16",
-          "h1_high": 24753.46,
-          "h1_low": 24602.01,
-          "h1_open": 24663.11,
+          "h1_high": 24050.28,
+          "h1_low": 23945.01,
+          "h1_open": 23948.37,
           "mm50_slope": 11.24784,
-          "overnight_gap": 166.35,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 17.01098,
-          "date": "2026-03-17",
-          "h1_high": 24810.75,
-          "h1_low": 24628.67,
-          "h1_open": 24695.57,
-          "mm50_slope": 11.27264,
-          "overnight_gap": 17.2,
-          "points": 126.73,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 17.49488,
-          "date": "2026-03-18",
-          "h1_high": 24781.71,
-          "h1_low": 24684.13,
-          "h1_open": 24704.18,
-          "mm50_slope": 11.32341,
-          "overnight_gap": 23.53,
-          "points": 157.88,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 18.78479,
-          "date": "2026-03-19",
-          "h1_high": 24829.65,
-          "h1_low": 24682.76,
-          "h1_open": 24792.03,
-          "mm50_slope": 11.7235,
-          "overnight_gap": -7.27,
-          "points": 348.63,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 19.98255,
-          "date": "2026-03-20",
-          "h1_high": 24832.24,
-          "h1_low": 24678.84,
-          "h1_open": 24713.31,
-          "mm50_slope": 11.62098,
-          "overnight_gap": -41.7,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.0392,
-          "date": "2026-03-23",
-          "h1_high": 24852.27,
-          "h1_low": 24711.41,
-          "h1_open": 24756.37,
-          "mm50_slope": 11.91662,
-          "overnight_gap": -24.66,
-          "points": 363.72,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.13511,
-          "date": "2026-03-24",
-          "h1_high": 24948.35,
-          "h1_low": 24808.46,
-          "h1_open": 24809.1,
-          "mm50_slope": 11.63338,
-          "overnight_gap": 168.98,
-          "points": 173.7,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.55155,
-          "date": "2026-03-25",
-          "h1_high": 24942.27,
-          "h1_low": 24776.04,
-          "h1_open": 24792.86,
-          "mm50_slope": 11.58355,
-          "overnight_gap": 13.07,
-          "points": 153.28,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.65692,
-          "date": "2026-03-26",
-          "h1_high": 24861.8,
-          "h1_low": 24753.51,
-          "h1_open": 24792.52,
-          "mm50_slope": 11.41358,
-          "overnight_gap": 66.52,
-          "points": 75.38,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.75476,
-          "date": "2026-03-27",
-          "h1_high": 24821.43,
-          "h1_low": 24605.01,
-          "h1_open": 24805.58,
-          "mm50_slope": 11.22718,
-          "overnight_gap": 64.53,
-          "points": 238.01,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.05312,
-          "date": "2026-03-30",
-          "h1_high": 24856.28,
-          "h1_low": 24649.6,
-          "h1_open": 24823.81,
-          "mm50_slope": 11.23198,
-          "overnight_gap": -29.54,
-          "points": 352.37,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.70706,
-          "date": "2026-03-31",
-          "h1_high": 24986.86,
-          "h1_low": 24853.75,
-          "h1_open": 24878.25,
-          "mm50_slope": 11.08169,
-          "overnight_gap": 117.65,
-          "points": 211.52,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.46958,
-          "date": "2026-04-01",
-          "h1_high": 24976.44,
-          "h1_low": 24820.18,
-          "h1_open": 24834.5,
-          "mm50_slope": 11.03512,
-          "overnight_gap": -226.45,
-          "points": 437.65,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 23.17763,
-          "date": "2026-04-02",
-          "h1_high": 24871.98,
-          "h1_low": 24752.32,
-          "h1_open": 24843.34,
-          "mm50_slope": 10.80869,
-          "overnight_gap": -75.37,
-          "points": 253.66,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.58099,
-          "date": "2026-04-03",
-          "h1_high": 24995.77,
-          "h1_low": 24907.38,
-          "h1_open": 24963.16,
-          "mm50_slope": 10.59234,
-          "overnight_gap": 133.32,
-          "points": -386.145,
-          "status": "traded",
-          "trade_count": 7
-        },
-        {
-          "adx14": 23.24619,
-          "date": "2026-04-06",
-          "h1_high": 25039.71,
-          "h1_low": 24847.65,
-          "h1_open": 24897.59,
-          "mm50_slope": 10.91611,
-          "overnight_gap": -176.81,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 23.24408,
-          "date": "2026-04-07",
-          "h1_high": 24968.19,
-          "h1_low": 24829.07,
-          "h1_open": 24883.25,
-          "mm50_slope": 11.04254,
-          "overnight_gap": -157.29,
-          "points": -334.44,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 22.53728,
-          "date": "2026-04-09",
-          "h1_high": 25146.14,
-          "h1_low": 24917.48,
-          "h1_open": 24940.82,
-          "mm50_slope": 10.57134,
-          "overnight_gap": -40.14,
-          "points": -4.13,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.56853,
-          "date": "2026-04-10",
-          "h1_high": 25033.09,
-          "h1_low": 24800.38,
-          "h1_open": 24901.98,
-          "mm50_slope": 10.59867,
-          "overnight_gap": 3.55,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.68095,
-          "date": "2026-04-13",
-          "h1_high": 24883.99,
-          "h1_low": 24704.58,
-          "h1_open": 24871.58,
-          "mm50_slope": 10.4506,
-          "overnight_gap": -36.99,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 22.78535,
-          "date": "2026-04-14",
-          "h1_high": 25003.45,
-          "h1_low": 24825.84,
-          "h1_open": 24983.58,
-          "mm50_slope": 10.34705,
-          "overnight_gap": 127.27,
-          "points": -368.26,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 23.64665,
-          "date": "2026-04-15",
-          "h1_high": 24909.07,
-          "h1_low": 24705.88,
-          "h1_open": 24897.45,
-          "mm50_slope": 9.88754,
-          "overnight_gap": 71.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 24.44644,
-          "date": "2026-04-16",
-          "h1_high": 24903.69,
-          "h1_low": 24792.69,
-          "h1_open": 24895.44,
-          "mm50_slope": 9.69627,
-          "overnight_gap": -64.23,
-          "points": 43.03,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 23.82581,
-          "date": "2026-04-17",
-          "h1_high": 25015.27,
-          "h1_low": 24918.14,
-          "h1_open": 24922.2,
-          "mm50_slope": 9.48713,
-          "overnight_gap": 191.53,
-          "points": 204.94,
+          "overnight_gap": -548.39,
+          "points": 315.82,
           "status": "traded",
           "trade_count": 5
         },
         {
-          "adx14": 23.50007,
-          "date": "2026-04-20",
-          "h1_high": 24861.01,
-          "h1_low": 24657.67,
-          "h1_open": 24849.79,
-          "mm50_slope": 8.99244,
-          "overnight_gap": -120.38,
-          "points": 85.72,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.4151,
-          "date": "2026-04-21",
-          "h1_high": 24883.66,
-          "h1_low": 24719.38,
-          "h1_open": 24855.48,
-          "mm50_slope": 8.57465,
-          "overnight_gap": 79.46,
-          "points": -61.91,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.80969,
-          "date": "2026-04-22",
-          "h1_high": 24956.67,
-          "h1_low": 24825.3,
-          "h1_open": 24886.64,
-          "mm50_slope": 8.29582,
-          "overnight_gap": 100.48,
-          "points": -352.4,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.85203,
-          "date": "2026-04-23",
-          "h1_high": 24967.34,
-          "h1_low": 24877.77,
-          "h1_open": 24908.73,
-          "mm50_slope": 8.1741,
-          "overnight_gap": -33.44,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 21.89135,
-          "date": "2026-04-24",
-          "h1_high": 25026.23,
-          "h1_low": 24891.45,
-          "h1_open": 24915.19,
-          "mm50_slope": 7.86368,
-          "overnight_gap": 18.16,
-          "points": -293.48,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 20.68512,
-          "date": "2026-04-27",
-          "h1_high": 25067.03,
-          "h1_low": 24861.88,
-          "h1_open": 24867.24,
-          "mm50_slope": 7.61548,
-          "overnight_gap": 95.3,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 19.56505,
-          "date": "2026-04-28",
-          "h1_high": 24896.91,
-          "h1_low": 24784.07,
-          "h1_open": 24842.33,
-          "mm50_slope": 7.22627,
-          "overnight_gap": 41.73,
-          "points": -307.06,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 18.49656,
-          "date": "2026-04-29",
-          "h1_high": 24867.82,
-          "h1_low": 24722.07,
-          "h1_open": 24822.24,
-          "mm50_slope": 7.12002,
-          "overnight_gap": 29.96,
-          "points": -677.38,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 17.5671,
-          "date": "2026-04-30",
-          "h1_high": 24939.4,
-          "h1_low": 24783.46,
-          "h1_open": 24856.16,
-          "mm50_slope": 6.64619,
-          "overnight_gap": 150.88,
-          "points": 197.85,
-          "status": "traded",
-          "trade_count": 1
-        }
-      ],
-      "summary": {
-        "average_loss": 286.6329,
-        "average_win": 98.0333,
-        "definition_code": "G9H",
-        "end_date": "2026-04-30",
-        "final_result": 1378.97,
-        "number_of_be": 7,
-        "number_of_days": 42,
-        "number_of_losing_positions": 14,
-        "number_of_trades": 76,
-        "number_of_winning_positions": 55,
-        "start_date": "2026-03-02"
-      }
-    }
-  },
-  "G9HIC": {
-    "day_detail": {
-      "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 24613.24,
-      "h1_low": 24501.23,
-      "h1_open": 24517.88,
-      "status": "traded",
-      "trades": [
-        {
-          "direction": "Buy",
-          "entry_price": 24517.98,
-          "entry_time": "2026-03-03T11:40:00",
-          "exit_price": 24603.24,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T12:05:00",
-          "points": 85.26
-        }
-      ]
-    },
-    "exit_reasons": {
-      "break_even": {
-        "count": 26,
-        "points": -17.98
-      },
-      "end_of_day": {
-        "count": 2,
-        "points": -187.76
-      },
-      "stop_loss": {
-        "count": 11,
-        "points": -1112.69
-      },
-      "take_profit": {
-        "count": 24,
-        "points": 2381.03
-      }
-    },
-    "run": {
-      "days": [
-        {
-          "adx14": 13.13053,
-          "date": "2026-03-02",
-          "h1_high": 24521.75,
-          "h1_low": 24298.95,
-          "h1_open": 24464.73,
-          "mm50_slope": 9.71291,
-          "overnight_gap": -46.02,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.32745,
-          "date": "2026-03-03",
-          "h1_high": 24613.24,
-          "h1_low": 24501.23,
-          "h1_open": 24517.88,
-          "mm50_slope": 9.86641,
-          "overnight_gap": 94.98,
-          "points": 85.26,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 14.13522,
-          "date": "2026-03-04",
-          "h1_high": 24517.62,
-          "h1_low": 24364.14,
-          "h1_open": 24476.26,
-          "mm50_slope": 10.13151,
-          "overnight_gap": -2.1,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.50398,
-          "date": "2026-03-05",
-          "h1_high": 24579.4,
-          "h1_low": 24417.13,
-          "h1_open": 24481.37,
-          "mm50_slope": 10.22573,
-          "overnight_gap": 281.9,
-          "points": 135.85,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 12.91783,
-          "date": "2026-03-06",
-          "h1_high": 24590.42,
-          "h1_low": 24440.7,
-          "h1_open": 24544.45,
-          "mm50_slope": 10.57154,
-          "overnight_gap": 84.18,
-          "points": 105.87,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 13.41297,
-          "date": "2026-03-09",
-          "h1_high": 24707.74,
-          "h1_low": 24554.47,
-          "h1_open": 24565.65,
-          "mm50_slope": 10.44738,
-          "overnight_gap": 153.54,
-          "points": -81.28,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 13.87275,
-          "date": "2026-03-10",
-          "h1_high": 24586.37,
-          "h1_low": 24436.78,
-          "h1_open": 24582.28,
-          "mm50_slope": 10.66631,
-          "overnight_gap": -4.05,
-          "points": 112.35,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 15.72043,
-          "date": "2026-03-12",
-          "h1_high": 24739.95,
-          "h1_low": 24590.84,
-          "h1_open": 24670.64,
-          "mm50_slope": 11.1303,
-          "overnight_gap": 28.46,
-          "points": 126.1,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 16.95558,
-          "date": "2026-03-13",
-          "h1_high": 24758.3,
-          "h1_low": 24571.97,
-          "h1_open": 24629.13,
-          "mm50_slope": 11.276,
-          "overnight_gap": -59.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 16.90595,
-          "date": "2026-03-16",
-          "h1_high": 24753.46,
-          "h1_low": 24602.01,
-          "h1_open": 24663.11,
-          "mm50_slope": 11.24784,
-          "overnight_gap": 166.35,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
           "adx14": 17.01098,
           "date": "2026-03-17",
-          "h1_high": 24810.75,
-          "h1_low": 24628.67,
-          "h1_open": 24695.57,
+          "h1_high": 24772.19,
+          "h1_low": 24664.15,
+          "h1_open": 24711.06,
           "mm50_slope": 11.27264,
-          "overnight_gap": 17.2,
-          "points": 0.0,
+          "overnight_gap": 32.69,
+          "points": 97.22,
           "status": "traded",
           "trade_count": 1
         },
         {
           "adx14": 17.49488,
           "date": "2026-03-18",
-          "h1_high": 24781.71,
-          "h1_low": 24684.13,
-          "h1_open": 24704.18,
+          "h1_high": 24931.1,
+          "h1_low": 24659.93,
+          "h1_open": 24711.79,
           "mm50_slope": 11.32341,
-          "overnight_gap": 23.53,
-          "points": 28.8,
+          "overnight_gap": 31.14,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 18.78479,
           "date": "2026-03-19",
-          "h1_high": 24829.65,
-          "h1_low": 24682.76,
-          "h1_open": 24792.03,
+          "h1_high": 24938.47,
+          "h1_low": 24783.37,
+          "h1_open": 24859.94,
           "mm50_slope": 11.7235,
-          "overnight_gap": -7.27,
-          "points": 123.05,
+          "overnight_gap": 60.64,
+          "points": 382.33,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 19.98255,
           "date": "2026-03-20",
-          "h1_high": 24832.24,
-          "h1_low": 24678.84,
-          "h1_open": 24713.31,
+          "h1_high": 24804.12,
+          "h1_low": 24668.17,
+          "h1_open": 24799.95,
           "mm50_slope": 11.62098,
-          "overnight_gap": -41.7,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
+          "overnight_gap": 44.94,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.0392,
           "date": "2026-03-23",
-          "h1_high": 24852.27,
-          "h1_low": 24711.41,
-          "h1_open": 24756.37,
+          "h1_high": 24487.25,
+          "h1_low": 24349.0,
+          "h1_open": 24397.19,
           "mm50_slope": 11.91662,
-          "overnight_gap": -24.66,
-          "points": 219.85,
-          "status": "traded",
-          "trade_count": 3
+          "overnight_gap": -383.84,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 21.13511,
           "date": "2026-03-24",
-          "h1_high": 24948.35,
-          "h1_low": 24808.46,
-          "h1_open": 24809.1,
+          "h1_high": 24561.59,
+          "h1_low": 24286.59,
+          "h1_open": 24297.57,
           "mm50_slope": 11.63338,
-          "overnight_gap": 168.98,
-          "points": 99.69,
+          "overnight_gap": -342.55,
+          "points": 334.44,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 3
         },
         {
           "adx14": 21.55155,
           "date": "2026-03-25",
-          "h1_high": 24942.27,
-          "h1_low": 24776.04,
-          "h1_open": 24792.86,
+          "h1_high": 24464.46,
+          "h1_low": 24261.8,
+          "h1_open": 24360.43,
           "mm50_slope": 11.58355,
-          "overnight_gap": 13.07,
+          "overnight_gap": -419.36,
           "points": 0.0,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 21.65692,
           "date": "2026-03-26",
-          "h1_high": 24861.8,
-          "h1_low": 24753.51,
-          "h1_open": 24792.52,
+          "h1_high": 24343.17,
+          "h1_low": 24147.12,
+          "h1_open": 24295.69,
           "mm50_slope": 11.41358,
-          "overnight_gap": 66.52,
-          "points": 58.99,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.75476,
-          "date": "2026-03-27",
-          "h1_high": 24821.43,
-          "h1_low": 24605.01,
-          "h1_open": 24805.58,
-          "mm50_slope": 11.22718,
-          "overnight_gap": 64.53,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 22.05312,
-          "date": "2026-03-30",
-          "h1_high": 24856.28,
-          "h1_low": 24649.6,
-          "h1_open": 24823.81,
-          "mm50_slope": 11.23198,
-          "overnight_gap": -29.54,
-          "points": 178.32,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.70706,
-          "date": "2026-03-31",
-          "h1_high": 24986.86,
-          "h1_low": 24853.75,
-          "h1_open": 24878.25,
-          "mm50_slope": 11.08169,
-          "overnight_gap": 117.65,
-          "points": -14.64,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 22.46958,
-          "date": "2026-04-01",
-          "h1_high": 24976.44,
-          "h1_low": 24820.18,
-          "h1_open": 24834.5,
-          "mm50_slope": 11.03512,
-          "overnight_gap": -226.45,
-          "points": 122.77,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 23.17763,
-          "date": "2026-04-02",
-          "h1_high": 24871.98,
-          "h1_low": 24752.32,
-          "h1_open": 24843.34,
-          "mm50_slope": 10.80869,
-          "overnight_gap": -75.37,
-          "points": 152.75,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.58099,
-          "date": "2026-04-03",
-          "h1_high": 24995.77,
-          "h1_low": 24907.38,
-          "h1_open": 24963.16,
-          "mm50_slope": 10.59234,
-          "overnight_gap": 133.32,
-          "points": 58.02,
-          "status": "traded",
-          "trade_count": 6
-        },
-        {
-          "adx14": 23.24619,
-          "date": "2026-04-06",
-          "h1_high": 25039.71,
-          "h1_low": 24847.65,
-          "h1_open": 24897.59,
-          "mm50_slope": 10.91611,
-          "overnight_gap": -176.81,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 23.24408,
-          "date": "2026-04-07",
-          "h1_high": 24968.19,
-          "h1_low": 24829.07,
-          "h1_open": 24883.25,
-          "mm50_slope": 11.04254,
-          "overnight_gap": -157.29,
-          "points": -3.34,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.53728,
-          "date": "2026-04-09",
-          "h1_high": 25146.14,
-          "h1_low": 24917.48,
-          "h1_open": 24940.82,
-          "mm50_slope": 10.57134,
-          "overnight_gap": -40.14,
-          "points": 203.53,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 22.56853,
-          "date": "2026-04-10",
-          "h1_high": 25033.09,
-          "h1_low": 24800.38,
-          "h1_open": 24901.98,
-          "mm50_slope": 10.59867,
-          "overnight_gap": 3.55,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.68095,
-          "date": "2026-04-13",
-          "h1_high": 24883.99,
-          "h1_low": 24704.58,
-          "h1_open": 24871.58,
-          "mm50_slope": 10.4506,
-          "overnight_gap": -36.99,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 22.78535,
-          "date": "2026-04-14",
-          "h1_high": 25003.45,
-          "h1_low": 24825.84,
-          "h1_open": 24983.58,
-          "mm50_slope": 10.34705,
-          "overnight_gap": 127.27,
-          "points": -142.73,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 23.64665,
-          "date": "2026-04-15",
-          "h1_high": 24909.07,
-          "h1_low": 24705.88,
-          "h1_open": 24897.45,
-          "mm50_slope": 9.88754,
-          "overnight_gap": 71.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 24.44644,
-          "date": "2026-04-16",
-          "h1_high": 24903.69,
-          "h1_low": 24792.69,
-          "h1_open": 24895.44,
-          "mm50_slope": 9.69627,
-          "overnight_gap": -64.23,
-          "points": -128.09,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 23.82581,
-          "date": "2026-04-17",
-          "h1_high": 25015.27,
-          "h1_low": 24918.14,
-          "h1_open": 24922.2,
-          "mm50_slope": 9.48713,
-          "overnight_gap": 191.53,
-          "points": 4.74,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 23.50007,
-          "date": "2026-04-20",
-          "h1_high": 24861.01,
-          "h1_low": 24657.67,
-          "h1_open": 24849.79,
-          "mm50_slope": 8.99244,
-          "overnight_gap": -120.38,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.4151,
-          "date": "2026-04-21",
-          "h1_high": 24883.66,
-          "h1_low": 24719.38,
-          "h1_open": 24855.48,
-          "mm50_slope": 8.57465,
-          "overnight_gap": 79.46,
-          "points": 92.01,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.80969,
-          "date": "2026-04-22",
-          "h1_high": 24956.67,
-          "h1_low": 24825.3,
-          "h1_open": 24886.64,
-          "mm50_slope": 8.29582,
-          "overnight_gap": 100.48,
-          "points": -234.94,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.85203,
-          "date": "2026-04-23",
-          "h1_high": 24967.34,
-          "h1_low": 24877.77,
-          "h1_open": 24908.73,
-          "mm50_slope": 8.1741,
-          "overnight_gap": -33.44,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 21.89135,
-          "date": "2026-04-24",
-          "h1_high": 25026.23,
-          "h1_low": 24891.45,
-          "h1_open": 24915.19,
-          "mm50_slope": 7.86368,
-          "overnight_gap": 18.16,
-          "points": -104.5,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 20.68512,
-          "date": "2026-04-27",
-          "h1_high": 25067.03,
-          "h1_low": 24861.88,
-          "h1_open": 24867.24,
-          "mm50_slope": 7.61548,
-          "overnight_gap": 95.3,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 19.56505,
-          "date": "2026-04-28",
-          "h1_high": 24896.91,
-          "h1_low": 24784.07,
-          "h1_open": 24842.33,
-          "mm50_slope": 7.22627,
-          "overnight_gap": 41.73,
-          "points": -61.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 18.49656,
-          "date": "2026-04-29",
-          "h1_high": 24867.82,
-          "h1_low": 24722.07,
-          "h1_open": 24822.24,
-          "mm50_slope": 7.12002,
-          "overnight_gap": 29.96,
-          "points": -182.17,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 17.5671,
-          "date": "2026-04-30",
-          "h1_high": 24939.4,
-          "h1_low": 24783.46,
-          "h1_open": 24856.16,
-          "mm50_slope": 6.64619,
-          "overnight_gap": 150.88,
-          "points": 107.34,
-          "status": "traded",
-          "trade_count": 1
-        }
-      ],
-      "summary": {
-        "average_loss": 100.0346,
-        "average_win": 99.2096,
-        "definition_code": "G9HIC",
-        "end_date": "2026-04-30",
-        "final_result": 1062.6,
-        "number_of_be": 26,
-        "number_of_days": 42,
-        "number_of_losing_positions": 13,
-        "number_of_trades": 63,
-        "number_of_winning_positions": 24,
-        "start_date": "2026-03-02"
-      }
-    }
-  },
-  "G9HICD": {
-    "day_detail": {
-      "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 24613.24,
-      "h1_low": 24501.23,
-      "h1_open": 24517.88,
-      "status": "traded",
-      "trades": [
-        {
-          "direction": "Buy",
-          "entry_price": 24517.98,
-          "entry_time": "2026-03-03T11:40:00",
-          "exit_price": 24703.24,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T12:45:00",
-          "points": 270.52
-        }
-      ]
-    },
-    "exit_reasons": {
-      "break_even": {
-        "count": 31,
-        "points": 761.56
-      },
-      "end_of_day": {
-        "count": 1,
-        "points": -122.0
-      },
-      "stop_loss": {
-        "count": 11,
-        "points": -2225.38
-      },
-      "take_profit": {
-        "count": 6,
-        "points": 1703.26
-      },
-      "trailing_stop": {
-        "count": 9,
-        "points": 1831.38
-      }
-    },
-    "run": {
-      "days": [
-        {
-          "adx14": 13.13053,
-          "date": "2026-03-02",
-          "h1_high": 24521.75,
-          "h1_low": 24298.95,
-          "h1_open": 24464.73,
-          "mm50_slope": 9.71291,
-          "overnight_gap": -46.02,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.32745,
-          "date": "2026-03-03",
-          "h1_high": 24613.24,
-          "h1_low": 24501.23,
-          "h1_open": 24517.88,
-          "mm50_slope": 9.86641,
-          "overnight_gap": 94.98,
-          "points": 270.52,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 14.13522,
-          "date": "2026-03-04",
-          "h1_high": 24517.62,
-          "h1_low": 24364.14,
-          "h1_open": 24476.26,
-          "mm50_slope": 10.13151,
-          "overnight_gap": -2.1,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 13.50398,
-          "date": "2026-03-05",
-          "h1_high": 24579.4,
-          "h1_low": 24417.13,
-          "h1_open": 24481.37,
-          "mm50_slope": 10.22573,
-          "overnight_gap": 281.9,
-          "points": 371.7,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 12.91783,
-          "date": "2026-03-06",
-          "h1_high": 24590.42,
-          "h1_low": 24440.7,
-          "h1_open": 24544.45,
-          "mm50_slope": 10.57154,
-          "overnight_gap": 84.18,
-          "points": 211.74,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 13.41297,
-          "date": "2026-03-09",
-          "h1_high": 24707.74,
-          "h1_low": 24554.47,
-          "h1_open": 24565.65,
-          "mm50_slope": 10.44738,
-          "overnight_gap": 153.54,
-          "points": -162.56,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 13.87275,
-          "date": "2026-03-10",
-          "h1_high": 24586.37,
-          "h1_low": 24436.78,
-          "h1_open": 24582.28,
-          "mm50_slope": 10.66631,
-          "overnight_gap": -4.05,
-          "points": 224.7,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 15.72043,
-          "date": "2026-03-12",
-          "h1_high": 24739.95,
-          "h1_low": 24590.84,
-          "h1_open": 24670.64,
-          "mm50_slope": 11.1303,
-          "overnight_gap": 28.46,
-          "points": 252.2,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 16.95558,
-          "date": "2026-03-13",
-          "h1_high": 24758.3,
-          "h1_low": 24571.97,
-          "h1_open": 24629.13,
-          "mm50_slope": 11.276,
-          "overnight_gap": -59.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 16.90595,
-          "date": "2026-03-16",
-          "h1_high": 24753.46,
-          "h1_low": 24602.01,
-          "h1_open": 24663.11,
-          "mm50_slope": 11.24784,
-          "overnight_gap": 166.35,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 17.01098,
-          "date": "2026-03-17",
-          "h1_high": 24810.75,
-          "h1_low": 24628.67,
-          "h1_open": 24695.57,
-          "mm50_slope": 11.27264,
-          "overnight_gap": 17.2,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 17.49488,
-          "date": "2026-03-18",
-          "h1_high": 24781.71,
-          "h1_low": 24684.13,
-          "h1_open": 24704.18,
-          "mm50_slope": 11.32341,
-          "overnight_gap": 23.53,
-          "points": 157.6,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 18.78479,
-          "date": "2026-03-19",
-          "h1_high": 24829.65,
-          "h1_low": 24682.76,
-          "h1_open": 24792.03,
-          "mm50_slope": 11.7235,
-          "overnight_gap": -7.27,
-          "points": 123.05,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 19.98255,
-          "date": "2026-03-20",
-          "h1_high": 24832.24,
-          "h1_low": 24678.84,
-          "h1_open": 24713.31,
-          "mm50_slope": 11.62098,
-          "overnight_gap": -41.7,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.0392,
-          "date": "2026-03-23",
-          "h1_high": 24852.27,
-          "h1_low": 24711.41,
-          "h1_open": 24756.37,
-          "mm50_slope": 11.91662,
-          "overnight_gap": -24.66,
-          "points": 539.7,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.13511,
-          "date": "2026-03-24",
-          "h1_high": 24948.35,
-          "h1_low": 24808.46,
-          "h1_open": 24809.1,
-          "mm50_slope": 11.63338,
-          "overnight_gap": 168.98,
-          "points": 199.38,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.55155,
-          "date": "2026-03-25",
-          "h1_high": 24942.27,
-          "h1_low": 24776.04,
-          "h1_open": 24792.86,
-          "mm50_slope": 11.58355,
-          "overnight_gap": 13.07,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.65692,
-          "date": "2026-03-26",
-          "h1_high": 24861.8,
-          "h1_low": 24753.51,
-          "h1_open": 24792.52,
-          "mm50_slope": 11.41358,
-          "overnight_gap": 66.52,
-          "points": 117.98,
+          "overnight_gap": -430.31,
+          "points": 288.915,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 21.75476,
           "date": "2026-03-27",
-          "h1_high": 24821.43,
-          "h1_low": 24605.01,
-          "h1_open": 24805.58,
+          "h1_high": 25216.56,
+          "h1_low": 24936.7,
+          "h1_open": 24986.39,
           "mm50_slope": 11.22718,
-          "overnight_gap": 64.53,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 2
+          "overnight_gap": 245.34,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 22.05312,
           "date": "2026-03-30",
-          "h1_high": 24856.28,
-          "h1_low": 24649.6,
-          "h1_open": 24823.81,
+          "h1_high": 24912.1,
+          "h1_low": 24803.97,
+          "h1_open": 24809.77,
           "mm50_slope": 11.23198,
-          "overnight_gap": -29.54,
-          "points": 356.64,
+          "overnight_gap": -43.58,
+          "points": 166.09,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 4
         },
         {
           "adx14": 21.70706,
           "date": "2026-03-31",
-          "h1_high": 24986.86,
-          "h1_low": 24853.75,
-          "h1_open": 24878.25,
+          "h1_high": 24487.71,
+          "h1_low": 24287.24,
+          "h1_open": 24420.41,
           "mm50_slope": 11.08169,
-          "overnight_gap": 117.65,
-          "points": -29.28,
+          "overnight_gap": -340.19,
+          "points": 72.515,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 22.46958,
           "date": "2026-04-01",
-          "h1_high": 24976.44,
-          "h1_low": 24820.18,
-          "h1_open": 24834.5,
+          "h1_high": 24913.73,
+          "h1_low": 24790.89,
+          "h1_open": 24803.13,
           "mm50_slope": 11.03512,
-          "overnight_gap": -226.45,
-          "points": 122.77,
+          "overnight_gap": -257.82,
+          "points": 57.32,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 23.17763,
           "date": "2026-04-02",
-          "h1_high": 24871.98,
-          "h1_low": 24752.32,
-          "h1_open": 24843.34,
+          "h1_high": 25037.73,
+          "h1_low": 24914.3,
+          "h1_open": 25017.55,
           "mm50_slope": 10.80869,
-          "overnight_gap": -75.37,
-          "points": 80.52,
+          "overnight_gap": 98.84,
+          "points": 95.01,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 22.58099,
           "date": "2026-04-03",
-          "h1_high": 24995.77,
-          "h1_low": 24907.38,
-          "h1_open": 24963.16,
+          "h1_high": 24850.85,
+          "h1_low": 24745.94,
+          "h1_open": 24749.0,
           "mm50_slope": 10.59234,
-          "overnight_gap": 133.32,
-          "points": 327.25,
+          "overnight_gap": -80.84,
+          "points": 135.325,
           "status": "traded",
           "trade_count": 4
         },
         {
           "adx14": 23.24619,
           "date": "2026-04-06",
-          "h1_high": 25039.71,
-          "h1_low": 24847.65,
-          "h1_open": 24897.59,
+          "h1_high": 24961.04,
+          "h1_low": 24769.59,
+          "h1_open": 24790.29,
           "mm50_slope": 10.91611,
-          "overnight_gap": -176.81,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -284.11,
+          "points": 571.295,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 23.24408,
           "date": "2026-04-07",
-          "h1_high": 24968.19,
-          "h1_low": 24829.07,
-          "h1_open": 24883.25,
+          "h1_high": 24873.21,
+          "h1_low": 24735.28,
+          "h1_open": 24846.18,
           "mm50_slope": 11.04254,
-          "overnight_gap": -157.29,
-          "points": -6.68,
+          "overnight_gap": -194.36,
+          "points": 175.395,
           "status": "traded",
           "trade_count": 1
         },
         {
           "adx14": 22.53728,
           "date": "2026-04-09",
-          "h1_high": 25146.14,
-          "h1_low": 24917.48,
-          "h1_open": 24940.82,
+          "h1_high": 24659.71,
+          "h1_low": 24372.86,
+          "h1_open": 24523.69,
           "mm50_slope": 10.57134,
-          "overnight_gap": -40.14,
-          "points": 203.53,
+          "overnight_gap": -457.27,
+          "points": -335.3,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 3
         },
         {
           "adx14": 22.56853,
           "date": "2026-04-10",
-          "h1_high": 25033.09,
-          "h1_low": 24800.38,
-          "h1_open": 24901.98,
+          "h1_high": 24758.39,
+          "h1_low": 24616.33,
+          "h1_open": 24625.92,
           "mm50_slope": 10.59867,
-          "overnight_gap": 3.55,
-          "points": 0.0,
+          "overnight_gap": -272.51,
+          "points": -245.1,
           "status": "traded",
           "trade_count": 3
         },
         {
           "adx14": 22.68095,
           "date": "2026-04-13",
-          "h1_high": 24883.99,
-          "h1_low": 24704.58,
-          "h1_open": 24871.58,
+          "h1_high": 25445.21,
+          "h1_low": 25318.24,
+          "h1_open": 25401.88,
           "mm50_slope": 10.4506,
-          "overnight_gap": -36.99,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 493.31,
+          "points": 557.485,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 22.78535,
           "date": "2026-04-14",
-          "h1_high": 25003.45,
-          "h1_low": 24825.84,
-          "h1_open": 24983.58,
+          "h1_high": 25439.26,
+          "h1_low": 25174.73,
+          "h1_open": 25191.45,
           "mm50_slope": 10.34705,
-          "overnight_gap": 127.27,
-          "points": -285.46,
+          "overnight_gap": 335.14,
+          "points": 0.0,
           "status": "traded",
           "trade_count": 1
         },
         {
           "adx14": 23.64665,
           "date": "2026-04-15",
-          "h1_high": 24909.07,
-          "h1_low": 24705.88,
-          "h1_open": 24897.45,
+          "h1_high": 24803.82,
+          "h1_low": 24587.68,
+          "h1_open": 24802.51,
           "mm50_slope": 9.88754,
-          "overnight_gap": 71.66,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -23.28,
+          "points": 82.32,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 24.44644,
           "date": "2026-04-16",
-          "h1_high": 24903.69,
-          "h1_low": 24792.69,
-          "h1_open": 24895.44,
+          "h1_high": 24730.56,
+          "h1_low": 24601.32,
+          "h1_open": 24672.17,
           "mm50_slope": 9.69627,
-          "overnight_gap": -64.23,
-          "points": -256.18,
-          "status": "traded",
-          "trade_count": 2
+          "overnight_gap": -287.5,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.82581,
           "date": "2026-04-17",
-          "h1_high": 25015.27,
-          "h1_low": 24918.14,
-          "h1_open": 24922.2,
+          "h1_high": 24905.19,
+          "h1_low": 24800.44,
+          "h1_open": 24846.48,
           "mm50_slope": 9.48713,
-          "overnight_gap": 191.53,
-          "points": -65.49,
-          "status": "traded",
-          "trade_count": 3
+          "overnight_gap": 115.81,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.50007,
           "date": "2026-04-20",
-          "h1_high": 24861.01,
-          "h1_low": 24657.67,
-          "h1_open": 24849.79,
+          "h1_high": 24916.34,
+          "h1_low": 24821.72,
+          "h1_open": 24891.25,
           "mm50_slope": 8.99244,
-          "overnight_gap": -120.38,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 22.4151,
-          "date": "2026-04-21",
-          "h1_high": 24883.66,
-          "h1_low": 24719.38,
-          "h1_open": 24855.48,
-          "mm50_slope": 8.57465,
-          "overnight_gap": 79.46,
-          "points": 45.73,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.80969,
-          "date": "2026-04-22",
-          "h1_high": 24956.67,
-          "h1_low": 24825.3,
-          "h1_open": 24886.64,
-          "mm50_slope": 8.29582,
-          "overnight_gap": 100.48,
-          "points": -469.88,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.85203,
-          "date": "2026-04-23",
-          "h1_high": 24967.34,
-          "h1_low": 24877.77,
-          "h1_open": 24908.73,
-          "mm50_slope": 8.1741,
-          "overnight_gap": -33.44,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
-        },
-        {
-          "adx14": 21.89135,
-          "date": "2026-04-24",
-          "h1_high": 25026.23,
-          "h1_low": 24891.45,
-          "h1_open": 24915.19,
-          "mm50_slope": 7.86368,
-          "overnight_gap": 18.16,
-          "points": -209.0,
+          "overnight_gap": -78.92,
+          "points": 115.78,
           "status": "traded",
           "trade_count": 2
         },
         {
-          "adx14": 20.68512,
-          "date": "2026-04-27",
-          "h1_high": 25067.03,
-          "h1_low": 24861.88,
-          "h1_open": 24867.24,
-          "mm50_slope": 7.61548,
-          "overnight_gap": 95.3,
+          "adx14": 22.4151,
+          "date": "2026-04-21",
+          "h1_high": 24369.93,
+          "h1_low": 24088.57,
+          "h1_open": 24367.41,
+          "mm50_slope": 8.57465,
+          "overnight_gap": -408.61,
+          "points": -112.46,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.80969,
+          "date": "2026-04-22",
+          "h1_high": 24529.58,
+          "h1_low": 24349.57,
+          "h1_open": 24397.63,
+          "mm50_slope": 8.29582,
+          "overnight_gap": -388.53,
+          "points": -356.3,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.85203,
+          "date": "2026-04-23",
+          "h1_high": 25023.08,
+          "h1_low": 24905.37,
+          "h1_open": 24966.66,
+          "mm50_slope": 8.1741,
+          "overnight_gap": 24.49,
+          "points": 44.235,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.89135,
+          "date": "2026-04-24",
+          "h1_high": 24446.15,
+          "h1_low": 24231.92,
+          "h1_open": 24385.38,
+          "mm50_slope": 7.86368,
+          "overnight_gap": -511.65,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
+          "adx14": 20.68512,
+          "date": "2026-04-27",
+          "h1_high": 24585.6,
+          "h1_low": 24467.2,
+          "h1_open": 24565.15,
+          "mm50_slope": 7.61548,
+          "overnight_gap": -206.79,
+          "points": -288.09,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
           "adx14": 19.56505,
           "date": "2026-04-28",
-          "h1_high": 24896.91,
-          "h1_low": 24784.07,
-          "h1_open": 24842.33,
+          "h1_high": 24644.8,
+          "h1_low": 24523.62,
+          "h1_open": 24631.72,
           "mm50_slope": 7.22627,
-          "overnight_gap": 41.73,
-          "points": -122.0,
+          "overnight_gap": -168.88,
+          "points": -111.76,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 3
         },
         {
           "adx14": 18.49656,
           "date": "2026-04-29",
-          "h1_high": 24867.82,
-          "h1_low": 24722.07,
-          "h1_open": 24822.24,
+          "h1_high": 25457.02,
+          "h1_low": 25315.59,
+          "h1_open": 25409.49,
           "mm50_slope": 7.12002,
-          "overnight_gap": 29.96,
-          "points": -364.34,
+          "overnight_gap": 617.21,
+          "points": 40.355,
           "status": "traded",
           "trade_count": 1
         },
         {
           "adx14": 17.5671,
           "date": "2026-04-30",
-          "h1_high": 24939.4,
-          "h1_low": 24783.46,
-          "h1_open": 24856.16,
+          "h1_high": 25395.6,
+          "h1_low": 25195.37,
+          "h1_open": 25305.26,
           "mm50_slope": 6.64619,
-          "overnight_gap": 150.88,
-          "points": 314.68,
+          "overnight_gap": 599.98,
+          "points": -0.66,
           "status": "traded",
           "trade_count": 1
         }
       ],
       "summary": {
-        "average_loss": 170.2386,
-        "average_win": 196.9164,
+        "average_loss": 270.7547,
+        "average_win": 99.6733,
+        "definition_code": "G9H",
+        "end_date": "2026-04-30",
+        "final_result": -288.615,
+        "number_of_be": 9,
+        "number_of_days": 42,
+        "number_of_losing_positions": 18,
+        "number_of_trades": 73,
+        "number_of_winning_positions": 46,
+        "start_date": "2026-03-02"
+      }
+    }
+  },
+  "G9HIC": {
+    "day_detail": {
+      "candle_count": 144,
+      "date": "2026-04-10",
+      "h1_high": 24758.39,
+      "h1_low": 24616.33,
+      "h1_open": 24625.92,
+      "status": "traded",
+      "trades": [
+        {
+          "direction": "Sell",
+          "entry_price": 24736.94,
+          "entry_time": "2026-04-10T09:30:00",
+          "exit_price": 24736.94,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T12:10:00",
+          "points": -0.0
+        }
+      ]
+    },
+    "exit_reasons": {
+      "break_even": {
+        "count": 24,
+        "points": -10.91
+      },
+      "stop_loss": {
+        "count": 21,
+        "points": -2876.52
+      },
+      "take_profit": {
+        "count": 19,
+        "points": 2120.82
+      }
+    },
+    "run": {
+      "days": [
+        {
+          "adx14": 13.13053,
+          "date": "2026-03-02",
+          "h1_high": 24942.59,
+          "h1_low": 24780.21,
+          "h1_open": 24833.67,
+          "mm50_slope": 9.71291,
+          "overnight_gap": 322.92,
+          "points": -87.83,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 13.32745,
+          "date": "2026-03-03",
+          "h1_high": 25119.87,
+          "h1_low": 24962.6,
+          "h1_open": 24981.21,
+          "mm50_slope": 9.86641,
+          "overnight_gap": 558.31,
+          "points": -156.13,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 14.13522,
+          "date": "2026-03-04",
+          "h1_high": 24844.56,
+          "h1_low": 24643.75,
+          "h1_open": 24663.71,
+          "mm50_slope": 10.13151,
+          "overnight_gap": 185.35,
+          "points": -153.28,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 13.50398,
+          "date": "2026-03-05",
+          "h1_high": 24853.9,
+          "h1_low": 24728.31,
+          "h1_open": 24765.71,
+          "mm50_slope": 10.22573,
+          "overnight_gap": 566.24,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 12.91783,
+          "date": "2026-03-06",
+          "h1_high": 24636.06,
+          "h1_low": 24525.05,
+          "h1_open": 24550.22,
+          "mm50_slope": 10.57154,
+          "overnight_gap": 89.95,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 13.41297,
+          "date": "2026-03-09",
+          "h1_high": 24518.9,
+          "h1_low": 24319.28,
+          "h1_open": 24475.26,
+          "mm50_slope": 10.44738,
+          "overnight_gap": 63.15,
+          "points": -126.6,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 13.87275,
+          "date": "2026-03-10",
+          "h1_high": 24382.27,
+          "h1_low": 24030.68,
+          "h1_open": 24048.13,
+          "mm50_slope": 10.66631,
+          "overnight_gap": -538.2,
+          "points": -87.1,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 15.72043,
+          "date": "2026-03-12",
+          "h1_high": 24491.44,
+          "h1_low": 24272.31,
+          "h1_open": 24471.05,
+          "mm50_slope": 11.1303,
+          "overnight_gap": -171.13,
+          "points": -190.5,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 16.95558,
+          "date": "2026-03-13",
+          "h1_high": 24830.4,
+          "h1_low": 24579.71,
+          "h1_open": 24579.89,
+          "mm50_slope": 11.276,
+          "overnight_gap": -108.37,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 16.90595,
+          "date": "2026-03-16",
+          "h1_high": 24050.28,
+          "h1_low": 23945.01,
+          "h1_open": 23948.37,
+          "mm50_slope": 11.24784,
+          "overnight_gap": -548.39,
+          "points": 138.72,
+          "status": "traded",
+          "trade_count": 5
+        },
+        {
+          "adx14": 17.01098,
+          "date": "2026-03-17",
+          "h1_high": 24772.19,
+          "h1_low": 24664.15,
+          "h1_open": 24711.06,
+          "mm50_slope": 11.27264,
+          "overnight_gap": 32.69,
+          "points": 70.62,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 17.49488,
+          "date": "2026-03-18",
+          "h1_high": 24931.1,
+          "h1_low": 24659.93,
+          "h1_open": 24711.79,
+          "mm50_slope": 11.32341,
+          "overnight_gap": 31.14,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 18.78479,
+          "date": "2026-03-19",
+          "h1_high": 24938.47,
+          "h1_low": 24783.37,
+          "h1_open": 24859.94,
+          "mm50_slope": 11.7235,
+          "overnight_gap": 60.64,
+          "points": 255.26,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 19.98255,
+          "date": "2026-03-20",
+          "h1_high": 24804.12,
+          "h1_low": 24668.17,
+          "h1_open": 24799.95,
+          "mm50_slope": 11.62098,
+          "overnight_gap": 44.94,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.0392,
+          "date": "2026-03-23",
+          "h1_high": 24487.25,
+          "h1_low": 24349.0,
+          "h1_open": 24397.19,
+          "mm50_slope": 11.91662,
+          "overnight_gap": -383.84,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.13511,
+          "date": "2026-03-24",
+          "h1_high": 24561.59,
+          "h1_low": 24286.59,
+          "h1_open": 24297.57,
+          "mm50_slope": 11.63338,
+          "overnight_gap": -342.55,
+          "points": 230.97,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.55155,
+          "date": "2026-03-25",
+          "h1_high": 24464.46,
+          "h1_low": 24261.8,
+          "h1_open": 24360.43,
+          "mm50_slope": 11.58355,
+          "overnight_gap": -419.36,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.65692,
+          "date": "2026-03-26",
+          "h1_high": 24343.17,
+          "h1_low": 24147.12,
+          "h1_open": 24295.69,
+          "mm50_slope": 11.41358,
+          "overnight_gap": -430.31,
+          "points": 159.66,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.75476,
+          "date": "2026-03-27",
+          "h1_high": 25216.56,
+          "h1_low": 24936.7,
+          "h1_open": 24986.39,
+          "mm50_slope": 11.22718,
+          "overnight_gap": 245.34,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 22.05312,
+          "date": "2026-03-30",
+          "h1_high": 24912.1,
+          "h1_low": 24803.97,
+          "h1_open": 24809.77,
+          "mm50_slope": 11.23198,
+          "overnight_gap": -43.58,
+          "points": -176.17,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.70706,
+          "date": "2026-03-31",
+          "h1_high": 24487.71,
+          "h1_low": 24287.24,
+          "h1_open": 24420.41,
+          "mm50_slope": 11.08169,
+          "overnight_gap": -340.19,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.46958,
+          "date": "2026-04-01",
+          "h1_high": 24913.73,
+          "h1_low": 24790.89,
+          "h1_open": 24803.13,
+          "mm50_slope": 11.03512,
+          "overnight_gap": -257.82,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 23.17763,
+          "date": "2026-04-02",
+          "h1_high": 25037.73,
+          "h1_low": 24914.3,
+          "h1_open": 25017.55,
+          "mm50_slope": 10.80869,
+          "overnight_gap": 98.84,
+          "points": 62.4,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 22.58099,
+          "date": "2026-04-03",
+          "h1_high": 24850.85,
+          "h1_low": 24745.94,
+          "h1_open": 24749.0,
+          "mm50_slope": 10.59234,
+          "overnight_gap": -80.84,
+          "points": 71.41,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 23.24619,
+          "date": "2026-04-06",
+          "h1_high": 24961.04,
+          "h1_low": 24769.59,
+          "h1_open": 24790.29,
+          "mm50_slope": 10.91611,
+          "overnight_gap": -284.11,
+          "points": 253.61,
+          "status": "traded",
+          "trade_count": 4
+        },
+        {
+          "adx14": 23.24408,
+          "date": "2026-04-07",
+          "h1_high": 24873.21,
+          "h1_low": 24735.28,
+          "h1_open": 24846.18,
+          "mm50_slope": 11.04254,
+          "overnight_gap": -194.36,
+          "points": 117.18,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.53728,
+          "date": "2026-04-09",
+          "h1_high": 24659.71,
+          "h1_low": 24372.86,
+          "h1_open": 24523.69,
+          "mm50_slope": 10.57134,
+          "overnight_gap": -457.27,
+          "points": -586.39,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 22.56853,
+          "date": "2026-04-10",
+          "h1_high": 24758.39,
+          "h1_low": 24616.33,
+          "h1_open": 24625.92,
+          "mm50_slope": 10.59867,
+          "overnight_gap": -272.51,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.68095,
+          "date": "2026-04-13",
+          "h1_high": 25445.21,
+          "h1_low": 25318.24,
+          "h1_open": 25401.88,
+          "mm50_slope": 10.4506,
+          "overnight_gap": 493.31,
+          "points": 380.12,
+          "status": "traded",
+          "trade_count": 4
+        },
+        {
+          "adx14": 22.78535,
+          "date": "2026-04-14",
+          "h1_high": 25439.26,
+          "h1_low": 25174.73,
+          "h1_open": 25191.45,
+          "mm50_slope": 10.34705,
+          "overnight_gap": 335.14,
+          "points": -260.86,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 23.64665,
+          "date": "2026-04-15",
+          "h1_high": 24803.82,
+          "h1_low": 24587.68,
+          "h1_open": 24802.51,
+          "mm50_slope": 9.88754,
+          "overnight_gap": -23.28,
+          "points": 37.26,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 24.44644,
+          "date": "2026-04-16",
+          "h1_high": 24730.56,
+          "h1_low": 24601.32,
+          "h1_open": 24672.17,
+          "mm50_slope": 9.69627,
+          "overnight_gap": -287.5,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 23.82581,
+          "date": "2026-04-17",
+          "h1_high": 24905.19,
+          "h1_low": 24800.44,
+          "h1_open": 24846.48,
+          "mm50_slope": 9.48713,
+          "overnight_gap": 115.81,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 23.50007,
+          "date": "2026-04-20",
+          "h1_high": 24916.34,
+          "h1_low": 24821.72,
+          "h1_open": 24891.25,
+          "mm50_slope": 8.99244,
+          "overnight_gap": -78.92,
+          "points": 47.82,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.4151,
+          "date": "2026-04-21",
+          "h1_high": 24369.93,
+          "h1_low": 24088.57,
+          "h1_open": 24367.41,
+          "mm50_slope": 8.57465,
+          "overnight_gap": -408.61,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.80969,
+          "date": "2026-04-22",
+          "h1_high": 24529.58,
+          "h1_low": 24349.57,
+          "h1_open": 24397.63,
+          "mm50_slope": 8.29582,
+          "overnight_gap": -388.53,
+          "points": -190.84,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.85203,
+          "date": "2026-04-23",
+          "h1_high": 25023.08,
+          "h1_low": 24905.37,
+          "h1_open": 24966.66,
+          "mm50_slope": 8.1741,
+          "overnight_gap": 24.49,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.89135,
+          "date": "2026-04-24",
+          "h1_high": 24446.15,
+          "h1_low": 24231.92,
+          "h1_open": 24385.38,
+          "mm50_slope": 7.86368,
+          "overnight_gap": -511.65,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 20.68512,
+          "date": "2026-04-27",
+          "h1_high": 24585.6,
+          "h1_low": 24467.2,
+          "h1_open": 24565.15,
+          "mm50_slope": 7.61548,
+          "overnight_gap": -206.79,
+          "points": -308.58,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 19.56505,
+          "date": "2026-04-28",
+          "h1_high": 24644.8,
+          "h1_low": 24523.62,
+          "h1_open": 24631.72,
+          "mm50_slope": 7.22627,
+          "overnight_gap": -168.88,
+          "points": -267.36,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 18.49656,
+          "date": "2026-04-29",
+          "h1_high": 25457.02,
+          "h1_low": 25315.59,
+          "h1_open": 25409.49,
+          "mm50_slope": 7.12002,
+          "overnight_gap": 617.21,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 17.5671,
+          "date": "2026-04-30",
+          "h1_high": 25395.6,
+          "h1_low": 25195.37,
+          "h1_open": 25305.26,
+          "mm50_slope": 6.64619,
+          "overnight_gap": 599.98,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        }
+      ],
+      "summary": {
+        "average_loss": 136.9771,
+        "average_win": 111.6221,
+        "definition_code": "G9HIC",
+        "end_date": "2026-04-30",
+        "final_result": -766.61,
+        "number_of_be": 24,
+        "number_of_days": 42,
+        "number_of_losing_positions": 21,
+        "number_of_trades": 64,
+        "number_of_winning_positions": 19,
+        "start_date": "2026-03-02"
+      }
+    }
+  },
+  "G9HICD": {
+    "day_detail": {
+      "candle_count": 144,
+      "date": "2026-04-10",
+      "h1_high": 24758.39,
+      "h1_low": 24616.33,
+      "h1_open": 24625.92,
+      "status": "traded",
+      "trades": [
+        {
+          "direction": "Sell",
+          "entry_price": 24736.94,
+          "entry_time": "2026-04-10T09:30:00",
+          "exit_price": 24736.94,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T12:10:00",
+          "points": -0.0
+        }
+      ]
+    },
+    "exit_reasons": {
+      "break_even": {
+        "count": 30,
+        "points": 706.33
+      },
+      "stop_loss": {
+        "count": 20,
+        "points": -5454.62
+      },
+      "take_profit": {
+        "count": 2,
+        "points": 1050.74
+      },
+      "trailing_stop": {
+        "count": 7,
+        "points": 1533.1
+      }
+    },
+    "run": {
+      "days": [
+        {
+          "adx14": 13.13053,
+          "date": "2026-03-02",
+          "h1_high": 24942.59,
+          "h1_low": 24780.21,
+          "h1_open": 24833.67,
+          "mm50_slope": 9.71291,
+          "overnight_gap": 322.92,
+          "points": -175.66,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 13.32745,
+          "date": "2026-03-03",
+          "h1_high": 25119.87,
+          "h1_low": 24962.6,
+          "h1_open": 24981.21,
+          "mm50_slope": 9.86641,
+          "overnight_gap": 558.31,
+          "points": -312.26,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 14.13522,
+          "date": "2026-03-04",
+          "h1_high": 24844.56,
+          "h1_low": 24643.75,
+          "h1_open": 24663.71,
+          "mm50_slope": 10.13151,
+          "overnight_gap": 185.35,
+          "points": -306.56,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 13.50398,
+          "date": "2026-03-05",
+          "h1_high": 24853.9,
+          "h1_low": 24728.31,
+          "h1_open": 24765.71,
+          "mm50_slope": 10.22573,
+          "overnight_gap": 566.24,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 12.91783,
+          "date": "2026-03-06",
+          "h1_high": 24636.06,
+          "h1_low": 24525.05,
+          "h1_open": 24550.22,
+          "mm50_slope": 10.57154,
+          "overnight_gap": 89.95,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 13.41297,
+          "date": "2026-03-09",
+          "h1_high": 24518.9,
+          "h1_low": 24319.28,
+          "h1_open": 24475.26,
+          "mm50_slope": 10.44738,
+          "overnight_gap": 63.15,
+          "points": -253.2,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 13.87275,
+          "date": "2026-03-10",
+          "h1_high": 24382.27,
+          "h1_low": 24030.68,
+          "h1_open": 24048.13,
+          "mm50_slope": 10.66631,
+          "overnight_gap": -538.2,
+          "points": -174.2,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 15.72043,
+          "date": "2026-03-12",
+          "h1_high": 24491.44,
+          "h1_low": 24272.31,
+          "h1_open": 24471.05,
+          "mm50_slope": 11.1303,
+          "overnight_gap": -171.13,
+          "points": -381.0,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 16.95558,
+          "date": "2026-03-13",
+          "h1_high": 24830.4,
+          "h1_low": 24579.71,
+          "h1_open": 24579.89,
+          "mm50_slope": 11.276,
+          "overnight_gap": -108.37,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 16.90595,
+          "date": "2026-03-16",
+          "h1_high": 24050.28,
+          "h1_low": 23945.01,
+          "h1_open": 23948.37,
+          "mm50_slope": 11.24784,
+          "overnight_gap": -548.39,
+          "points": 193.73,
+          "status": "traded",
+          "trade_count": 5
+        },
+        {
+          "adx14": 17.01098,
+          "date": "2026-03-17",
+          "h1_high": 24772.19,
+          "h1_low": 24664.15,
+          "h1_open": 24711.06,
+          "mm50_slope": 11.27264,
+          "overnight_gap": 32.69,
+          "points": 70.62,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 17.49488,
+          "date": "2026-03-18",
+          "h1_high": 24931.1,
+          "h1_low": 24659.93,
+          "h1_open": 24711.79,
+          "mm50_slope": 11.32341,
+          "overnight_gap": 31.14,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 18.78479,
+          "date": "2026-03-19",
+          "h1_high": 24938.47,
+          "h1_low": 24783.37,
+          "h1_open": 24859.94,
+          "mm50_slope": 11.7235,
+          "overnight_gap": 60.64,
+          "points": 255.26,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 19.98255,
+          "date": "2026-03-20",
+          "h1_high": 24804.12,
+          "h1_low": 24668.17,
+          "h1_open": 24799.95,
+          "mm50_slope": 11.62098,
+          "overnight_gap": 44.94,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.0392,
+          "date": "2026-03-23",
+          "h1_high": 24487.25,
+          "h1_low": 24349.0,
+          "h1_open": 24397.19,
+          "mm50_slope": 11.91662,
+          "overnight_gap": -383.84,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.13511,
+          "date": "2026-03-24",
+          "h1_high": 24561.59,
+          "h1_low": 24286.59,
+          "h1_open": 24297.57,
+          "mm50_slope": 11.63338,
+          "overnight_gap": -342.55,
+          "points": 561.94,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.55155,
+          "date": "2026-03-25",
+          "h1_high": 24464.46,
+          "h1_low": 24261.8,
+          "h1_open": 24360.43,
+          "mm50_slope": 11.58355,
+          "overnight_gap": -419.36,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.65692,
+          "date": "2026-03-26",
+          "h1_high": 24343.17,
+          "h1_low": 24147.12,
+          "h1_open": 24295.69,
+          "mm50_slope": 11.41358,
+          "overnight_gap": -430.31,
+          "points": 319.32,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.75476,
+          "date": "2026-03-27",
+          "h1_high": 25216.56,
+          "h1_low": 24936.7,
+          "h1_open": 24986.39,
+          "mm50_slope": 11.22718,
+          "overnight_gap": 245.34,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 22.05312,
+          "date": "2026-03-30",
+          "h1_high": 24912.1,
+          "h1_low": 24803.97,
+          "h1_open": 24809.77,
+          "mm50_slope": 11.23198,
+          "overnight_gap": -43.58,
+          "points": -352.34,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.70706,
+          "date": "2026-03-31",
+          "h1_high": 24487.71,
+          "h1_low": 24287.24,
+          "h1_open": 24420.41,
+          "mm50_slope": 11.08169,
+          "overnight_gap": -340.19,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.46958,
+          "date": "2026-04-01",
+          "h1_high": 24913.73,
+          "h1_low": 24790.89,
+          "h1_open": 24803.13,
+          "mm50_slope": 11.03512,
+          "overnight_gap": -257.82,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 23.17763,
+          "date": "2026-04-02",
+          "h1_high": 25037.73,
+          "h1_low": 24914.3,
+          "h1_open": 25017.55,
+          "mm50_slope": 10.80869,
+          "overnight_gap": 98.84,
+          "points": 49.07,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 22.58099,
+          "date": "2026-04-03",
+          "h1_high": 24850.85,
+          "h1_low": 24745.94,
+          "h1_open": 24749.0,
+          "mm50_slope": 10.59234,
+          "overnight_gap": -80.84,
+          "points": 136.0,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 23.24619,
+          "date": "2026-04-06",
+          "h1_high": 24961.04,
+          "h1_low": 24769.59,
+          "h1_open": 24790.29,
+          "mm50_slope": 10.91611,
+          "overnight_gap": -284.11,
+          "points": 507.22,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 23.24408,
+          "date": "2026-04-07",
+          "h1_high": 24873.21,
+          "h1_low": 24735.28,
+          "h1_open": 24846.18,
+          "mm50_slope": 11.04254,
+          "overnight_gap": -194.36,
+          "points": 117.18,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.53728,
+          "date": "2026-04-09",
+          "h1_high": 24659.71,
+          "h1_low": 24372.86,
+          "h1_open": 24523.69,
+          "mm50_slope": 10.57134,
+          "overnight_gap": -457.27,
+          "points": -1172.78,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 22.56853,
+          "date": "2026-04-10",
+          "h1_high": 24758.39,
+          "h1_low": 24616.33,
+          "h1_open": 24625.92,
+          "mm50_slope": 10.59867,
+          "overnight_gap": -272.51,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.68095,
+          "date": "2026-04-13",
+          "h1_high": 25445.21,
+          "h1_low": 25318.24,
+          "h1_open": 25401.88,
+          "mm50_slope": 10.4506,
+          "overnight_gap": 493.31,
+          "points": 293.69,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 22.78535,
+          "date": "2026-04-14",
+          "h1_high": 25439.26,
+          "h1_low": 25174.73,
+          "h1_open": 25191.45,
+          "mm50_slope": 10.34705,
+          "overnight_gap": 335.14,
+          "points": -521.72,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 23.64665,
+          "date": "2026-04-15",
+          "h1_high": 24803.82,
+          "h1_low": 24587.68,
+          "h1_open": 24802.51,
+          "mm50_slope": 9.88754,
+          "overnight_gap": -23.28,
+          "points": 466.98,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 24.44644,
+          "date": "2026-04-16",
+          "h1_high": 24730.56,
+          "h1_low": 24601.32,
+          "h1_open": 24672.17,
+          "mm50_slope": 9.69627,
+          "overnight_gap": -287.5,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 23.82581,
+          "date": "2026-04-17",
+          "h1_high": 24905.19,
+          "h1_low": 24800.44,
+          "h1_open": 24846.48,
+          "mm50_slope": 9.48713,
+          "overnight_gap": 115.81,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 23.50007,
+          "date": "2026-04-20",
+          "h1_high": 24916.34,
+          "h1_low": 24821.72,
+          "h1_open": 24891.25,
+          "mm50_slope": 8.99244,
+          "overnight_gap": -78.92,
+          "points": 47.82,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.4151,
+          "date": "2026-04-21",
+          "h1_high": 24369.93,
+          "h1_low": 24088.57,
+          "h1_open": 24367.41,
+          "mm50_slope": 8.57465,
+          "overnight_gap": -408.61,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.80969,
+          "date": "2026-04-22",
+          "h1_high": 24529.58,
+          "h1_low": 24349.57,
+          "h1_open": 24397.63,
+          "mm50_slope": 8.29582,
+          "overnight_gap": -388.53,
+          "points": -381.68,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.85203,
+          "date": "2026-04-23",
+          "h1_high": 25023.08,
+          "h1_low": 24905.37,
+          "h1_open": 24966.66,
+          "mm50_slope": 8.1741,
+          "overnight_gap": 24.49,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.89135,
+          "date": "2026-04-24",
+          "h1_high": 24446.15,
+          "h1_low": 24231.92,
+          "h1_open": 24385.38,
+          "mm50_slope": 7.86368,
+          "overnight_gap": -511.65,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 20.68512,
+          "date": "2026-04-27",
+          "h1_high": 24585.6,
+          "h1_low": 24467.2,
+          "h1_open": 24565.15,
+          "mm50_slope": 7.61548,
+          "overnight_gap": -206.79,
+          "points": -617.16,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 19.56505,
+          "date": "2026-04-28",
+          "h1_high": 24644.8,
+          "h1_low": 24523.62,
+          "h1_open": 24631.72,
+          "mm50_slope": 7.22627,
+          "overnight_gap": -168.88,
+          "points": -534.72,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 18.49656,
+          "date": "2026-04-29",
+          "h1_high": 25457.02,
+          "h1_low": 25315.59,
+          "h1_open": 25409.49,
+          "mm50_slope": 7.12002,
+          "overnight_gap": 617.21,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 17.5671,
+          "date": "2026-04-30",
+          "h1_high": 25395.6,
+          "h1_low": 25195.37,
+          "h1_open": 25305.26,
+          "mm50_slope": 6.64619,
+          "overnight_gap": 599.98,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        }
+      ],
+      "summary": {
+        "average_loss": 260.7829,
+        "average_win": 194.8229,
         "definition_code": "G9HICD",
         "end_date": "2026-04-30",
-        "final_result": 1948.82,
-        "number_of_be": 22,
+        "final_result": -2164.45,
+        "number_of_be": 21,
         "number_of_days": 42,
-        "number_of_losing_positions": 14,
-        "number_of_trades": 58,
-        "number_of_winning_positions": 22,
+        "number_of_losing_positions": 21,
+        "number_of_trades": 59,
+        "number_of_winning_positions": 17,
         "start_date": "2026-03-02"
       }
     }
@@ -5109,48 +5079,57 @@
   "G9HSL": {
     "day_detail": {
       "candle_count": 90,
-      "date": "2026-03-03",
-      "h1_high": 24613.24,
-      "h1_low": 24501.23,
-      "h1_open": 24517.88,
+      "date": "2026-04-10",
+      "h1_high": 24758.39,
+      "h1_low": 24616.33,
+      "h1_open": 24625.92,
       "status": "traded",
       "trades": [
         {
-          "direction": "Buy",
-          "entry_price": 24517.98,
-          "entry_time": "2026-03-03T11:40:00",
-          "exit_price": 24603.24,
-          "exit_reason": "take_profit",
-          "exit_time": "2026-03-03T12:05:00",
-          "points": 85.26
+          "direction": "Sell",
+          "entry_price": 24736.94,
+          "entry_time": "2026-04-10T09:30:00",
+          "exit_price": 24908.39,
+          "exit_reason": "stop_loss",
+          "exit_time": "2026-04-10T09:50:00",
+          "points": -171.45
         },
         {
           "direction": "Sell",
-          "entry_price": 24602.59,
-          "entry_time": "2026-03-03T16:10:00",
-          "exit_price": 24529.68,
-          "exit_reason": "end_of_day",
-          "exit_time": "2026-03-03T16:25:00",
-          "points": 72.91
+          "entry_price": 24742.44,
+          "entry_time": "2026-04-10T11:40:00",
+          "exit_price": 24742.44,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T12:10:00",
+          "points": -0.0
+        },
+        {
+          "direction": "Buy",
+          "entry_price": 24644.64,
+          "entry_time": "2026-04-10T14:10:00",
+          "exit_price": 24644.64,
+          "exit_reason": "break_even",
+          "exit_time": "2026-04-10T14:35:00",
+          "points": 0.0
         }
       ]
     },
     "exit_reasons": {
       "break_even": {
-        "count": 29,
-        "points": -39.86
+        "count": 28,
+        "points": -43.34
       },
       "end_of_day": {
-        "count": 5,
-        "points": -2.67
+        "count": 6,
+        "points": -154.66
       },
       "stop_loss": {
-        "count": 11,
-        "points": -1836.56
+        "count": 14,
+        "points": -2430.42
       },
       "take_profit": {
-        "count": 28,
-        "points": 2808.72
+        "count": 23,
+        "points": 2412.28
       }
     },
     "run": {
@@ -5158,519 +5137,519 @@
         {
           "adx14": 13.13053,
           "date": "2026-03-02",
-          "h1_high": 24521.75,
-          "h1_low": 24298.95,
-          "h1_open": 24464.73,
+          "h1_high": 24942.59,
+          "h1_low": 24780.21,
+          "h1_open": 24833.67,
           "mm50_slope": 9.71291,
-          "overnight_gap": -46.02,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 322.92,
+          "points": -153.18,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 13.32745,
           "date": "2026-03-03",
-          "h1_high": 24613.24,
-          "h1_low": 24501.23,
-          "h1_open": 24517.88,
+          "h1_high": 25119.87,
+          "h1_low": 24962.6,
+          "h1_open": 24981.21,
           "mm50_slope": 9.86641,
-          "overnight_gap": 94.98,
-          "points": 158.17,
+          "overnight_gap": 558.31,
+          "points": -169.77,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 14.13522,
           "date": "2026-03-04",
-          "h1_high": 24517.62,
-          "h1_low": 24364.14,
-          "h1_open": 24476.26,
+          "h1_high": 24844.56,
+          "h1_low": 24643.75,
+          "h1_open": 24663.71,
           "mm50_slope": 10.13151,
-          "overnight_gap": -2.1,
-          "points": -20.73,
+          "overnight_gap": 185.35,
+          "points": -174.54,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 13.50398,
           "date": "2026-03-05",
-          "h1_high": 24579.4,
-          "h1_low": 24417.13,
-          "h1_open": 24481.37,
+          "h1_high": 24853.9,
+          "h1_low": 24728.31,
+          "h1_open": 24765.71,
           "mm50_slope": 10.22573,
-          "overnight_gap": 281.9,
-          "points": 135.85,
+          "overnight_gap": 566.24,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 12.91783,
           "date": "2026-03-06",
-          "h1_high": 24590.42,
-          "h1_low": 24440.7,
-          "h1_open": 24544.45,
+          "h1_high": 24636.06,
+          "h1_low": 24525.05,
+          "h1_open": 24550.22,
           "mm50_slope": 10.57154,
-          "overnight_gap": 84.18,
-          "points": 105.87,
-          "status": "traded",
-          "trade_count": 1
+          "overnight_gap": 89.95,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 13.41297,
           "date": "2026-03-09",
-          "h1_high": 24707.74,
-          "h1_low": 24554.47,
-          "h1_open": 24565.65,
+          "h1_high": 24518.9,
+          "h1_low": 24319.28,
+          "h1_open": 24475.26,
           "mm50_slope": 10.44738,
-          "overnight_gap": 153.54,
-          "points": -174.54,
+          "overnight_gap": 63.15,
+          "points": -284.12,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 2
         },
         {
           "adx14": 13.87275,
           "date": "2026-03-10",
-          "h1_high": 24586.37,
-          "h1_low": 24436.78,
-          "h1_open": 24582.28,
+          "h1_high": 24382.27,
+          "h1_low": 24030.68,
+          "h1_open": 24048.13,
           "mm50_slope": 10.66631,
-          "overnight_gap": -4.05,
-          "points": 112.35,
+          "overnight_gap": -538.2,
+          "points": -189.14,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 1
         },
         {
           "adx14": 15.72043,
           "date": "2026-03-12",
-          "h1_high": 24739.95,
-          "h1_low": 24590.84,
-          "h1_open": 24670.64,
+          "h1_high": 24491.44,
+          "h1_low": 24272.31,
+          "h1_open": 24471.05,
           "mm50_slope": 11.1303,
-          "overnight_gap": 28.46,
-          "points": 125.24,
+          "overnight_gap": -171.13,
+          "points": -341.8,
           "status": "traded",
-          "trade_count": 3
+          "trade_count": 2
         },
         {
           "adx14": 16.95558,
           "date": "2026-03-13",
-          "h1_high": 24758.3,
-          "h1_low": 24571.97,
-          "h1_open": 24629.13,
+          "h1_high": 24830.4,
+          "h1_low": 24579.71,
+          "h1_open": 24579.89,
           "mm50_slope": 11.276,
-          "overnight_gap": -59.13,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -108.37,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
         },
         {
           "adx14": 16.90595,
           "date": "2026-03-16",
-          "h1_high": 24753.46,
-          "h1_low": 24602.01,
-          "h1_open": 24663.11,
+          "h1_high": 24050.28,
+          "h1_low": 23945.01,
+          "h1_open": 23948.37,
           "mm50_slope": 11.24784,
-          "overnight_gap": 166.35,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -548.39,
+          "points": 138.72,
+          "status": "traded",
+          "trade_count": 5
         },
         {
           "adx14": 17.01098,
           "date": "2026-03-17",
-          "h1_high": 24810.75,
-          "h1_low": 24628.67,
-          "h1_open": 24695.57,
+          "h1_high": 24772.19,
+          "h1_low": 24664.15,
+          "h1_open": 24711.06,
           "mm50_slope": 11.27264,
-          "overnight_gap": 17.2,
-          "points": 28.65,
+          "overnight_gap": 32.69,
+          "points": 70.62,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 17.49488,
           "date": "2026-03-18",
-          "h1_high": 24781.71,
-          "h1_low": 24684.13,
-          "h1_open": 24704.18,
+          "h1_high": 24931.1,
+          "h1_low": 24659.93,
+          "h1_open": 24711.79,
           "mm50_slope": 11.32341,
-          "overnight_gap": 23.53,
-          "points": 150.86,
+          "overnight_gap": 31.14,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 18.78479,
           "date": "2026-03-19",
-          "h1_high": 24829.65,
-          "h1_low": 24682.76,
-          "h1_open": 24792.03,
+          "h1_high": 24938.47,
+          "h1_low": 24783.37,
+          "h1_open": 24859.94,
           "mm50_slope": 11.7235,
-          "overnight_gap": -7.27,
-          "points": 237.76,
+          "overnight_gap": 60.64,
+          "points": 255.26,
           "status": "traded",
           "trade_count": 2
         },
         {
           "adx14": 19.98255,
           "date": "2026-03-20",
-          "h1_high": 24832.24,
-          "h1_low": 24678.84,
-          "h1_open": 24713.31,
+          "h1_high": 24804.12,
+          "h1_low": 24668.17,
+          "h1_open": 24799.95,
           "mm50_slope": 11.62098,
-          "overnight_gap": -41.7,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.0392,
-          "date": "2026-03-23",
-          "h1_high": 24852.27,
-          "h1_low": 24711.41,
-          "h1_open": 24756.37,
-          "mm50_slope": 11.91662,
-          "overnight_gap": -24.66,
-          "points": 219.85,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.13511,
-          "date": "2026-03-24",
-          "h1_high": 24948.35,
-          "h1_low": 24808.46,
-          "h1_open": 24809.1,
-          "mm50_slope": 11.63338,
-          "overnight_gap": 168.98,
-          "points": 99.69,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.55155,
-          "date": "2026-03-25",
-          "h1_high": 24942.27,
-          "h1_low": 24776.04,
-          "h1_open": 24792.86,
-          "mm50_slope": 11.58355,
-          "overnight_gap": 13.07,
-          "points": 0.0,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.65692,
-          "date": "2026-03-26",
-          "h1_high": 24861.8,
-          "h1_low": 24753.51,
-          "h1_open": 24792.52,
-          "mm50_slope": 11.41358,
-          "overnight_gap": 66.52,
-          "points": 58.99,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.75476,
-          "date": "2026-03-27",
-          "h1_high": 24821.43,
-          "h1_low": 24605.01,
-          "h1_open": 24805.58,
-          "mm50_slope": 11.22718,
-          "overnight_gap": 64.53,
-          "points": 62.3,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.05312,
-          "date": "2026-03-30",
-          "h1_high": 24856.28,
-          "h1_low": 24649.6,
-          "h1_open": 24823.81,
-          "mm50_slope": 11.23198,
-          "overnight_gap": -29.54,
-          "points": 178.32,
-          "status": "traded",
-          "trade_count": 2
-        },
-        {
-          "adx14": 21.70706,
-          "date": "2026-03-31",
-          "h1_high": 24986.86,
-          "h1_low": 24853.75,
-          "h1_open": 24878.25,
-          "mm50_slope": 11.08169,
-          "overnight_gap": 117.65,
-          "points": 103.56,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.46958,
-          "date": "2026-04-01",
-          "h1_high": 24976.44,
-          "h1_low": 24820.18,
-          "h1_open": 24834.5,
-          "mm50_slope": 11.03512,
-          "overnight_gap": -226.45,
-          "points": 260.27,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 23.17763,
-          "date": "2026-04-02",
-          "h1_high": 24871.98,
-          "h1_low": 24752.32,
-          "h1_open": 24843.34,
-          "mm50_slope": 10.80869,
-          "overnight_gap": -75.37,
-          "points": 152.75,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 22.58099,
-          "date": "2026-04-03",
-          "h1_high": 24995.77,
-          "h1_low": 24907.38,
-          "h1_open": 24963.16,
-          "mm50_slope": 10.59234,
-          "overnight_gap": 133.32,
-          "points": -130.37,
-          "status": "traded",
-          "trade_count": 7
-        },
-        {
-          "adx14": 23.24619,
-          "date": "2026-04-06",
-          "h1_high": 25039.71,
-          "h1_low": 24847.65,
-          "h1_open": 24897.59,
-          "mm50_slope": 10.91611,
-          "overnight_gap": -176.81,
+          "overnight_gap": 44.94,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 23.24408,
-          "date": "2026-04-07",
-          "h1_high": 24968.19,
-          "h1_low": 24829.07,
-          "h1_open": 24883.25,
-          "mm50_slope": 11.04254,
-          "overnight_gap": -157.29,
-          "points": -167.22,
+          "adx14": 21.0392,
+          "date": "2026-03-23",
+          "h1_high": 24487.25,
+          "h1_low": 24349.0,
+          "h1_open": 24397.19,
+          "mm50_slope": 11.91662,
+          "overnight_gap": -383.84,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 21.13511,
+          "date": "2026-03-24",
+          "h1_high": 24561.59,
+          "h1_low": 24286.59,
+          "h1_open": 24297.57,
+          "mm50_slope": 11.63338,
+          "overnight_gap": -342.55,
+          "points": 230.97,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.55155,
+          "date": "2026-03-25",
+          "h1_high": 24464.46,
+          "h1_low": 24261.8,
+          "h1_open": 24360.43,
+          "mm50_slope": 11.58355,
+          "overnight_gap": -419.36,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.65692,
+          "date": "2026-03-26",
+          "h1_high": 24343.17,
+          "h1_low": 24147.12,
+          "h1_open": 24295.69,
+          "mm50_slope": 11.41358,
+          "overnight_gap": -430.31,
+          "points": 188.47,
           "status": "traded",
           "trade_count": 2
         },
         {
+          "adx14": 21.75476,
+          "date": "2026-03-27",
+          "h1_high": 25216.56,
+          "h1_low": 24936.7,
+          "h1_open": 24986.39,
+          "mm50_slope": 11.22718,
+          "overnight_gap": 245.34,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
+        },
+        {
+          "adx14": 22.05312,
+          "date": "2026-03-30",
+          "h1_high": 24912.1,
+          "h1_low": 24803.97,
+          "h1_open": 24809.77,
+          "mm50_slope": 11.23198,
+          "overnight_gap": -43.58,
+          "points": 58.36,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 21.70706,
+          "date": "2026-03-31",
+          "h1_high": 24487.71,
+          "h1_low": 24287.24,
+          "h1_open": 24420.41,
+          "mm50_slope": 11.08169,
+          "overnight_gap": -340.19,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 22.46958,
+          "date": "2026-04-01",
+          "h1_high": 24913.73,
+          "h1_low": 24790.89,
+          "h1_open": 24803.13,
+          "mm50_slope": 11.03512,
+          "overnight_gap": -257.82,
+          "points": 0.0,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 23.17763,
+          "date": "2026-04-02",
+          "h1_high": 25037.73,
+          "h1_low": 24914.3,
+          "h1_open": 25017.55,
+          "mm50_slope": 10.80869,
+          "overnight_gap": 98.84,
+          "points": -13.33,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 22.58099,
+          "date": "2026-04-03",
+          "h1_high": 24850.85,
+          "h1_low": 24745.94,
+          "h1_open": 24749.0,
+          "mm50_slope": 10.59234,
+          "overnight_gap": -80.84,
+          "points": -65.83,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 23.24619,
+          "date": "2026-04-06",
+          "h1_high": 24961.04,
+          "h1_low": 24769.59,
+          "h1_open": 24790.29,
+          "mm50_slope": 10.91611,
+          "overnight_gap": -284.11,
+          "points": 328.17,
+          "status": "traded",
+          "trade_count": 3
+        },
+        {
+          "adx14": 23.24408,
+          "date": "2026-04-07",
+          "h1_high": 24873.21,
+          "h1_low": 24735.28,
+          "h1_open": 24846.18,
+          "mm50_slope": 11.04254,
+          "overnight_gap": -194.36,
+          "points": 117.18,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
           "adx14": 22.53728,
           "date": "2026-04-09",
-          "h1_high": 25146.14,
-          "h1_low": 24917.48,
-          "h1_open": 24940.82,
+          "h1_high": 24659.71,
+          "h1_low": 24372.86,
+          "h1_open": 24523.69,
           "mm50_slope": 10.57134,
-          "overnight_gap": -40.14,
-          "points": 50.1,
+          "overnight_gap": -457.27,
+          "points": -167.65,
           "status": "traded",
           "trade_count": 3
         },
         {
           "adx14": 22.56853,
           "date": "2026-04-10",
-          "h1_high": 25033.09,
-          "h1_low": 24800.38,
-          "h1_open": 24901.98,
+          "h1_high": 24758.39,
+          "h1_low": 24616.33,
+          "h1_open": 24625.92,
           "mm50_slope": 10.59867,
-          "overnight_gap": 3.55,
-          "points": 0.0,
+          "overnight_gap": -272.51,
+          "points": -171.45,
           "status": "traded",
           "trade_count": 3
         },
         {
           "adx14": 22.68095,
           "date": "2026-04-13",
-          "h1_high": 24883.99,
-          "h1_low": 24704.58,
-          "h1_open": 24871.58,
+          "h1_high": 25445.21,
+          "h1_low": 25318.24,
+          "h1_open": 25401.88,
           "mm50_slope": 10.4506,
-          "overnight_gap": -36.99,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": 493.31,
+          "points": 380.12,
+          "status": "traded",
+          "trade_count": 4
         },
         {
           "adx14": 22.78535,
           "date": "2026-04-14",
-          "h1_high": 25003.45,
-          "h1_low": 24825.84,
-          "h1_open": 24983.58,
+          "h1_high": 25439.26,
+          "h1_low": 25174.73,
+          "h1_open": 25191.45,
           "mm50_slope": 10.34705,
-          "overnight_gap": 127.27,
-          "points": -184.13,
+          "overnight_gap": 335.14,
+          "points": 0.0,
           "status": "traded",
           "trade_count": 1
         },
         {
           "adx14": 23.64665,
           "date": "2026-04-15",
-          "h1_high": 24909.07,
-          "h1_low": 24705.88,
-          "h1_open": 24897.45,
+          "h1_high": 24803.82,
+          "h1_low": 24587.68,
+          "h1_open": 24802.51,
           "mm50_slope": 9.88754,
-          "overnight_gap": 71.66,
+          "overnight_gap": -23.28,
+          "points": 81.33,
+          "status": "traded",
+          "trade_count": 4
+        },
+        {
+          "adx14": 24.44644,
+          "date": "2026-04-16",
+          "h1_high": 24730.56,
+          "h1_low": 24601.32,
+          "h1_open": 24672.17,
+          "mm50_slope": 9.69627,
+          "overnight_gap": -287.5,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
         },
         {
-          "adx14": 24.44644,
-          "date": "2026-04-16",
-          "h1_high": 24903.69,
-          "h1_low": 24792.69,
-          "h1_open": 24895.44,
-          "mm50_slope": 9.69627,
-          "overnight_gap": -64.23,
-          "points": -21.02,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
           "adx14": 23.82581,
           "date": "2026-04-17",
-          "h1_high": 25015.27,
-          "h1_low": 24918.14,
-          "h1_open": 24922.2,
+          "h1_high": 24905.19,
+          "h1_low": 24800.44,
+          "h1_open": 24846.48,
           "mm50_slope": 9.48713,
-          "overnight_gap": 191.53,
-          "points": 132.66,
-          "status": "traded",
-          "trade_count": 2
+          "overnight_gap": 115.81,
+          "points": 0,
+          "status": "no_trade",
+          "trade_count": 0
         },
         {
           "adx14": 23.50007,
           "date": "2026-04-20",
-          "h1_high": 24861.01,
-          "h1_low": 24657.67,
-          "h1_open": 24849.79,
+          "h1_high": 24916.34,
+          "h1_low": 24821.72,
+          "h1_open": 24891.25,
           "mm50_slope": 8.99244,
-          "overnight_gap": -120.38,
+          "overnight_gap": -78.92,
+          "points": 95.2,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 22.4151,
+          "date": "2026-04-21",
+          "h1_high": 24369.93,
+          "h1_low": 24088.57,
+          "h1_open": 24367.41,
+          "mm50_slope": 8.57465,
+          "overnight_gap": -408.61,
+          "points": -56.23,
+          "status": "traded",
+          "trade_count": 1
+        },
+        {
+          "adx14": 21.80969,
+          "date": "2026-04-22",
+          "h1_high": 24529.58,
+          "h1_low": 24349.57,
+          "h1_open": 24397.63,
+          "mm50_slope": 8.29582,
+          "overnight_gap": -388.53,
+          "points": -178.15,
+          "status": "traded",
+          "trade_count": 2
+        },
+        {
+          "adx14": 21.85203,
+          "date": "2026-04-23",
+          "h1_high": 25023.08,
+          "h1_low": 24905.37,
+          "h1_open": 24966.66,
+          "mm50_slope": 8.1741,
+          "overnight_gap": 24.49,
           "points": 0.0,
           "status": "traded",
           "trade_count": 1
         },
         {
-          "adx14": 22.4151,
-          "date": "2026-04-21",
-          "h1_high": 24883.66,
-          "h1_low": 24719.38,
-          "h1_open": 24855.48,
-          "mm50_slope": 8.57465,
-          "overnight_gap": 79.46,
-          "points": -19.36,
-          "status": "traded",
-          "trade_count": 3
-        },
-        {
-          "adx14": 21.80969,
-          "date": "2026-04-22",
-          "h1_high": 24956.67,
-          "h1_low": 24825.3,
-          "h1_open": 24886.64,
-          "mm50_slope": 8.29582,
-          "overnight_gap": 100.48,
-          "points": -176.2,
-          "status": "traded",
-          "trade_count": 1
-        },
-        {
-          "adx14": 21.85203,
-          "date": "2026-04-23",
-          "h1_high": 24967.34,
-          "h1_low": 24877.77,
-          "h1_open": 24908.73,
-          "mm50_slope": 8.1741,
-          "overnight_gap": -33.44,
+          "adx14": 21.89135,
+          "date": "2026-04-24",
+          "h1_high": 24446.15,
+          "h1_low": 24231.92,
+          "h1_open": 24385.38,
+          "mm50_slope": 7.86368,
+          "overnight_gap": -511.65,
           "points": 0,
           "status": "no_trade",
           "trade_count": 0
-        },
-        {
-          "adx14": 21.89135,
-          "date": "2026-04-24",
-          "h1_high": 25026.23,
-          "h1_low": 24891.45,
-          "h1_open": 24915.19,
-          "mm50_slope": 7.86368,
-          "overnight_gap": 18.16,
-          "points": -165.16,
-          "status": "traded",
-          "trade_count": 2
         },
         {
           "adx14": 20.68512,
           "date": "2026-04-27",
-          "h1_high": 25067.03,
-          "h1_low": 24861.88,
-          "h1_open": 24867.24,
+          "h1_high": 24585.6,
+          "h1_low": 24467.2,
+          "h1_open": 24565.15,
           "mm50_slope": 7.61548,
-          "overnight_gap": 95.3,
-          "points": 0,
-          "status": "no_trade",
-          "trade_count": 0
+          "overnight_gap": -206.79,
+          "points": -189.73,
+          "status": "traded",
+          "trade_count": 3
         },
         {
           "adx14": 19.56505,
           "date": "2026-04-28",
-          "h1_high": 24896.91,
-          "h1_low": 24784.07,
-          "h1_open": 24842.33,
+          "h1_high": 24644.8,
+          "h1_low": 24523.62,
+          "h1_open": 24631.72,
           "mm50_slope": 7.22627,
-          "overnight_gap": 41.73,
-          "points": -153.53,
+          "overnight_gap": -168.88,
+          "points": -5.29,
           "status": "traded",
-          "trade_count": 1
+          "trade_count": 3
         },
         {
           "adx14": 18.49656,
           "date": "2026-04-29",
-          "h1_high": 24867.82,
-          "h1_low": 24722.07,
-          "h1_open": 24822.24,
+          "h1_high": 25457.02,
+          "h1_low": 25315.59,
+          "h1_open": 25409.49,
           "mm50_slope": 7.12002,
-          "overnight_gap": 29.96,
-          "points": -338.69,
+          "overnight_gap": 617.21,
+          "points": 0.0,
           "status": "traded",
-          "trade_count": 2
+          "trade_count": 1
         },
         {
           "adx14": 17.5671,
           "date": "2026-04-30",
-          "h1_high": 24939.4,
-          "h1_low": 24783.46,
-          "h1_open": 24856.16,
+          "h1_high": 25395.6,
+          "h1_low": 25195.37,
+          "h1_open": 25305.26,
           "mm50_slope": 6.64619,
-          "overnight_gap": 150.88,
-          "points": 107.34,
+          "overnight_gap": 599.98,
+          "points": -0.33,
           "status": "traded",
           "trade_count": 1
         }
       ],
       "summary": {
-        "average_loss": 154.0838,
-        "average_win": 95.8897,
+        "average_loss": 149.2322,
+        "average_win": 100.5352,
         "definition_code": "G9HSL",
         "end_date": "2026-04-30",
-        "final_result": 929.63,
-        "number_of_be": 29,
+        "final_result": -216.14,
+        "number_of_be": 28,
         "number_of_days": 42,
-        "number_of_losing_positions": 13,
-        "number_of_trades": 73,
-        "number_of_winning_positions": 31,
+        "number_of_losing_positions": 18,
+        "number_of_trades": 71,
+        "number_of_winning_positions": 25,
         "start_date": "2026-03-02"
       }
     }


### PR DESCRIPTION
Follow-up to your "the golden feature is hard to maintain" point. **Stacked on #692** — retarget to `main` once that merges.

Two fixes for the two things that actually made it painful.

## 1. Regeneration was one command away from a silent behavior change

The old script rewrote the file wholesale. So the test whose entire job is *failing when behavior moves* could be made green by running it. In phase 3 my fixture bug changed all seven shipped definitions and the suite passed afterwards — I only caught it by diffing the regenerated file per definition, a step nothing enforced.

Now: new definitions are written freely, but changing one already in the file is **refused**, with what moved printed:

```
REFUSED: these definitions already exist in the snapshot and their results changed:

    G9H
      number_of_trades: 3 -> 76
      final_result: 99999.0 -> 1378.97

If the change is intended, name them:
    python -m tests.api.services.backtest.test_backtest_golden --accept G9H
If it is not, this is the regression the snapshot exists to catch - fix the code, not the file.
```

Exit 1, file untouched. `--accept G9H` (or `--accept all`) allows it. Adding a backtest — the common case — stays one command with no flag.

13 tests in `test_golden_regeneration.py` cover the gate itself, including that a refusal leaves the file byte-identical and that a change *outside* the summary (per-day rows, a trade's exit price) is still caught.

Also: regeneration used to emit ~890KB of DynamoDB cache warnings, burying the one thing it exists to print. Silenced.

## 2. The fixture answered in strategy-shaped questions

It served one H1 *reference* candle per day and a post-10:00 5-minute scan — the shapes the strategies of the day happened to ask for. A backtest with a new shape couldn't be added without editing the market, which is why a combo definition saw 21 candles where `combo` needs 235, and why I ended up with a window-width discriminator.

It now draws **one 5-minute price path per instrument and day** across the widest session, and aggregates it to whatever timeframe and window is asked for. Buckets are anchored to midnight, so a 09:00–10:00 request and a 02:00–22:00 request agree on the 09:00 hourly candle. Nothing in the file knows a strategy exists; the discriminator is gone.

## Every snapshot changed — and why that's fine

The market changed, so all ten entries did. Accepted deliberately through the new gate, which is a fair first exercise of it.

**The evidence no strategy moved**: the 475 unit tests that pin the actual rules passed untouched throughout. That's the right division of labour — unit tests pin rules, the snapshot pins the composition.

## I have to correct something I told you

**C1H now trades 14 times.** In #692 I reported it produced zero trades and suggested FR-C10 might make H1 untradeable because the ma50 sits above the mm20 in a trend. That reading was **an artifact of the old fixture**, which drew the H1 path from a separate RNG with its own drift. With one coherent path across timeframes, H1 trades normally.

The FR-C10 mechanism is real and still worth checking against live data, but "H1 may be untradeable" was the fixture talking, not the strategy. I'd disregard that part of #692's description.

A happy side effect: the detail day moves to 2026-04-10 where all ten definitions trade, which **retires both exemption lists** #692 had to introduce.

## Verification

```
955 passed, 10 skipped
flake8 0 · mypy 0 · black/isort clean
```

Both gate paths exercised by hand as well: corrupting `G9H`'s entry produced the refusal above with the file untouched, and `--accept G9H` then wrote it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141Ck7BANUxeAZC51V6WnDQ)_