### PR TITLE
docs: spec 028 — workflow-trigger corroboration in the alert triage agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Examples:
 - N/A — ephemeral, computed on demand per request, nothing persisted (inherits spec 021's decision). (025-ger40-bougie-9h)
 - Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI + Pydantic v2, existing `services/indicator_service.py` (`combo`, `bollinger_bands`), existing `services/candles_service.py` (`get_candles_in_window`), `aioboto3` (DynamoDB), `zoneinfo`; React Router DOM v7+, Axios, Vite. **No new dependency.** (026-combo-ger40-backtest)
 - existing DynamoDB backtest raw-candle table, under a **new key namespace** for arbitrary-timeframe series (`{instrument}:{session}:{ut}:v1`). No new table, no migration of existing entries. (026-combo-ger40-backtest)
+- Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + existing only — `aioboto3` (DynamoDB), `anthropic` SDK, `slack_sdk`, FastAPI + Pydantic v2, `zoneinfo`; Axios, React Router DOM v7+, Vite. **No new dependency.** (028-triage-workflow-trigger)
+- existing tables only — reads `workflow_orders` and `workflows`, writes enriched asset entries into the existing `alert_digests` items. No new table, no migration. (028-triage-workflow-trigger)
 
 ## Recent Changes
 - 004-watchlist-menu: Added Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend) + FastAPI (backend), Vite + React Router DOM v7+ (frontend)

--- a/specs/028-triage-workflow-trigger/checklists/requirements.md
+++ b/specs/028-triage-workflow-trigger/checklists/requirements.md
@@ -1,0 +1,62 @@
+# Specification Quality Checklist: Workflow-Trigger Corroboration in the Alert Triage Agent
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+- [x] Failure-tolerance requirement is stated as an observable outcome, not a code pattern
+
+## Validation Notes
+
+**Iteration 1 findings (resolved in the spec as written):**
+
+- *Implementation leakage*: the source description names concrete storage tables, functions, and field
+  names. These were restated as domain outcomes — "the instrument actually traded (the CFD)" resolved to
+  "the underlying asset the workflow watches" (FR-003) — so the spec describes the join rule without
+  naming the mechanism. The technical join path belongs in `plan.md`.
+- *Untestable phrasing*: "at least as authoritative as the combo pattern" was generalised to "at least as
+  authoritative as the strongest existing directional pattern" (FR-008), which stays true if the pattern
+  set changes.
+- *Unbounded failure requirement*: "logged and swallowed" was split into an observable outcome (FR-019,
+  the brief is identical to the no-feature brief) and a delivery constraint (FR-020, failures reach
+  operational logs only), both verifiable from outside the system.
+
+**Open decision carried into planning:**
+
+- A-003 (dry-run triggers included and labelled vs. excluded outright) is an informed default, not a
+  confirmed choice. It is written so that reversing it removes FR-012 and adds a filter to FR-001 —
+  a contained change. Worth confirming before `/speckit.plan`.
+
+**Dependency worth restating:**
+
+- A-001 (alert set and workflow set overlap) was accepted on the trader's word rather than measured. If
+  the overlap turns out to be thin in practice, SC-001 through SC-003 become untestable in production and
+  the feature's value assumption should be revisited before further investment.
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/028-triage-workflow-trigger/contracts/alert-digests.openapi.yaml
+++ b/specs/028-triage-workflow-trigger/contracts/alert-digests.openapi.yaml
@@ -1,0 +1,130 @@
+openapi: 3.1.0
+info:
+  title: Alert Digests API — workflow-trigger corroboration (delta)
+  version: 1.1.0
+  description: >
+    Additive change to the Alert Digests read API introduced by spec 028. No new
+    path, no new parameter, no changed response code: TriagedAssetResponse gains
+    an optional workflow_triggers array carrying the same-day workflow firings
+    that corroborated the asset.
+
+    Existing clients are unaffected — the field is omitted entirely when an asset
+    has no triggers, which is the case for most assets, for every day with no
+    triggers, and for every digest written before this feature (no backfill).
+
+    Both existing paths (/api/alert-digests and /api/alert-digests/{run_date})
+    return the enriched shape; only the changed schemas are reproduced here.
+    See specs/023-alert-triage/contracts/alert-digests.openapi.yaml for the full
+    contract.
+servers:
+  - url: http://localhost:8000
+
+components:
+  schemas:
+    WorkflowTriggerResponse:
+      type: object
+      description: >
+        A registered workflow that fired during the current Paris trading day on
+        this asset. Evidence produced by a mechanism independent of the chart
+        pattern detectors — pre-registered by the trader rather than matched
+        after the fact.
+      required: [workflow_name, direction, order_price, placed_at, dry_run]
+      additionalProperties: false
+      properties:
+        workflow_name:
+          type: string
+          description: Name of the workflow that fired.
+          examples: ["AI breakout H1"]
+        direction:
+          type: string
+          enum: [BUY, SELL]
+          description: >
+            Order direction, as the Direction enum NAME — matching how the
+            workflow_orders table stores it. Note this is the name (BUY), not
+            the value (Buy).
+        order_price:
+          type: number
+          format: float
+          description: Price of the order the workflow produced.
+          examples: [158.4]
+        trigger_close:
+          type: [number, "null"]
+          format: float
+          default: null
+          description: >
+            Market close at the moment the workflow fired. Null when the engine
+            could not record it.
+          examples: [157.9]
+        placed_at:
+          type: integer
+          format: int64
+          description: >
+            Epoch seconds when the workflow fired. Clients render the Paris-local
+            time of day from this.
+          examples: [1785412200]
+        dry_run:
+          type: boolean
+          description: >
+            True when the workflow was in dry-run mode — the rule fired but no
+            capital was committed. Read from the workflow definition, not the
+            order row. Displayed distinctly and weighed one step lower in
+            ranking.
+
+    TriagedAssetResponse:
+      type: object
+      description: >
+        Unchanged except for the final property. Reproduced in full so the
+        addition is unambiguous.
+      required: [asset_code, asset_description, exchange, conviction, rationale, patterns]
+      properties:
+        asset_code:
+          type: string
+          description: Asset symbol or ticker.
+        asset_description:
+          type: string
+          description: Human-readable asset name.
+        exchange:
+          type: string
+          description: Exchange name (e.g. 'saxo', 'binance').
+        country_code:
+          type: [string, "null"]
+          default: null
+          description: Exchange or country code (null for crypto assets).
+        conviction:
+          type: string
+          enum: [high, watch, noise]
+          description: Conviction tier.
+        rank:
+          type: [integer, "null"]
+          default: null
+          description: 1-based rank within high+watch (null for noise).
+        rationale:
+          type: string
+          description: >
+            One-line rationale (empty for noise). When a workflow trigger
+            influenced the ranking, it is named here.
+        patterns:
+          type: array
+          items:
+            type: string
+          description: Distinct patterns that fired on this asset.
+        ma50_slope:
+          type: [number, "null"]
+          format: float
+          default: null
+          description: MA50 slope used in ranking.
+        tradingview_url:
+          type: [string, "null"]
+          default: null
+          description: Custom TradingView URL if configured.
+        workflow_triggers:
+          type: [array, "null"]
+          default: null
+          description: >
+            NEW in 1.1.0. Same-day workflow firings that corroborated this asset.
+            Omitted entirely when the asset has none — clients MUST treat an
+            absent field as "no corroboration", never as an error. Multiple
+            entries still represent a single point of convergence for ranking
+            purposes.
+          items:
+            $ref: "#/components/schemas/WorkflowTriggerResponse"

--- a/specs/028-triage-workflow-trigger/data-model.md
+++ b/specs/028-triage-workflow-trigger/data-model.md
@@ -1,0 +1,188 @@
+# Data Model: Workflow-Trigger Corroboration
+
+**Feature**: 028-triage-workflow-trigger | **Date**: 2026-08-01
+
+No new table. No schema migration. One new domain entity, one new field on an existing entity, and
+an additive field inside the existing `alert_digests` item.
+
+## 1. `WorkflowTrigger` (new — `model/__init__.py`)
+
+A same-day firing of a registered workflow, already resolved to the asset it corroborates.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `workflow_name` | `str` | From the `workflow_orders` row; shown to the trader |
+| `direction` | `Direction` | Existing enum. **Parsed by name** — see §4 |
+| `order_price` | `float` | Price of the order the workflow produced |
+| `trigger_close` | `Optional[float]` | Market close at firing; `None` when the engine could not record it |
+| `placed_at` | `int` | Epoch seconds; the source of the displayed time of day |
+| `dry_run` | `bool` | From the **workflow definition**, not the order row |
+
+**Validation**
+- `order_price > 0` — `workflow_orders` already enforces this at write time (`WorkflowOrder.__post_init__`), so a violation means corrupt data: log and drop the trigger.
+- `direction` must resolve to a `Direction` member; an unknown value raises `SaxoException` inside the collector, which catches it, logs, and drops that trigger.
+- `placed_at` must fall inside the session window (§5); out-of-window rows are filtered before construction.
+
+**Not carried**: `order_quantity`, `order_type`, `asset_type`, `execution_context`, `ttl`, `id`,
+`workflow_id`. The brief answers "was this corroborated, which way, when" — position sizing and
+order mechanics belong to the workflow orders page.
+
+## 2. `TriagedAsset` (modified — `model/__init__.py`)
+
+```python
+@dataclass
+class TriagedAsset:
+    asset_code: str
+    asset_description: str
+    exchange: str
+    conviction: Conviction
+    rationale: str
+    patterns: List[AlertType]
+    ma50_slope: Optional[float] = None
+    rank: Optional[int] = None
+    country_code: Optional[str] = None
+    workflow_triggers: List[WorkflowTrigger] = field(default_factory=list)   # NEW
+```
+
+Empty list on most assets. Defaulting to `[]` rather than `None` keeps every consumer's iteration
+unconditional; "has corroboration" is `len(...) > 0`, expressed once.
+
+## 3. `AlertDigest`
+
+Unchanged — same fields, same key schema, same absence of TTL. Only the contents of its
+`triaged_assets` grow.
+
+## 4. Join: `workflow_orders` row → asset
+
+Three steps, each of which can drop a trigger without affecting the rest.
+
+**Step 1 — window filter.** Keep rows whose `placed_at` is inside the session window (§5).
+
+**Step 2 — resolve the underlying.** `workflow_orders.order_code` is the **CFD actually traded**,
+not the asset the alert scan sees. Join `workflow_orders.workflow_id` against the
+`{workflow_id: (name, index, dry_run)}` map built from one `get_all_workflows()` read.
+`workflow.index` is the underlying; `workflow.dry_run` is the label. A `workflow_id` absent from the
+map (deleted workflow) drops the trigger.
+
+**Step 3 — match to an alert asset.** Case-insensitive, reusing the semantics of
+`WorkflowService.get_workflows_by_asset`:
+
+```
+index.lower() == asset_code.lower()
+  or index.lower() == f"{asset_code}:{country_code}".lower()
+```
+
+**Trap — never match on `Alert.id`.** `Alert.id` joins with an underscore (`AI_xpar`);
+`workflow.index` uses a colon (`AI:xpar`). Comparing ids would silently never match and the feature
+would appear to do nothing. Match on the `asset_code` / `country_code` fields.
+
+**Trap — `order_direction` is stored as the enum NAME.** `WorkflowEngine` writes
+`order_direction.name`, so the stored value is `"BUY"`, while `Direction.BUY.value` is `"Buy"`.
+Parse with `Direction[value]`, not `Direction(value)`.
+
+Unmatched triggers are logged with both sides of the comparison — a mismatch must be diagnosable
+from one run's logs, not inferred from an absence of corroboration.
+
+## 5. Session window
+
+```
+start = midnight of run_date in ZoneInfo("Europe/Paris")   → epoch seconds
+end   = now                                                → epoch seconds
+keep row if start <= placed_at <= end
+```
+
+`run_date` comes from the digest being built, so manual and off-schedule runs compute their own
+window rather than assuming the 18:15 schedule.
+
+## 6. Collector output
+
+```python
+Dict[str, List[WorkflowTrigger]]
+```
+
+Keyed by the same key `TriageAgent._group_by_asset` uses (`Alert.id`), so attaching is a dict
+lookup with no second matching rule. Assets with no trigger are **absent** from the map, not present
+with an empty list. On any failure the whole map is `{}`.
+
+## 7. Reasoning payload
+
+Per asset, `workflow_triggers` is added **only when non-empty**:
+
+```json
+{
+  "id": "AI_xpar",
+  "patterns": ["combo", "mm50_touch"],
+  "ma50_slope": 4.2,
+  "workflow_triggers": [
+    {"workflow": "AI breakout H1", "direction": "Buy", "dry_run": false, "hour": "14:30"}
+  ]
+}
+```
+
+`hour` is Paris-local `HH:MM` derived from `placed_at` — the model reasons about "when in the
+session", not about epoch arithmetic. Prices are omitted from the payload: they carry no ranking
+information and would invite spurious precision. The response schema is **unchanged** (research R7);
+triggers are re-attached from the collector map when building each `TriagedAsset`, never read back
+from the model.
+
+## 8. Persistence (inside the existing `alert_digests` item)
+
+```json
+{
+  "asset_code": "AI",
+  "conviction": "high",
+  "rank": 1,
+  "patterns": ["combo", "mm50_touch"],
+  "ma50_slope": 4.2,
+  "workflow_triggers": [
+    {
+      "workflow_name": "AI breakout H1",
+      "direction": "BUY",
+      "order_price": 158.4,
+      "trigger_close": 157.9,
+      "placed_at": 1785412200,
+      "dry_run": false
+    }
+  ]
+}
+```
+
+Omitted entirely when empty, so existing items and no-trigger days are byte-identical to today.
+Floats pass through the existing `_convert_floats_to_decimal` on write; `AlertDigestService`
+converts `Decimal` back to `float` on read. `direction` is stored as the enum **name**, matching
+`workflow_orders` and keeping one parse rule across both tables.
+
+Digests written before this feature have no `workflow_triggers` key — readers must treat a missing
+key as an empty list, never as an error (A-005: no backfill).
+
+## 9. API shape
+
+`WorkflowTriggerResponse` mirrors the persisted fields, plus `placed_at` rendered for display. The
+field on `TriagedAssetResponse` is `Optional[List[...]] = None`, omitted when empty so a no-trigger
+brief serialises exactly as it does today. The TypeScript interface mirrors it field for field, per
+the constitution's API Contract Standards.
+
+## 10. Entity relationships
+
+```
+Workflow (workflows)
+  └─ id ──────────────┐
+                      │  (resolution: 1 read for all)
+WorkflowOrder (workflow_orders, TTL'd)
+  ├─ workflow_id ─────┘
+  ├─ order_code  → the CFD traded  (NOT the join key)
+  └─ placed_at   → window filter
+                      │
+                      ▼  workflow.index ≈ asset_code[:country_code]
+Alert (in memory, this run)
+  └─ asset_code + country_code
+                      │
+                      ▼
+TriagedAsset ──► workflow_triggers: List[WorkflowTrigger]
+                      │
+                      ▼
+AlertDigest (alert_digests, no TTL — outlives the source rows, SC-008)
+```
+
+The lifetime asymmetry is the reason for §8: `workflow_orders` expires, `alert_digests` does not, so
+the digest must carry its own copy of the corroboration it was ranked on. It cannot re-derive it.

--- a/specs/028-triage-workflow-trigger/plan.md
+++ b/specs/028-triage-workflow-trigger/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Workflow-Trigger Corroboration in the Alert Triage Agent
+
+**Branch**: `028-triage-workflow-trigger` | **Date**: 2026-08-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/028-triage-workflow-trigger/spec.md`
+
+## Summary
+
+The daily brief ranks assets on chart-pattern detectors and MA50 slope — evidence that all comes
+from one mechanism, on one set of candles, at one moment. This feature adds the one signal in the
+system that is structurally independent: a same-day workflow trigger, meaning a rule the trader
+registered in advance fired during the session and produced a directional order.
+
+A new `WorkflowTriggerService` reads the day's `workflow_orders` rows and resolves each one from the
+traded CFD back to the underlying asset the workflow watches, using a single read of the workflow
+definitions. The resulting map is handed to `TriageAgent.synthesize`, which stays synchronous and
+pure. Triggers enrich assets already in the alert set and never add new ones. The reasoning prompt
+learns that a trigger is one point of convergence from a separate mechanism, that it carries
+directional authority at least equal to `combo`, and that a trigger contradicting the pattern read
+is a red flag. The deterministic fallback counts a trigger as one extra pattern family. The
+corroboration is stored with the digest and surfaced in the API, the Daily Brief, and Slack.
+
+If anything in the collection or join fails, the collector returns an empty map — which provably
+reproduces today's brief through every downstream path.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (backend), TypeScript 5+ / React 19+ (frontend)
+**Primary Dependencies**: existing only — `aioboto3` (DynamoDB), `anthropic` SDK, `slack_sdk`,
+FastAPI + Pydantic v2, `zoneinfo` (stdlib, already used for Paris-local math in `utils/helper.py`);
+Axios + React Router DOM v7+ on the frontend. **No new dependency.**
+**Storage**: existing tables only — reads `workflow_orders` and `workflows`, writes the enriched
+asset entries into the existing `alert_digests` items. **No new table, no schema migration, no
+Pulumi change.**
+**Testing**: pytest with `unittest.mock`; tests mirror source structure under `tests/`
+**Target Platform**: AWS Lambda (`alerting` command, 18:15 Paris weekdays) + FastAPI API + Vite SPA
+**Project Type**: Web (backend + frontend) with a Lambda entry point
+**Performance Goals**: the enrichment adds two DynamoDB scans of small tables per run — a few
+seconds at most against the scan's existing budget (SC-007)
+**Constraints**: must never delay or break the end-of-day scan; must reproduce the pre-feature brief
+exactly when workflow data is unavailable (FR-019); must not write to any workflow table (FR-021)
+**Scale/Scope**: ~1 digest/day; a handful of triggering workflows per day against a few hundred
+scanned assets
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. Layered Architecture** | PASS. New logic sits in the Service layer (`services/workflow_trigger_service.py`); the CLI command only calls it and passes the result on. No new client methods are needed — `get_all_workflow_orders()` and `get_all_workflows()` already exist, so no service touches client internals. `WorkflowTrigger` lives in the Model layer with no external dependencies. Frontend changes stay in `services/api.ts` (types) and a component (render). |
+| **II. Clean Code First** | PASS. Reuses the matching semantics of `get_workflows_by_asset` rather than inventing a second rule; no shared helper is extracted for two callers (R3). No new config knob (R11). No `assert` — the direction parse raises an explicit exception on an unknown value. |
+| **III. Configuration-Driven** | PASS by vacuity — the feature introduces no threshold, endpoint, or timeout. R11 records why. |
+| **IV. Safe Deployment** | PASS. No infrastructure change; existing tables and IAM grants suffice. Conventional commits throughout. |
+| **V. Domain Model Integrity** | PASS. `Direction` is the existing enum, parsed by **name** because `WorkflowEngine` writes `order_direction.name` (R5). `TriagedAsset` already carries an explicit `exchange`; triggers attach to it and never infer an exchange from `country_code`. |
+| **Planning Requirement** | PASS. Spec and this plan precede implementation; `/speckit.implement` awaits human validation. |
+| **Testing Standards** | PASS. Tests mirror structure; behaviour is asserted (ranking, tier, payload, degraded output), not mock invocation. |
+
+**Post-Phase-1 re-check**: no new violations. The design added no client-internals access, no new
+table, and no cross-layer call. Complexity Tracking stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-triage-workflow-trigger/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 — 11 decisions with alternatives
+├── data-model.md        # Phase 1 — entities, serialisation, join rules
+├── quickstart.md        # Phase 1 — how to exercise the feature locally
+├── contracts/
+│   └── alert-digests.openapi.yaml   # Phase 1 — the additive API change
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 — /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+model/
+└── __init__.py                      # MODIFIED: + WorkflowTrigger; TriagedAsset gains workflow_triggers
+
+services/
+├── workflow_trigger_service.py      # NEW: collect + resolve today's triggers
+└── alert_triage_service.py          # MODIFIED: prompt section, payload, re-attach, fallback tally
+
+saxo_order/commands/
+└── alerting.py                      # MODIFIED: collect triggers, pass into synthesize
+
+client/
+└── aws_client.py                    # MODIFIED: store_alert_digest serialises triggers
+
+api/
+├── models/alert_digest.py           # MODIFIED: + WorkflowTriggerResponse, optional field
+└── services/alert_digest_service.py # MODIFIED: hydrate triggers, Decimal → float
+
+frontend/src/
+├── services/api.ts                  # MODIFIED: + WorkflowTrigger interface, optional field
+└── components/
+    ├── DailyBriefCarousel.tsx       # MODIFIED: render trigger line on corroborated assets
+    └── DailyBriefCarousel.css       # MODIFIED: trigger line + dry-run styling
+
+tests/
+├── services/test_workflow_trigger_service.py   # NEW
+├── services/test_alert_triage_service.py       # MODIFIED
+└── client/test_aws_client_alert_digests.py     # MODIFIED
+```
+
+**Structure Decision**: Standard backend layering for this repo — new Service, existing Clients,
+Model extension — with the frontend change confined to a type and a component. The one deliberate
+divergence from the feature description is the workflow-resolution path: a single
+`get_all_workflows()` scan instead of per-trigger `get_workflow_by_id` calls (research R1), because
+the same record carries both `index` and `dry_run` and the table is one item per workflow.
+
+## Phase Handoff
+
+- Phase 0 → `research.md`: resolution strategy, session window, matching rule, service placement,
+  model shape, prompt design, schema stability, fallback tally, persistence, failure tolerance,
+  configuration.
+- Phase 1 → `data-model.md`, `contracts/alert-digests.openapi.yaml`, `quickstart.md`: entity
+  definitions with validation and join rules, the additive API contract, and a local exercise path.
+- Phase 2 → `tasks.md` via `/speckit.tasks`.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `workflow.index` formatting drifts from the alert asset code, so triggers silently never match | FR-003 drops rather than guesses, and the drop is logged with both sides of the comparison so a mismatch is diagnosable from one run's logs rather than inferred from an absence |
+| Reasoning over-weights a trigger and floods the top tier | A-004 fixes it at one convergence point with no multiplier; the prompt states the cap explicitly, and the fallback uses the same weight so the two paths agree |
+| `order_direction` parsed as value instead of name, yielding a wrong or crashed direction | Called out in R5 and data-model.md; covered by a dedicated round-trip test against a row written by `WorkflowEngine`'s own format |
+| Enrichment slows the end-of-day scan | Two scans of small tables, once per run, after all detection has completed; a failure or timeout returns `{}` rather than retrying |
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/028-triage-workflow-trigger/quickstart.md
+++ b/specs/028-triage-workflow-trigger/quickstart.md
@@ -1,0 +1,128 @@
+# Quickstart: Workflow-Trigger Corroboration
+
+**Feature**: 028-triage-workflow-trigger | **Date**: 2026-08-01
+
+How to exercise the feature without waiting for an 18:15 Lambda run.
+
+## Prerequisites
+
+```bash
+poetry install
+```
+
+AWS credentials with read access to `workflows` and `workflow_orders`, and read/write on
+`alert_digests`.
+
+## 1. Unit tests — the fastest loop
+
+```bash
+poetry run pytest tests/services/test_workflow_trigger_service.py -v
+poetry run pytest tests/services/test_alert_triage_service.py -v
+```
+
+The triage tests run without AWS: `TriageAgent.synthesize` is synchronous and takes the trigger map
+as a plain argument, so a corroborated asset is a dict literal, not a mocked table.
+
+## 2. Confirm the join actually matches
+
+The failure mode that produces a silently inert feature is a `workflow.index` that never equals any
+scanned asset code. Check the real data before trusting an empty result:
+
+```bash
+poetry run python -c "
+import asyncio
+from client.aws_client import create_dynamodb_client
+
+async def main():
+    async with create_dynamodb_client() as db:
+        wfs = await db.get_all_workflows()
+        for w in wfs:
+            print(f\"{w.get('enable')}  dry_run={w.get('dry_run')}  index={w.get('index')!r}  cfd={w.get('cfd')!r}  {w.get('name')}\")
+asyncio.run(main())
+"
+```
+
+Compare the `index` column against the codes in `stocks.json` / `followup-stocks.json`. An `index`
+of `AI` or `AI:xpar` matches the alert asset `AI` + `xpar`; an `index` of `GER40.I` will never
+match, and that workflow simply never corroborates anything — expected, not a bug.
+
+## 3. Inspect today's triggers
+
+```bash
+poetry run python -c "
+import asyncio, datetime
+from zoneinfo import ZoneInfo
+from client.aws_client import create_dynamodb_client
+
+async def main():
+    async with create_dynamodb_client() as db:
+        orders = await db.get_all_workflow_orders()
+        start = datetime.datetime.now(ZoneInfo('Europe/Paris')).replace(
+            hour=0, minute=0, second=0, microsecond=0).timestamp()
+        today = [o for o in orders if int(o['placed_at']) >= start]
+        print(f'{len(today)} trigger(s) today of {len(orders)} retained')
+        for o in today:
+            ts = datetime.datetime.fromtimestamp(int(o['placed_at']), ZoneInfo('Europe/Paris'))
+            print(f\"  {ts:%H:%M}  {o['workflow_name']}  {o['order_direction']}  {o['order_code']}\")
+asyncio.run(main())
+"
+```
+
+Note `order_direction` prints as `BUY`/`SELL` — the enum **name**. Parsing it with
+`Direction("BUY")` raises; use `Direction["BUY"]`.
+
+## 4. End-to-end on a narrow asset list
+
+`run_alerting` accepts an explicit asset list, so you can scan just the assets your workflows watch
+instead of the full French universe:
+
+```bash
+poetry run python -c "
+import asyncio
+from saxo_order.commands.alerting import run_alerting
+asyncio.run(run_alerting('config.yml', assets=[{'code': 'AI:xpar', 'name': 'Air Liquide'}]))
+"
+```
+
+This performs real detection, real triage, writes a real digest, and posts to Slack. Point
+`SAXO_CONFIG` at a test config first if you do not want the Slack post.
+
+## 5. Check the brief
+
+```bash
+poetry run python run_api.py
+curl -s localhost:8000/api/alert-digests?limit=1 | python -m json.tool
+```
+
+A corroborated asset carries `workflow_triggers`; an uncorroborated one omits the key entirely.
+
+Then `cd frontend && npm run dev`, open `http://localhost:5173`, and confirm the Daily Brief shows
+the workflow name, direction, and time of day on the corroborated asset, with a visible dry-run
+marker when applicable.
+
+## 6. Verify the degraded path
+
+The most important test: with workflow data unavailable, the brief must be **exactly** today's.
+
+```bash
+poetry run pytest tests/services/test_workflow_trigger_service.py -k "failure or unavailable" -v
+poetry run pytest tests/services/test_alert_triage_service.py -k "no_triggers" -v
+```
+
+## Pre-commit gates
+
+```bash
+poetry run black . && poetry run isort . && poetry run mypy . && poetry run flake8
+poetry run pytest
+cd frontend && npm run lint && npm run build
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| No asset ever shows corroboration | `workflow.index` doesn't match any scanned asset code — run step 2 and read the drop logs, which print both sides of the comparison |
+| `ValueError: 'BUY' is not a valid Direction` | Parsed with `Direction(value)` instead of `Direction[value]` — see data-model §4 |
+| Triggers appear on the workflow orders page but not in the brief | The asset isn't in the alert set (excluded, or index-only) — working as specified, FR-002 |
+| Brief has triggers but ranking looks unchanged | Expected when the trigger agrees with an already-strong read; corroboration breaks ties, it doesn't multiply (A-004) |
+| Old digests error on read | A pre-feature digest has no `workflow_triggers` key — readers must default it to empty (data-model §8) |

--- a/specs/028-triage-workflow-trigger/research.md
+++ b/specs/028-triage-workflow-trigger/research.md
@@ -1,0 +1,158 @@
+# Research: Workflow-Trigger Corroboration in the Alert Triage Agent
+
+**Feature**: 028-triage-workflow-trigger | **Date**: 2026-08-01
+**Input**: [spec.md](./spec.md)
+
+## R1. Resolving a trigger to the asset the workflow watches
+
+- **Decision**: Read the workflow definitions **once per run** with the existing
+  `DynamoDBClient.get_all_workflows()` and build an in-memory
+  `{workflow_id: (name, index, dry_run)}` map. Join each `workflow_orders` row to that map by
+  `workflow_id`. Do **not** call `get_workflow_by_id` per trigger.
+- **Rationale**: The `workflows` table is tiny (one item per registered workflow) and
+  `get_all_workflows()` already exists and is already used this way by
+  `WorkflowService.get_workflows_by_asset`. One scan replaces N round trips, and the same record
+  carries both fields the join needs — `index` (the underlying) and `dry_run` — so there is no
+  second lookup for the dry-run label. This deviates from the feature description's suggested
+  `get_workflow_by_id` path, deliberately.
+- **Alternatives considered**: (a) `get_workflow_by_id` per triggering workflow — correct but N
+  reads for data that fits in one scan, and N failure points inside a step that must not slow the
+  scan. (b) Denormalising `index` onto `workflow_orders` at write time — would make triage a pure
+  single-table read, but changes the order-recording path, which FR-021 forbids, and would not
+  backfill existing rows.
+
+## R2. The session window
+
+- **Decision**: The window is `[Paris-local midnight of the run date, run time]`, computed with
+  `zoneinfo.ZoneInfo("Europe/Paris")` and compared against `workflow_orders.placed_at`
+  (epoch seconds, Number). The run date comes from the digest's own `run_date`, not from an
+  assumed 18:15 schedule.
+- **Rationale**: FR-004. `zoneinfo` is already the codebase's tool for Paris-local math
+  (`utils/helper.py`), so DST is handled by the same mechanism as the rest of the project. Deriving
+  the window from the run itself keeps manual and on-demand runs correct (spec edge case
+  "manual or off-schedule triage run").
+- **Alternatives considered**: (a) A rolling 24-hour window — simpler, but bleeds the previous
+  evening's triggers into the morning of a manual run. (b) UTC day boundaries — wrong for a
+  Euronext-hours product; a 00:30 Paris trigger in summer would land on the previous UTC day.
+
+## R3. Matching the underlying to the alert asset
+
+- **Decision**: Reuse the matching semantics already established in
+  `WorkflowService.get_workflows_by_asset`: case-insensitive equality of `workflow.index` against
+  either the bare `asset_code` or the composite `f"{asset_code}:{country_code}"`. Match on the
+  `Alert`'s `asset_code`/`country_code` **fields**, never on `Alert.id`.
+- **Rationale**: FR-003. One matching rule for "which workflows watch this asset" already exists
+  and is proven; a second, subtly different rule would drift. The field-level caution matters:
+  `Alert.id` joins with an underscore (`AI_xpar`) while `workflow.index` uses a colon
+  (`AI:xpar`), so an id-level comparison would silently never match.
+- **Alternatives considered**: (a) Normalising both sides through a new shared helper — worth doing
+  if a third caller appears, but extracting it now for two callers is the speculative abstraction
+  the constitution's Clean Code First principle warns against. (b) Fuzzy or prefix matching — FR-003
+  requires dropping unresolvable triggers rather than guessing.
+
+## R4. Where the logic lives
+
+- **Decision**: A new `services/workflow_trigger_service.py` exposing an async
+  `collect_todays_triggers(dynamodb_client, run_date) -> Dict[str, List[WorkflowTrigger]]`, keyed by
+  the alert-asset key. `TriageAgent.synthesize` gains an optional `triggers` parameter and stays
+  **synchronous and pure** — it receives the already-resolved map and never touches storage.
+  `run_alerting` calls the collector and passes the result in.
+- **Rationale**: Constitution I — the fetch-and-join is business logic and belongs in the Service
+  layer, not in the CLI command; `TriageAgent` remaining pure keeps it unit-testable without async
+  storage mocks, which is how its existing tests are written. Keeping the collector separate from
+  `alert_triage_service.py` also means a total failure of trigger collection is an empty dict, not a
+  broken triage.
+- **Alternatives considered**: (a) Collecting inside `TriageAgent.synthesize` — would make the agent
+  async and storage-dependent, forcing every existing triage test to grow a DynamoDB mock. (b)
+  Inlining in `run_alerting` — puts business logic in the CLI layer, violating Constitution I.
+
+## R5. Domain model for a trigger
+
+- **Decision**: New `WorkflowTrigger` dataclass in `model/__init__.py`, carrying `workflow_name`,
+  `direction: Direction`, `order_price: float`, `trigger_close: Optional[float]`,
+  `placed_at: int`, `dry_run: bool`. Direction uses the existing `Direction` enum; no new enum is
+  introduced.
+- **Rationale**: Constitution II.3 (enum-driven) and V. `workflow_orders` stores
+  `order_direction` as the enum **name** (`WorkflowEngine` writes `order_direction.name`), so
+  parsing is `Direction[value]`, not `Direction(value)` — a real trap, since `Direction.BUY.value`
+  is `"Buy"` while its name is `"BUY"`.
+- **Alternatives considered**: Passing raw dicts into the agent — rejected: the model layer exists so
+  that the reasoning payload and the persistence layer agree on shape.
+
+## R6. Teaching the reasoning about triggers
+
+- **Decision**: Extend the payload built by `TriageAgent._build_payload` with an optional
+  `workflow_triggers` array per asset (omitted entirely when empty), and add a section to
+  `TRIAGE_SYSTEM_PROMPT` covering: independence from the detectors (one convergence point,
+  contrasted with the existing `congestion20`/`congestion100` collapse), directional authority at
+  least equal to `combo`, contradiction as a red flag (parallel to the existing `mm50_touch`
+  guidance), multiple same-day triggers still counting once, and dry-run triggers weighing one step
+  lower.
+- **Rationale**: FR-007 through FR-012. The existing prompt already teaches independence and
+  red-flag reasoning for patterns; triggers slot into that same vocabulary rather than introducing a
+  parallel scoring scheme. Omitting the key on assets without triggers keeps the payload honest and
+  avoids teaching the model that `null` means anything.
+- **Alternatives considered**: (a) A numeric weight or score in the payload — rejected: the whole
+  design deliberately reasons in tiers, and a number invites false precision. (b) A separate
+  pre-pass that re-ranks after the model responds — rejected: two ranking authorities that can
+  disagree.
+
+## R7. Structured-output schema
+
+- **Decision**: `TRIAGE_RESPONSE_SCHEMA` is **unchanged**. Triggers are input-only; the response
+  keeps `id`/`conviction`/`rank`/`rationale`, and the trigger appears in the digest because the
+  service re-attaches it from the input map when building each `TriagedAsset`.
+- **Rationale**: The model must not be able to invent, alter, or drop a trigger — it is a fact from
+  storage. Echoing it back through the model would put a fact at the mercy of generation. This
+  mirrors how `patterns` and `ma50_slope` are already re-attached from `grouped` in
+  `_parse_triaged` rather than read from the response.
+- **Alternatives considered**: Adding trigger fields to the response schema — rejected for the
+  above; it would also enlarge the schema for zero informational gain.
+
+## R8. Fallback ranking
+
+- **Decision**: `_pattern_families` gains a companion so that an asset with ≥1 attached trigger
+  counts one extra family in `_fallback_conviction`'s tally, and `_fallback_rationale` appends the
+  workflow name and direction. Multiple triggers on one asset still add exactly one.
+- **Rationale**: FR-013, FR-014, and A-004 (one point, no multiplier). The fallback's existing
+  contract — pure, synchronous, side-effect-free, always succeeds — is preserved because the
+  triggers arrive as plain data.
+- **Alternatives considered**: Giving triggers a heavier weight in the fallback than in the
+  reasoning — rejected: the two paths should rank consistently, or a fallback day would reorder the
+  brief for reasons the trader cannot see.
+
+## R9. Persistence and read-back
+
+- **Decision**: `store_alert_digest` serialises `workflow_triggers` inside each triaged-asset item
+  (omitted when empty); the existing `_convert_floats_to_decimal` pass handles the prices.
+  `AlertDigestService` converts `Decimal` back to `float` on read, as it already does elsewhere.
+- **Rationale**: FR-015 and SC-008 — `workflow_orders` carries a TTL and `alert_digests` does not,
+  so a brief read months later must carry its own copy of the corroboration it was ranked on. It
+  cannot re-derive it.
+- **Alternatives considered**: Storing only the workflow id and re-resolving on read — rejected:
+  the trigger row will have expired, and a renamed or deleted workflow would rewrite history.
+
+## R10. Failure tolerance
+
+- **Decision**: `collect_todays_triggers` catches every exception internally, logs a warning, and
+  returns `{}`. The caller in `run_alerting` needs no new try/except — the existing triage block is
+  already wrapped — and an empty map provably reproduces current behaviour through every downstream
+  path (payload key omitted, prompt section inert, fallback tally unchanged, no persisted field).
+- **Rationale**: FR-019 and FR-020. "Degrades to exactly today's behaviour" is stronger than
+  "degrades gracefully", and an empty map is the same input the system will see on most days
+  anyway — so the degraded path is the well-tested path.
+- **Alternatives considered**: Letting failures bubble to the existing outer handler — the digest
+  would survive, but a mid-loop failure could produce a *partially* enriched brief, where some
+  corroborations are missing without any indication. All-or-nothing is easier to reason about.
+
+## R11. Configuration
+
+- **Decision**: No new configuration. The session window is derived, the convergence weight is fixed
+  at one point by design (A-004), and dry-run handling is a labelling rule rather than a threshold.
+- **Rationale**: Constitution III forbids hardcoded thresholds, but this feature introduces none —
+  adding a knob nobody will turn is the over-engineering Constitution II.2 rejects. If the trader
+  later wants dry-run triggers filtered out entirely, that becomes a boolean in `config.yml` at
+  that point.
+- **Alternatives considered**: A `triage_workflow_triggers_enabled` kill switch — rejected: the
+  failure path already produces the pre-feature brief, so the switch's only use would be
+  disabling a working feature.

--- a/specs/028-triage-workflow-trigger/spec.md
+++ b/specs/028-triage-workflow-trigger/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: Workflow-Trigger Corroboration in the Alert Triage Agent
+
+**Feature Branch**: `028-triage-workflow-trigger`
+**Created**: 2026-08-01
+**Status**: Draft
+**Input**: User description: "Enrich the alert triage agent with same-day workflow trigger data. Workflow triggers (recorded in the workflow_orders DynamoDB table by WorkflowEngine) are pre-registered, explicitly directional, capital-committing signals produced by a different mechanism than the chart-pattern detectors. They should be attached to assets already present in the day's alert set as an additional independent convergence signal — they must never introduce new assets into the digest ranking. Join path: workflow_orders.order_code is the traded CFD, so resolve each order to its Workflow via workflow_id (get_workflow_by_id) and match on Workflow.index against the alert asset id. Filter to today's Paris session. Dry-run workflows must be distinguished (excluded or explicitly labelled). The TriageAgent LLM prompt gains guidance that a workflow trigger counts as one independent convergence point, carries directional bias at least as authoritative as the combo pattern, and a trigger contradicting the pattern read is a red flag. The deterministic fallback counts a trigger as an extra pattern family. TriagedAsset gains an optional workflow-trigger field surfaced in the API, frontend Daily Brief, and Slack digest. The whole enrichment must be failure-tolerant: any error reading or joining workflow data is logged and swallowed, leaving the digest exactly as it is today."
+
+## Context
+
+The daily brief currently ranks assets using a single family of evidence: chart-pattern detectors and the 50-period moving-average slope, all computed by the same end-of-day scan from the same candles. Because these inputs are not truly independent of one another, the triage reasoning has to spend most of its effort discounting false confluence.
+
+Workflow triggers are a structurally different kind of evidence. A workflow is a rule the trader registered in advance; when it fires during the trading day it produces an explicitly directional order at a known price. It is the only signal in the system that is both pre-registered and directional, and it is produced by a mechanism entirely separate from the pattern detectors. When a workflow trigger lands on an asset that also fired patterns today, that is the strongest corroboration the system can produce — and today the brief is blind to it.
+
+This feature makes the brief aware of that corroboration.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Workflow-corroborated assets rise in the brief (Priority: P1)
+
+The trader opens the daily brief after the close. An asset that fired chart patterns today *and* triggered one of their registered workflows in the same direction is ranked at the top, and its rationale explicitly says so — naming the workflow, its direction, and the fact that this is evidence from a separate mechanism rather than another chart pattern.
+
+**Why this priority**: This is the entire value of the feature. Corroboration between two independent mechanisms is the signal the trader most wants surfaced, and ranking is what the brief exists to do. Everything else is presentation.
+
+**Independent Test**: Run a triage over an alert set in which exactly one asset also has a same-day workflow trigger aligned with its patterns, and confirm that asset is ranked above otherwise comparable assets and that its rationale names the workflow trigger as a distinct source of evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** an asset with two independent bullish patterns and a rising 50-MA, **and** a same-day workflow trigger in the buy direction on that asset, **When** the brief is generated, **Then** the asset is ranked above an otherwise identical asset with no trigger, and its rationale names the workflow.
+2. **Given** an asset whose patterns read bearish, **and** a same-day workflow trigger in the buy direction on that asset, **When** the brief is generated, **Then** the contradiction is treated as a red flag on the bearish read rather than as supporting evidence, and the rationale says so.
+3. **Given** a workflow trigger on an asset that produced no alerts today, **When** the brief is generated, **Then** that asset does not appear in the brief at all.
+4. **Given** an alert set where no asset has a same-day trigger, **When** the brief is generated, **Then** the ranking and rationales are indistinguishable from the current behaviour.
+
+---
+
+### User Story 2 - The trigger is visible wherever the brief is read (Priority: P2)
+
+Having been told an asset is workflow-corroborated, the trader can see the specifics — which workflow, which direction, at what price, at what time of day — without leaving the brief, whether they are reading it in the app or glancing at the Slack notification.
+
+**Why this priority**: The ranking is useful on its own (US1 ships without this), but a claim of corroboration that the trader cannot verify at a glance forces them back into the workflow orders page, undoing the brief's zero-click promise.
+
+**Independent Test**: Generate a brief containing at least one corroborated asset, then confirm the trigger details are present in the brief data served to the app, rendered on the asset's entry in the Daily Brief, and reflected in the Slack message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a brief containing a corroborated asset, **When** the trader views the Daily Brief in the app, **Then** the asset's entry shows the workflow name, the trigger direction, and the time of day the workflow fired.
+2. **Given** a brief containing at least one corroborated asset, **When** the Slack digest is posted, **Then** the message distinguishes corroborated assets from the rest.
+3. **Given** a brief with no corroborated assets, **When** the trader views the Daily Brief and the Slack digest, **Then** no empty trigger section, badge, or placeholder text appears anywhere.
+
+---
+
+### User Story 3 - Corroboration survives degraded reasoning (Priority: P3)
+
+When the triage reasoning is unavailable and the brief falls back to deterministic ranking, an asset with a workflow trigger is still ranked above an equivalent asset without one.
+
+**Why this priority**: The fallback path is rare, and the brief remains useful without this. But a fallback that silently discards the strongest available signal would make degraded days quietly worse than they need to be.
+
+**Independent Test**: Force the reasoning step to fail over an alert set containing one corroborated asset, and confirm the fallback ranking places it above equivalent uncorroborated assets and that the brief is still flagged as a fallback.
+
+**Acceptance Scenarios**:
+
+1. **Given** reasoning is unavailable, **and** an asset has one pattern plus a same-day trigger, **When** the fallback ranking runs, **Then** the trigger counts toward that asset's confluence and lifts its conviction tier accordingly.
+2. **Given** reasoning is unavailable, **When** the fallback ranking runs, **Then** the brief is still marked as a fallback and its templated rationales mention the trigger where one exists.
+
+---
+
+### Edge Cases
+
+- **No triggers today**: the brief is byte-for-byte what it would have been before this feature.
+- **Trigger on an asset outside the alert set** (index, CFD-only instrument, or a stock excluded from the scan): silently ignored; it never creates a brief entry.
+- **Trigger whose workflow record can no longer be resolved** (deleted or renamed workflow): that trigger is dropped; the rest of the enrichment proceeds.
+- **Several triggers on one asset in the same day**: all are attached; the brief still counts them as a single point of convergence, not one per trigger.
+- **Triggers on one asset disagreeing with each other on direction**: treated as an internally inconsistent signal, not as amplified conviction.
+- **Underlying identifier does not match the alert asset identifier** (formatting or market-suffix differences): the trigger is dropped rather than guessed at, and the mismatch is logged so the mapping can be corrected.
+- **Workflow data unreadable** (storage error, timeout, permission failure): the brief is produced exactly as it is today, and the failure is recorded in operational logs only.
+- **Manual or off-schedule triage run**: the session window is computed from the run's own date, not from the scheduled run time.
+- **Trigger fired after the triage run**: not included in that day's brief; it is not retro-fitted into an already-stored brief.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Sourcing and scoping**
+
+- **FR-001**: The system MUST read the workflow triggers recorded during the current Paris trading day and make them available to the triage step.
+- **FR-002**: The system MUST attach a trigger only to an asset that already appears in the day's alert set. Triggers MUST NOT introduce assets into the brief.
+- **FR-003**: The system MUST resolve each recorded trigger from the instrument actually traded (the CFD) to the underlying asset the workflow watches, and match that underlying against the alert asset identifier. A trigger whose underlying cannot be resolved or matched MUST be dropped, not approximated.
+- **FR-004**: The system MUST bound the session window to the current run date in Paris local time, computed from the run itself rather than from an assumed schedule.
+- **FR-005**: The system MUST record, for each trigger it attaches: the workflow name, the order direction, the order price, the market price at the moment the workflow fired, the time of day it fired, and whether the workflow was in dry-run mode.
+- **FR-006**: The system MUST distinguish dry-run triggers from live ones everywhere a trigger is used — in reasoning, in fallback ranking, and in every display surface.
+
+**Reasoning**
+
+- **FR-007**: The triage reasoning MUST treat a workflow trigger as evidence produced by a mechanism independent of the chart-pattern detectors, and therefore as a genuine point of convergence — unlike two lookback windows of the same detector, which already count as one.
+- **FR-008**: The triage reasoning MUST treat a trigger's direction as directional bias at least as authoritative as the strongest existing directional pattern.
+- **FR-009**: The triage reasoning MUST treat a trigger whose direction contradicts the pattern-and-trend read as a red flag on that read, not as supporting confluence — consistent with how structurally impossible pattern combinations are already handled.
+- **FR-010**: The triage reasoning MUST count multiple same-day triggers on one asset as a single point of convergence.
+- **FR-011**: The triage reasoning MUST name the workflow trigger in the rationale of any asset whose ranking it influenced, so the trader can see why the asset rose.
+- **FR-012**: The triage reasoning MUST weigh a dry-run trigger as directional evidence one step weaker than a live trigger, since no capital was committed.
+
+**Degraded operation**
+
+- **FR-013**: The deterministic fallback ranking MUST count an attached trigger as one additional independent point of confluence when tiering and ordering assets.
+- **FR-014**: The deterministic fallback rationale MUST mention the trigger where one is attached.
+
+**Surfacing**
+
+- **FR-015**: The stored brief MUST carry the attached trigger information alongside the asset it corroborates, so that a brief re-read later shows the same corroboration it was ranked on.
+- **FR-016**: The brief data served to the app MUST expose the attached trigger information for each asset that has one, and omit it entirely for assets that do not.
+- **FR-017**: The Daily Brief in the app MUST show, on a corroborated asset, the workflow name, the trigger direction, the time of day, and a clear dry-run indication when applicable.
+- **FR-018**: The Slack digest MUST distinguish corroborated assets from the rest without growing into a per-trigger listing.
+
+**Failure tolerance**
+
+- **FR-019**: Any failure in reading, resolving, or attaching workflow trigger data MUST leave the brief exactly as it would have been without this feature — same assets, same ranking, same rationales, same delivery.
+- **FR-020**: Such failures MUST be recorded in operational logs only, and MUST NOT reach the trader-facing brief, the Slack digest, or the alerting error channel.
+- **FR-021**: The enrichment MUST NOT change alert detection, alert storage, or any part of the workflow and order path. It reads workflow data; it never writes it.
+
+### Key Entities
+
+- **Workflow Trigger (as consumed by triage)**: a same-day record that a registered workflow fired. Carries the workflow's name, the direction and price of the resulting order, the market price at firing, the time of day, and whether the workflow was live or dry-run. Belongs to exactly one underlying asset, reached by resolving the traded instrument back to the asset the workflow watches.
+- **Triaged Asset**: unchanged in purpose — an asset in the day's brief with its conviction tier, rank, rationale, patterns, and trend slope. Gains an optional set of attached workflow triggers, absent on most assets.
+- **Alert Digest**: unchanged in shape and lifecycle. Its assets may now carry trigger corroboration, which is stored with the brief and persists for later review.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a day where an asset both fires patterns and triggers a workflow in the same direction, that asset appears in the brief's top tier, ranked above otherwise comparable uncorroborated assets.
+- **SC-002**: Every asset whose ranking was influenced by a trigger has a rationale that names the workflow, so the trader never has to guess why an asset rose.
+- **SC-003**: No asset appears in the brief solely because a workflow triggered on it — the set of assets in the brief is identical to what the alert scan produced.
+- **SC-004**: On days with no same-day triggers, the brief is indistinguishable from the pre-feature brief.
+- **SC-005**: When workflow data is unavailable, the brief is still produced and delivered in full, with no trader-visible sign of the failure.
+- **SC-006**: A trader reading a corroborated asset in the app can identify the workflow, its direction, its timing, and whether it was live or dry-run without navigating away from the brief.
+- **SC-007**: The triage step's contribution to the end-of-day scan grows by no more than a few seconds, and the scan continues to complete within its existing time budget.
+- **SC-008**: A brief re-read weeks later still shows the trigger corroboration it was ranked on, outliving the short retention of the raw trigger records.
+
+## Assumptions
+
+- **A-001 — Universe overlap**: the trader has confirmed that most registered workflows watch individual assets rather than index CFDs, so the alert set and the workflow set overlap meaningfully. This feature's value depends on that overlap; it was accepted as given rather than measured.
+- **A-002 — Session window**: "today" means the current calendar day in Paris local time, from midnight to the moment the brief is generated. Triggers firing after the brief is generated belong to the next day's brief, if any.
+- **A-003 — Dry-run handling**: dry-run triggers are included and explicitly labelled rather than excluded, on the reasoning that the rule still fired and the analytical content is identical; only the capital commitment differs, which FR-012 accounts for by weighting them one step lower. If the trader would rather not see dry-run rules in the brief at all, this reverses to a filter and FR-012 falls away.
+- **A-004 — Convergence weighting**: a trigger adds one point of convergence, matching how a distinct pattern family is counted today. It is deliberately not given a multiplier; the intent is to break ties toward corroborated assets, not to let a single trigger dominate the ranking.
+- **A-005 — No backfill**: briefs generated before this feature are left as they are. Corroboration appears from the first run after deployment onward.
+- **A-006 — Read-only join**: resolving a trigger to its underlying asset requires reading the workflow definitions that the triggers reference. These reads are few (one per triggering workflow per day) and add negligible cost to the scan.
+
+## Out of Scope
+
+- Measuring whether workflow-corroborated assets subsequently performed better; the brief records the corroboration, it does not evaluate it.
+- Surfacing workflow triggers on assets outside the alert set, in the brief or anywhere else. Those remain visible on the existing workflow orders page.
+- Any change to workflow definitions, workflow scheduling, order placement, or the workflow Slack channels.
+- Triggers from earlier days, multi-day trigger history, or trends in triggering behaviour.
+- Retro-fitting corroboration into a brief that has already been generated and stored.

--- a/specs/028-triage-workflow-trigger/tasks.md
+++ b/specs/028-triage-workflow-trigger/tasks.md
@@ -1,0 +1,173 @@
+---
+
+description: "Task list for 028-triage-workflow-trigger"
+---
+
+# Tasks: Workflow-Trigger Corroboration in the Alert Triage Agent
+
+**Input**: Design documents from `/specs/028-triage-workflow-trigger/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/)
+
+**Tests**: Included. Not an optional extra here — the constitution's Pre-Merge Gates require passing
+tests and maintained coverage, and FR-019 ("the brief is identical when workflow data is
+unavailable") is a claim that can only be made good by a test.
+
+**Organization**: Grouped by user story so each ships independently. US1 alone is a complete,
+useful feature.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete work)
+- **[Story]**: US1 / US2 / US3, mapping to the spec's user stories
+- Exact file paths in every description
+
+## Path Conventions
+
+Repository root. Backend: `model/`, `services/`, `client/`, `api/`, `saxo_order/commands/`.
+Frontend: `frontend/src/`. Tests mirror source under `tests/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a known-good baseline so any later failure is attributable to this feature.
+
+- [ ] T001 Run the full backend gate on a clean tree and record the result: `poetry run pytest`, `poetry run mypy .`, `poetry run flake8`
+- [ ] T002 [P] Capture a pre-feature digest sample from `GET /api/alert-digests?limit=1` into `/tmp/digest-before.json` — the byte-comparison baseline for FR-019 and SC-004
+- [ ] T003 [P] Run quickstart step 2 (`get_all_workflows()` dump) and record which `index` values match scanned asset codes — confirms A-001 against live data before any code is written
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The domain model and the collector. Every user story depends on these.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Add the `WorkflowTrigger` dataclass to `model/__init__.py` with fields `workflow_name`, `direction: Direction`, `order_price: float`, `trigger_close: Optional[float]`, `placed_at: int`, `dry_run: bool` per data-model.md §1
+- [ ] T005 Add `workflow_triggers: List[WorkflowTrigger] = field(default_factory=list)` to `TriagedAsset` in `model/__init__.py` (data-model.md §2)
+- [ ] T006 Create `services/workflow_trigger_service.py` with async `collect_todays_triggers(dynamodb_client, run_date) -> Dict[str, List[WorkflowTrigger]]`, returning `{}` on any exception (research R4, R10)
+- [ ] T007 Implement the Paris session window in `services/workflow_trigger_service.py` using `zoneinfo.ZoneInfo("Europe/Paris")`, deriving bounds from `run_date` rather than an assumed schedule (data-model.md §5, FR-004)
+- [ ] T008 Implement workflow resolution in `services/workflow_trigger_service.py`: one `get_all_workflows()` read into a `{workflow_id: (name, index, dry_run)}` map; drop triggers whose `workflow_id` is absent (research R1, FR-003)
+- [ ] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log both sides of every non-match (data-model.md §4, FR-003)
+- [ ] T010 Parse `order_direction` with `Direction[value]` (enum **name**, not value) in `services/workflow_trigger_service.py`, raising `SaxoException` on an unknown value — no `assert` (research R5, Constitution II.5)
+- [ ] T011 [P] Create `tests/services/test_workflow_trigger_service.py` covering: in-window vs out-of-window rows, deleted-workflow drop, unmatched-index drop, `BUY`-name parse, dry-run flag read from the workflow record, and `{}` on a raising client
+
+**Checkpoint**: Triggers can be collected and resolved. Nothing consumes them yet.
+
+---
+
+## Phase 3: User Story 1 — Workflow-corroborated assets rise in the brief (Priority: P1) 🎯 MVP
+
+**Goal**: An asset that fired patterns *and* triggered a workflow in the same direction ranks at the
+top, with a rationale that names the workflow.
+
+**Independent Test**: Run a triage over an alert set where exactly one asset also has a same-day
+trigger aligned with its patterns; confirm it outranks otherwise comparable assets and that its
+rationale names the workflow.
+
+- [ ] T012 [US1] Add the optional `triggers: Optional[Dict[str, List[WorkflowTrigger]]] = None` parameter to `TriageAgent.synthesize` in `services/alert_triage_service.py`, keeping the method synchronous and storage-free (research R4)
+- [ ] T013 [US1] Extend `TriageAgent._build_payload` in `services/alert_triage_service.py` to emit `workflow_triggers` per asset **only when non-empty**, with `workflow`, `direction`, `dry_run`, and Paris-local `hour` (data-model.md §7)
+- [ ] T014 [US1] Add the workflow-trigger section to `TRIAGE_SYSTEM_PROMPT` in `services/alert_triage_service.py`: independent mechanism = one convergence point (contrast with the `congestion20`/`congestion100` collapse), directional authority at least equal to `combo`, contradiction is a red flag (parallel to `mm50_touch`), multiple same-day triggers still count once, dry-run weighs one step lower (FR-007 – FR-012)
+- [ ] T015 [US1] Re-attach triggers from the input map in `TriageAgent._parse_triaged` / `_build_triaged_asset` in `services/alert_triage_service.py` — never read them back from the model response; leave `TRIAGE_RESPONSE_SCHEMA` unchanged (research R7)
+- [ ] T016 [US1] Wire `collect_todays_triggers` into `run_alerting` in `saxo_order/commands/alerting.py`, inside the existing triage try/except, passing the map into `synthesize` (FR-001, FR-019)
+- [ ] T017 [P] [US1] Add tests to `tests/services/test_alert_triage_service.py`: payload omits `workflow_triggers` for assets without one, includes it with the right shape for assets with one, and the returned `TriagedAsset` carries the trigger even though the model response never mentions it
+- [ ] T018 [P] [US1] Add a test to `tests/services/test_alert_triage_service.py` asserting that `synthesize(alerts)` with no `triggers` argument produces output identical to the pre-feature behaviour (SC-004, FR-019)
+- [ ] T019 [US1] Verify end-to-end via quickstart step 4 against a narrow asset list; confirm rank and rationale name the workflow (SC-001, SC-002) and that no asset appears solely because a workflow triggered (SC-003)
+
+**Checkpoint**: US1 is shippable. Ranking is corroboration-aware; nothing is displayed yet.
+
+---
+
+## Phase 4: User Story 2 — The trigger is visible wherever the brief is read (Priority: P2)
+
+**Goal**: The trader can see which workflow, which direction, at what time, live or dry-run — in the
+app and in Slack — without leaving the brief.
+
+**Independent Test**: Generate a brief with one corroborated asset; confirm the trigger details are
+persisted, served by the API, rendered in the Daily Brief, and reflected in the Slack message.
+
+- [ ] T020 [US2] Serialise `workflow_triggers` inside each triaged-asset item in `store_alert_digest` in `client/aws_client.py`, omitting the key when empty and storing `direction` as the enum name (data-model.md §8, FR-015)
+- [ ] T021 [US2] Add `WorkflowTriggerResponse` to `api/models/alert_digest.py` and an optional `workflow_triggers` field on `TriagedAssetResponse`, per `contracts/alert-digests.openapi.yaml`
+- [ ] T022 [US2] Hydrate `workflow_triggers` in `api/services/alert_digest_service.py`, converting `Decimal` back to `float` and defaulting a **missing** key to empty for pre-feature digests (data-model.md §8, A-005)
+- [ ] T023 [P] [US2] Add the `WorkflowTrigger` interface and the optional field on `TriagedAsset` in `frontend/src/services/api.ts`, mirroring the Pydantic models field-for-field (Constitution — API Contract Standards)
+- [ ] T024 [US2] Render the trigger line on corroborated assets in `frontend/src/components/DailyBriefCarousel.tsx` — workflow name, direction, Paris-local time of day, distinct dry-run marker; render nothing at all when the list is empty (FR-017, edge case "no empty section")
+- [ ] T025 [P] [US2] Style the trigger line and the dry-run marker in `frontend/src/components/DailyBriefCarousel.css`, consistent with the existing conviction badges
+- [ ] T026 [US2] Mark corroborated assets in `format_slack_digest` in `services/alert_triage_service.py` without expanding into a per-trigger listing (FR-018)
+- [ ] T027 [P] [US2] Add tests to `tests/client/test_aws_client_alert_digests.py` for the store/read round trip: triggers present, key absent when empty, and a pre-feature item without the key reading back cleanly
+- [ ] T028 [P] [US2] Add a `format_slack_digest` test to `tests/services/test_alert_triage_service.py` covering a corroborated asset and confirming an uncorroborated digest is unchanged
+- [ ] T029 [US2] Verify in the browser via quickstart step 5 (SC-006), including a dry-run trigger and a no-trigger day
+
+**Checkpoint**: US1 + US2 shippable. Corroboration is ranked, stored, served, and visible.
+
+---
+
+## Phase 5: User Story 3 — Corroboration survives degraded reasoning (Priority: P3)
+
+**Goal**: When reasoning is unavailable, a corroborated asset still outranks an equivalent
+uncorroborated one.
+
+**Independent Test**: Force the reasoning step to fail over an alert set with one corroborated
+asset; confirm the fallback lifts it and still flags the brief as a fallback.
+
+- [ ] T030 [US3] Count an attached trigger as one extra confluence point in `TriageAgent._fallback_conviction` in `services/alert_triage_service.py` — one point regardless of trigger count (FR-013, A-004)
+- [ ] T031 [US3] Thread triggers through `_fallback_digest` ordering in `services/alert_triage_service.py` so the primary sort key reflects the extra point (FR-013)
+- [ ] T032 [US3] Append the workflow name and direction to the templated string in `TriageAgent._fallback_rationale` in `services/alert_triage_service.py` (FR-014)
+- [ ] T033 [P] [US3] Add tests to `tests/services/test_alert_triage_service.py`: one pattern + one trigger lifts the tier, two triggers on one asset add only one point, and the fallback flag is still set
+
+**Checkpoint**: All three stories complete.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T034 Add tests to `tests/services/test_workflow_trigger_service.py` for the remaining spec edge cases: several triggers on one asset, triggers disagreeing on direction, and a trigger on an asset outside the alert set
+- [ ] T035 [P] Confirm no `assert` in any new production code and that every new public method omits the leading underscore (Constitution II.5, I)
+- [ ] T036 [P] Run `poetry run black . && poetry run isort . && poetry run mypy . && poetry run flake8`
+- [ ] T037 [P] Run `npm run lint && npm run build` in `frontend/`
+- [ ] T038 Diff a no-trigger-day digest against `/tmp/digest-before.json` from T002 and confirm equivalence (SC-004, FR-019)
+- [ ] T039 Time the triage step with and without the enrichment; confirm the added cost is a few seconds at most and the scan stays inside its budget (SC-007)
+- [ ] T040 Confirm no Pulumi or IAM change is required — existing `workflows` / `workflow_orders` read grants already cover the alerting Lambda (plan.md Technical Context)
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+   └─► Phase 2 (Foundational: model + collector)   ← BLOCKS EVERYTHING
+          ├─► Phase 3 US1 (P1, MVP)  ─┐
+          ├─► Phase 4 US2 (P2)        ├─► Phase 6 (Polish)
+          └─► Phase 5 US3 (P3)       ─┘
+```
+
+- **US1** depends only on Phase 2.
+- **US2** depends on Phase 2 and consumes the field US1 populates — sequence it after US1 in practice, though its persistence and display tasks touch disjoint files.
+- **US3** depends only on Phase 2 and touches the fallback path exclusively. It can be built in parallel with US1 or US2.
+- T003 (live overlap check) gates nothing technically, but a null result should prompt a conversation before Phase 2 rather than after Phase 6.
+
+## Parallel Opportunities
+
+**Phase 1**: T002, T003 together.
+**Phase 2**: T004 → T005 sequentially (same file); T006 – T010 sequentially (same file); T011 alongside once T010 lands.
+**Phase 3 (US1)**: T012 – T016 sequentially (T012 – T015 share `alert_triage_service.py`); T017 and T018 in parallel afterwards.
+**Phase 4 (US2)**: T020, T021, T023, T025 touch four different files and can run in parallel; T022 follows T021; T024 follows T023; T027 and T028 in parallel at the end.
+**Phase 5 (US3)**: T030 – T032 sequentially (same file); T033 after.
+**Phase 6**: T035, T036, T037 in parallel.
+
+## Implementation Strategy
+
+**MVP = Phase 1 + Phase 2 + Phase 3 (US1).** Twenty tasks deliver the actual value: the brief ranks
+corroborated assets first and says why. Everything after that is presentation and resilience.
+
+**Recommended increments**:
+
+1. **Foundational + US1** — ship, then watch a few real runs. This is where A-001 gets tested for
+   real: if no asset is ever corroborated, stop and revisit the premise rather than building US2 on
+   top of a feature that never fires.
+2. **US2** — once corroboration is demonstrably appearing, make it visible.
+3. **US3** — the fallback path is rare; it can follow at leisure.
+
+**Verification order that matters**: T018 and T038 are the two tasks that prove the feature is safe.
+Neither tests the feature working — they test that it changes nothing when it has nothing to say,
+which is its behaviour on most days.


### PR DESCRIPTION
Adds same-day workflow triggers to the daily brief as an independent
convergence signal on assets already in the alert set. Triggers never
introduce new assets, are resolved from the traded CFD back to the
workflow's underlying, and any failure leaves the brief unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tn3UsiFaMTgUgJyQaWShsi