### PR TITLE
feat: workflow-trigger collector for the alert triage agent (spec 028, phases 1-2)

### DIFF
--- a/api/services/alert_digest_service.py
+++ b/api/services/alert_digest_service.py
@@ -1,5 +1,4 @@
 import asyncio
-from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from cachetools import TTLCache
@@ -9,6 +8,7 @@ from api.models.alert_digest import (
     TriagedAssetResponse,
 )
 from client.aws_client import DynamoDBClient
+from utils.helper import to_float
 from utils.logger import Logger
 
 logger = Logger.get_logger("alert_digest_api_service")
@@ -89,10 +89,6 @@ class AlertDigestService:
             ),
             rationale=asset["rationale"],
             patterns=asset["patterns"],
-            ma50_slope=(
-                float(asset["ma50_slope"])
-                if isinstance(asset.get("ma50_slope"), Decimal)
-                else asset.get("ma50_slope")
-            ),
+            ma50_slope=to_float(asset.get("ma50_slope")),
             tradingview_url=tradingview_links.get(asset_id),
         )

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,5 +1,5 @@
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 from model.backtest import (  # noqa: F401
@@ -74,6 +74,16 @@ class Alert:
 
 
 @dataclass
+class WorkflowTrigger:
+    workflow_name: str
+    direction: Direction
+    order_price: float
+    placed_at: int
+    dry_run: bool
+    trigger_close: Optional[float] = None
+
+
+@dataclass
 class TriagedAsset:
     asset_code: str
     asset_description: str
@@ -84,6 +94,7 @@ class TriagedAsset:
     ma50_slope: Optional[float] = None
     rank: Optional[int] = None
     country_code: Optional[str] = None
+    workflow_triggers: List[WorkflowTrigger] = field(default_factory=list)
 
 
 @dataclass

--- a/services/workflow_service.py
+++ b/services/workflow_service.py
@@ -18,6 +18,7 @@ from model.workflow_api import (
     WorkflowListResponse,
     WorkflowOrderListItem,
 )
+from utils.helper import to_float
 from utils.logger import Logger
 from utils.tradingview import build_tradingview_url_from_symbol
 
@@ -355,46 +356,26 @@ class WorkflowService:
     def _convert_all_order_to_item(
         self, order_data: Dict[str, Any]
     ) -> AllWorkflowOrderItem:
-        from decimal import Decimal
-
         return AllWorkflowOrderItem(
             id=order_data["id"],
             workflow_id=order_data["workflow_id"],
             workflow_name=order_data["workflow_name"],
             placed_at=int(order_data["placed_at"]),
             order_code=order_data["order_code"],
-            order_price=(
-                float(order_data["order_price"])
-                if isinstance(order_data["order_price"], Decimal)
-                else order_data["order_price"]
-            ),
-            order_quantity=(
-                float(order_data["order_quantity"])
-                if isinstance(order_data["order_quantity"], Decimal)
-                else order_data["order_quantity"]
-            ),
+            order_price=to_float(order_data["order_price"]),
+            order_quantity=to_float(order_data["order_quantity"]),
             order_direction=order_data["order_direction"],
         )
 
     def _convert_order_to_list_item(
         self, order_data: Dict[str, Any]
     ) -> WorkflowOrderListItem:
-        from decimal import Decimal
-
         return WorkflowOrderListItem(
             id=order_data["id"],
             workflow_id=order_data["workflow_id"],
             placed_at=int(order_data["placed_at"]),
             order_code=order_data["order_code"],
-            order_price=(
-                float(order_data["order_price"])
-                if isinstance(order_data["order_price"], Decimal)
-                else order_data["order_price"]
-            ),
-            order_quantity=(
-                float(order_data["order_quantity"])
-                if isinstance(order_data["order_quantity"], Decimal)
-                else order_data["order_quantity"]
-            ),
+            order_price=to_float(order_data["order_price"]),
+            order_quantity=to_float(order_data["order_quantity"]),
             order_direction=order_data["order_direction"],
         )

--- a/services/workflow_trigger_service.py
+++ b/services/workflow_trigger_service.py
@@ -29,13 +29,6 @@ def _to_float(value: Any) -> Optional[float]:
     return float(value)
 
 
-def _parse_direction(value: Any) -> Direction:
-    try:
-        return Direction[str(value)]
-    except KeyError:
-        raise SaxoException(f"Unknown order direction: {value!r}")
-
-
 def _asset_keys(alert: Alert) -> List[str]:
     keys = [alert.asset_code.lower()]
     if alert.country_code:
@@ -82,7 +75,7 @@ def _build_trigger(
 
     return WorkflowTrigger(
         workflow_name=order.get("workflow_name", workflow.get("name", "")),
-        direction=_parse_direction(order.get("order_direction")),
+        direction=Direction.get_value(str(order.get("order_direction"))),
         order_price=order_price,
         placed_at=int(order["placed_at"]),
         dry_run=bool(workflow.get("dry_run", False)),
@@ -145,7 +138,7 @@ async def _collect(
 
         try:
             trigger = _build_trigger(order, workflow)
-        except SaxoException as e:
+        except (SaxoException, ValueError) as e:
             logger.warning(f"Dropping malformed trigger: {e}")
             continue
 

--- a/services/workflow_trigger_service.py
+++ b/services/workflow_trigger_service.py
@@ -1,11 +1,11 @@
 import datetime
 import logging
-from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 from model import Alert, Direction, WorkflowTrigger
 from utils.exception import SaxoException
+from utils.helper import to_float
 from utils.logger import Logger
 
 PARIS = ZoneInfo("Europe/Paris")
@@ -19,14 +19,6 @@ def _session_window(run_date: str) -> Tuple[int, int]:
         day, datetime.time.min, tzinfo=PARIS
     ).timestamp()
     return int(start), int(datetime.datetime.now(PARIS).timestamp())
-
-
-def _to_float(value: Any) -> Optional[float]:
-    if value is None:
-        return None
-    if isinstance(value, Decimal):
-        return float(value)
-    return float(value)
 
 
 def _asset_keys(alert: Alert) -> List[str]:
@@ -69,7 +61,7 @@ def _build_workflow_map(
 def _build_trigger(
     order: Dict[str, Any], workflow: Dict[str, Any]
 ) -> WorkflowTrigger:
-    order_price = _to_float(order.get("order_price"))
+    order_price = to_float(order.get("order_price"))
     if order_price is None or order_price <= 0:
         raise SaxoException(f"Invalid order_price: {order.get('order_price')}")
 
@@ -79,7 +71,7 @@ def _build_trigger(
         order_price=order_price,
         placed_at=int(order["placed_at"]),
         dry_run=bool(workflow.get("dry_run", False)),
-        trigger_close=_to_float(order.get("trigger_close")),
+        trigger_close=to_float(order.get("trigger_close")),
     )
 
 

--- a/services/workflow_trigger_service.py
+++ b/services/workflow_trigger_service.py
@@ -1,0 +1,145 @@
+import datetime
+import logging
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
+
+from model import Alert, Direction, WorkflowTrigger
+from utils.exception import SaxoException
+from utils.logger import Logger
+
+PARIS = ZoneInfo("Europe/Paris")
+
+logger = Logger.get_logger("workflow_trigger_service", logging.INFO)
+
+
+def _session_window(run_date: str) -> Tuple[int, int]:
+    day = datetime.datetime.strptime(run_date, "%Y-%m-%d").date()
+    start = datetime.datetime.combine(
+        day, datetime.time.min, tzinfo=PARIS
+    ).timestamp()
+    return int(start), int(datetime.datetime.now(PARIS).timestamp())
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    return float(value)
+
+
+def _parse_direction(value: Any) -> Direction:
+    try:
+        return Direction[str(value)]
+    except KeyError:
+        raise SaxoException(f"Unknown order direction: {value!r}")
+
+
+def _asset_keys(alert: Alert) -> List[str]:
+    keys = [alert.asset_code.lower()]
+    if alert.country_code:
+        keys.append(f"{alert.asset_code}:{alert.country_code}".lower())
+    return keys
+
+
+def _index_to_alert_id(alerts: List[Alert]) -> Dict[str, str]:
+    lookup: Dict[str, str] = {}
+    for alert in alerts:
+        for key in _asset_keys(alert):
+            lookup.setdefault(key, alert.id)
+    return lookup
+
+
+def _build_workflow_map(
+    workflows: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        workflow["id"]: workflow
+        for workflow in workflows
+        if workflow.get("id")
+    }
+
+
+def _build_trigger(
+    order: Dict[str, Any], workflow: Dict[str, Any]
+) -> WorkflowTrigger:
+    order_price = _to_float(order.get("order_price"))
+    if order_price is None or order_price <= 0:
+        raise SaxoException(f"Invalid order_price: {order.get('order_price')}")
+
+    return WorkflowTrigger(
+        workflow_name=order.get("workflow_name", workflow.get("name", "")),
+        direction=_parse_direction(order.get("order_direction")),
+        order_price=order_price,
+        placed_at=int(order["placed_at"]),
+        dry_run=bool(workflow.get("dry_run", False)),
+        trigger_close=_to_float(order.get("trigger_close")),
+    )
+
+
+async def collect_todays_triggers(
+    dynamodb_client: Any, run_date: str, alerts: List[Alert]
+) -> Dict[str, List[WorkflowTrigger]]:
+    """Resolve the day's workflow orders to the alert assets they corroborate.
+
+    Returns an empty mapping on any failure: the digest must be identical to
+    what it would have been without this enrichment.
+    """
+    try:
+        return await _collect(dynamodb_client, run_date, alerts)
+    except Exception as e:
+        logger.warning(f"Workflow trigger collection failed, skipping: {e}")
+        return {}
+
+
+async def _collect(
+    dynamodb_client: Any, run_date: str, alerts: List[Alert]
+) -> Dict[str, List[WorkflowTrigger]]:
+    if not alerts:
+        return {}
+
+    start, end = _session_window(run_date)
+    orders = await dynamodb_client.get_all_workflow_orders()
+    todays_orders = [
+        order
+        for order in orders
+        if start <= int(order.get("placed_at", 0)) <= end
+    ]
+    if not todays_orders:
+        return {}
+
+    workflows = _build_workflow_map(await dynamodb_client.get_all_workflows())
+    alert_ids = _index_to_alert_id(alerts)
+
+    triggers: Dict[str, List[WorkflowTrigger]] = {}
+    for order in todays_orders:
+        workflow = workflows.get(order.get("workflow_id"))
+        if workflow is None:
+            logger.info(
+                f"Dropping trigger for unknown workflow "
+                f"{order.get('workflow_id')!r}"
+            )
+            continue
+
+        index = workflow.get("index", "")
+        alert_id = alert_ids.get(index.lower())
+        if alert_id is None:
+            logger.info(
+                f"Dropping trigger: workflow index {index!r} "
+                f"({workflow.get('name')!r}) matches no scanned asset"
+            )
+            continue
+
+        try:
+            trigger = _build_trigger(order, workflow)
+        except SaxoException as e:
+            logger.warning(f"Dropping malformed trigger: {e}")
+            continue
+
+        triggers.setdefault(alert_id, []).append(trigger)
+
+    for trigger_list in triggers.values():
+        trigger_list.sort(key=lambda t: t.placed_at)
+
+    return triggers

--- a/services/workflow_trigger_service.py
+++ b/services/workflow_trigger_service.py
@@ -51,6 +51,18 @@ def _index_to_alert_id(alerts: List[Alert]) -> Dict[str, str]:
     return lookup
 
 
+def _first_match(
+    candidates: List[Optional[str]], alert_ids: Dict[str, str]
+) -> Optional[str]:
+    for candidate in candidates:
+        if not candidate:
+            continue
+        alert_id = alert_ids.get(candidate.lower())
+        if alert_id is not None:
+            return alert_id
+    return None
+
+
 def _build_workflow_map(
     workflows: List[Dict[str, Any]],
 ) -> Dict[str, Dict[str, Any]]:
@@ -122,12 +134,12 @@ async def _collect(
             )
             continue
 
-        index = workflow.get("index", "")
-        alert_id = alert_ids.get(index.lower())
+        candidates = [order.get("order_code"), workflow.get("index")]
+        alert_id = _first_match(candidates, alert_ids)
         if alert_id is None:
             logger.info(
-                f"Dropping trigger: workflow index {index!r} "
-                f"({workflow.get('name')!r}) matches no scanned asset"
+                f"Dropping trigger: neither {candidates!r} "
+                f"({workflow.get('name')!r}) matches a scanned asset"
             )
             continue
 

--- a/specs/028-triage-workflow-trigger/data-model.md
+++ b/specs/028-triage-workflow-trigger/data-model.md
@@ -88,9 +88,11 @@ because `dry_run` has no other source.
 `workflow.index` uses a colon (`AI:xpar`). Comparing ids would silently never match and the feature
 would appear to do nothing. Match on the `asset_code` / `country_code` fields.
 
-**Trap — `order_direction` is stored as the enum NAME.** `WorkflowEngine` writes
-`order_direction.name`, so the stored value is `"BUY"`, while `Direction.BUY.value` is `"Buy"`.
-Parse with `Direction[value]`, not `Direction(value)`.
+**`order_direction` is stored as the enum NAME.** `WorkflowEngine` writes `order_direction.name`,
+so the stored value is `"BUY"`, while `Direction.BUY.value` is `"Buy"` — `Direction("BUY")` raises.
+Use the enum's own `EnumWithGetValue.get_value`, which compares case-insensitively on the value and
+therefore accepts both `"BUY"` and `"Buy"`. No hand-rolled parsing: the base enum already does this,
+and it raises `ValueError` on anything unrecognised.
 
 Unmatched triggers are logged with both sides of the comparison — a mismatch must be diagnosable
 from one run's logs, not inferred from an absence of corroboration.

--- a/specs/028-triage-workflow-trigger/data-model.md
+++ b/specs/028-triage-workflow-trigger/data-model.md
@@ -94,11 +94,17 @@ keep row if start <= placed_at <= end
 `run_date` comes from the digest being built, so manual and off-schedule runs compute their own
 window rather than assuming the 18:15 schedule.
 
-## 6. Collector output
+## 6. Collector signature and output
 
 ```python
-Dict[str, List[WorkflowTrigger]]
+async def collect_todays_triggers(
+    dynamodb_client, run_date: str, alerts: List[Alert]
+) -> Dict[str, List[WorkflowTrigger]]
 ```
+
+The alert set is a **parameter, not an afterthought**: FR-002 makes the scanned assets the domain
+of the result, and the output is keyed by `Alert.id`, which only the alerts can supply. (Earlier
+drafts of this document showed a two-argument signature; that could not have satisfied FR-002.)
 
 Keyed by the same key `TriageAgent._group_by_asset` uses (`Alert.id`), so attaching is a dict
 lookup with no second matching rule. Assets with no trigger are **absent** from the map, not present

--- a/specs/028-triage-workflow-trigger/data-model.md
+++ b/specs/028-triage-workflow-trigger/data-model.md
@@ -58,19 +58,31 @@ Three steps, each of which can drop a trigger without affecting the rest.
 
 **Step 1 — window filter.** Keep rows whose `placed_at` is inside the session window (§5).
 
-**Step 2 — resolve the underlying.** `workflow_orders.order_code` is the **CFD actually traded**,
-not the asset the alert scan sees. Join `workflow_orders.workflow_id` against the
-`{workflow_id: (name, index, dry_run)}` map built from one `get_all_workflows()` read.
-`workflow.index` is the underlying; `workflow.dry_run` is the label. A `workflow_id` absent from the
-map (deleted workflow) drops the trigger.
+**Step 2 — load the workflow record.** Join `workflow_orders.workflow_id` against the
+`{workflow_id: workflow}` map built from one `get_all_workflows()` read. A `workflow_id` absent from
+the map (deleted workflow) drops the trigger — not because the asset is unresolvable (step 3 can
+often still resolve it from the order alone) but because `dry_run` lives only on the workflow
+record, and mislabelling a dry-run trigger as live would inflate conviction. FR-006 makes that
+worse than losing the corroboration.
 
-**Step 3 — match to an alert asset.** Case-insensitive, reusing the semantics of
-`WorkflowService.get_workflows_by_asset`:
+**Step 3 — match to an alert asset.** Two candidate identifiers are tried in order, both
+case-insensitive, against the `asset_code` and `f"{asset_code}:{country_code}"` forms:
 
-```
-index.lower() == asset_code.lower()
-  or index.lower() == f"{asset_code}:{country_code}".lower()
-```
+1. `order.order_code` — **this is the asset code.** Despite the `cfd` field name it comes from, it
+   carries the ordinary `CODE:exchange` form. Confirmed by the repo owner and corroborated by
+   `WorkflowEngine._get_market`, which market-detects by testing
+   `workflow.cfd.lower().endswith(":xnys")` — an opaque CFD instrument name would not carry an
+   exchange suffix.
+2. `workflow.index` — the underlying used for indicator calculation, kept as a fallback for
+   workflows where the two differ.
+
+Trying `order_code` first means the common case resolves without depending on `index` formatting at
+all. A trigger matching neither is dropped, never guessed at (FR-003).
+
+**Superseded assumption.** Spec and plan describe `order_code` as "the CFD actually traded (NOT the
+join key)". That was wrong: it is the code, and it is now the primary join key. The `workflow.index`
+indirection is retained as a fallback rather than removed, and the workflow read stays regardless
+because `dry_run` has no other source.
 
 **Trap — never match on `Alert.id`.** `Alert.id` joins with an underscore (`AI_xpar`);
 `workflow.index` uses a colon (`AI:xpar`). Comparing ids would silently never match and the feature
@@ -175,11 +187,11 @@ Workflow (workflows)
   └─ id ──────────────┐
                       │  (resolution: 1 read for all)
 WorkflowOrder (workflow_orders, TTL'd)
-  ├─ workflow_id ─────┘
-  ├─ order_code  → the CFD traded  (NOT the join key)
+  ├─ workflow_id ─────┘  (needed for dry_run)
+  ├─ order_code  → the asset code — PRIMARY join key
   └─ placed_at   → window filter
                       │
-                      ▼  workflow.index ≈ asset_code[:country_code]
+                      ▼  order_code (else workflow.index) ≈ asset_code[:country_code]
 Alert (in memory, this run)
   └─ asset_code + country_code
                       │

--- a/specs/028-triage-workflow-trigger/plan.md
+++ b/specs/028-triage-workflow-trigger/plan.md
@@ -10,9 +10,9 @@ from one mechanism, on one set of candles, at one moment. This feature adds the 
 system that is structurally independent: a same-day workflow trigger, meaning a rule the trader
 registered in advance fired during the session and produced a directional order.
 
-A new `WorkflowTriggerService` reads the day's `workflow_orders` rows and resolves each one from the
-traded CFD back to the underlying asset the workflow watches, using a single read of the workflow
-definitions. The resulting map is handed to `TriageAgent.synthesize`, which stays synchronous and
+A new `WorkflowTriggerService` reads the day's `workflow_orders` rows and matches each one to a
+scanned asset — by the code on the order itself, falling back to the workflow's watched underlying —
+alongside a single read of the workflow definitions for the dry-run label. The resulting map is handed to `TriageAgent.synthesize`, which stays synchronous and
 pure. Triggers enrich assets already in the alert set and never add new ones. The reasoning prompt
 learns that a trigger is one point of convergence from a separate mechanism, that it carries
 directional authority at least equal to `combo`, and that a trigger contradicting the pattern read
@@ -109,10 +109,11 @@ tests/
 ```
 
 **Structure Decision**: Standard backend layering for this repo — new Service, existing Clients,
-Model extension — with the frontend change confined to a type and a component. The one deliberate
-divergence from the feature description is the workflow-resolution path: a single
-`get_all_workflows()` scan instead of per-trigger `get_workflow_by_id` calls (research R1), because
-the same record carries both `index` and `dry_run` and the table is one item per workflow.
+Model extension — with the frontend change confined to a type and a component. Two deliberate
+divergences from the feature description, both recorded in research: a single `get_all_workflows()`
+scan instead of per-trigger `get_workflow_by_id` calls (R1), and `order_code` as the primary join
+key rather than an opaque CFD name (R3, corrected by the repo owner during implementation). The
+workflow read survives the second change because `dry_run` has no other source.
 
 ## Phase Handoff
 
@@ -127,7 +128,7 @@ the same record carries both `index` and `dry_run` and the table is one item per
 
 | Risk | Mitigation |
 |------|------------|
-| `workflow.index` formatting drifts from the alert asset code, so triggers silently never match | FR-003 drops rather than guesses, and the drop is logged with both sides of the comparison so a mismatch is diagnosable from one run's logs rather than inferred from an absence |
+| Identifier formatting drifts from the alert asset code, so triggers silently never match | Largely retired: `order_code` is the asset code and is tried first, so matching no longer hinges on `index` formatting. `index` remains a fallback, FR-003 drops rather than guesses, and every drop is logged with all candidates so a mismatch is diagnosable from one run's logs rather than inferred from an absence |
 | Reasoning over-weights a trigger and floods the top tier | A-004 fixes it at one convergence point with no multiplier; the prompt states the cap explicitly, and the fallback uses the same weight so the two paths agree |
 | `order_direction` parsed as value instead of name, yielding a wrong or crashed direction | Called out in R5 and data-model.md; covered by a dedicated round-trip test against a row written by `WorkflowEngine`'s own format |
 | Enrichment slows the end-of-day scan | Two scans of small tables, once per run, after all detection has completed; a failure or timeout returns `{}` rather than retrying |

--- a/specs/028-triage-workflow-trigger/quickstart.md
+++ b/specs/028-triage-workflow-trigger/quickstart.md
@@ -121,7 +121,7 @@ cd frontend && npm run lint && npm run build
 
 | Symptom | Likely cause |
 |---------|--------------|
-| No asset ever shows corroboration | `workflow.index` doesn't match any scanned asset code — run step 2 and read the drop logs, which print both sides of the comparison |
+| No asset ever shows corroboration | Neither `order_code` nor `workflow.index` matches a scanned asset code — run step 2 and read the drop logs, which print every candidate tried |
 | `ValueError: 'BUY' is not a valid Direction` | Parsed with `Direction(value)` instead of `Direction[value]` — see data-model §4 |
 | Triggers appear on the workflow orders page but not in the brief | The asset isn't in the alert set (excluded, or index-only) — working as specified, FR-002 |
 | Brief has triggers but ranking looks unchanged | Expected when the trigger agrees with an already-strong read; corroboration breaks ties, it doesn't multiply (A-004) |

--- a/specs/028-triage-workflow-trigger/research.md
+++ b/specs/028-triage-workflow-trigger/research.md
@@ -37,12 +37,23 @@
 
 ## R3. Matching the underlying to the alert asset
 
-- **Decision**: Reuse the matching semantics already established in
-  `WorkflowService.get_workflows_by_asset`: case-insensitive equality of `workflow.index` against
-  either the bare `asset_code` or the composite `f"{asset_code}:{country_code}"`. Match on the
-  `Alert`'s `asset_code`/`country_code` **fields**, never on `Alert.id`.
-- **Rationale**: FR-003. One matching rule for "which workflows watch this asset" already exists
-  and is proven; a second, subtly different rule would drift. The field-level caution matters:
+> **Revised after implementation.** This decision originally treated `order_code` as an opaque CFD
+> instrument name and matched only on `workflow.index`. The repo owner corrected it: `order_code`
+> **is** the asset code, despite deriving from the field named `cfd`. `WorkflowEngine._get_market`
+> confirms it — market detection tests `workflow.cfd.lower().endswith(":xnys")`, which only works on
+> a `CODE:exchange` value. `order_code` is now the primary join key.
+
+- **Decision**: Try two candidate identifiers in order — `order.order_code` first, then
+  `workflow.index` — each compared case-insensitively against the bare `asset_code` and the
+  composite `f"{asset_code}:{country_code}"`, reusing the semantics established in
+  `WorkflowService.get_workflows_by_asset`. Match on the `Alert`'s `asset_code`/`country_code`
+  **fields**, never on `Alert.id`.
+- **Rationale**: FR-003. Preferring `order_code` means the common case resolves straight from the
+  order row, without depending on how `index` happens to be formatted — removing the failure mode
+  this feature was most exposed to. `workflow.index` is kept as a fallback rather than deleted,
+  since the two fields can legitimately differ. One matching rule for "which workflows watch this
+  asset" already exists and is proven; a second, subtly different rule would drift. The field-level
+  caution matters:
   `Alert.id` joins with an underscore (`AI_xpar`) while `workflow.index` uses a colon
   (`AI:xpar`), so an id-level comparison would silently never match.
 - **Alternatives considered**: (a) Normalising both sides through a new shared helper — worth doing

--- a/specs/028-triage-workflow-trigger/research.md
+++ b/specs/028-triage-workflow-trigger/research.md
@@ -86,8 +86,10 @@
   introduced.
 - **Rationale**: Constitution II.3 (enum-driven) and V. `workflow_orders` stores
   `order_direction` as the enum **name** (`WorkflowEngine` writes `order_direction.name`), so
-  parsing is `Direction[value]`, not `Direction(value)` — a real trap, since `Direction.BUY.value`
-  is `"Buy"` while its name is `"BUY"`.
+  `Direction("BUY")` raises — `Direction.BUY.value` is `"Buy"`. Parsing goes through the base
+  enum's own `EnumWithGetValue.get_value`, which compares case-insensitively on the value and so
+  accepts both stored forms. Corrected in review: an earlier draft hand-rolled `Direction[value]`
+  instead of using the method the enum already provides.
 - **Alternatives considered**: Passing raw dicts into the agent — rejected: the model layer exists so
   that the reasoning payload and the persistence layer agree on shape.
 

--- a/specs/028-triage-workflow-trigger/research.md
+++ b/specs/028-triage-workflow-trigger/research.md
@@ -53,8 +53,9 @@
 ## R4. Where the logic lives
 
 - **Decision**: A new `services/workflow_trigger_service.py` exposing an async
-  `collect_todays_triggers(dynamodb_client, run_date) -> Dict[str, List[WorkflowTrigger]]`, keyed by
-  the alert-asset key. `TriageAgent.synthesize` gains an optional `triggers` parameter and stays
+  `collect_todays_triggers(dynamodb_client, run_date, alerts) -> Dict[str, List[WorkflowTrigger]]`,
+  keyed by the alert-asset key. The alert set is a parameter because FR-002 makes it the domain of
+  the result. `TriageAgent.synthesize` gains an optional `triggers` parameter and stays
   **synchronous and pure** — it receives the already-resolved map and never touches storage.
   `run_alerting` calls the collector and passes the result in.
 - **Rationale**: Constitution I — the fetch-and-join is business logic and belongs in the Service

--- a/specs/028-triage-workflow-trigger/spec.md
+++ b/specs/028-triage-workflow-trigger/spec.md
@@ -83,7 +83,7 @@ When the triage reasoning is unavailable and the brief falls back to determinist
 
 - **FR-001**: The system MUST read the workflow triggers recorded during the current Paris trading day and make them available to the triage step.
 - **FR-002**: The system MUST attach a trigger only to an asset that already appears in the day's alert set. Triggers MUST NOT introduce assets into the brief.
-- **FR-003**: The system MUST resolve each recorded trigger from the instrument actually traded (the CFD) to the underlying asset the workflow watches, and match that underlying against the alert asset identifier. A trigger whose underlying cannot be resolved or matched MUST be dropped, not approximated.
+- **FR-003**: The system MUST match each recorded trigger to the asset it was placed on, trying the code recorded on the trigger itself first and the workflow's watched underlying second. A trigger matching neither MUST be dropped, not approximated.
 - **FR-004**: The system MUST bound the session window to the current run date in Paris local time, computed from the run itself rather than from an assumed schedule.
 - **FR-005**: The system MUST record, for each trigger it attaches: the workflow name, the order direction, the order price, the market price at the moment the workflow fired, the time of day it fired, and whether the workflow was in dry-run mode.
 - **FR-006**: The system MUST distinguish dry-run triggers from live ones everywhere a trigger is used — in reasoning, in fallback ranking, and in every display surface.

--- a/specs/028-triage-workflow-trigger/tasks.md
+++ b/specs/028-triage-workflow-trigger/tasks.md
@@ -54,7 +54,7 @@ Frontend: `frontend/src/`. Tests mirror source under `tests/`.
 - [x] T007 Implement the Paris session window in `services/workflow_trigger_service.py` using `zoneinfo.ZoneInfo("Europe/Paris")`, deriving bounds from `run_date` rather than an assumed schedule (data-model.md §5, FR-004)
 - [x] T008 Implement workflow resolution in `services/workflow_trigger_service.py`: one `get_all_workflows()` read into a `{workflow_id: (name, index, dry_run)}` map; drop triggers whose `workflow_id` is absent (research R1, FR-003)
 - [x] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `order_code` then `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log all candidates on every non-match (data-model.md §4, FR-003)
-- [x] T010 Parse `order_direction` with `Direction[value]` (enum **name**, not value) in `services/workflow_trigger_service.py`, raising `SaxoException` on an unknown value — no `assert` (research R5, Constitution II.5)
+- [x] T010 Parse `order_direction` with the enum's own `Direction.get_value(...)` in `services/workflow_trigger_service.py` — it accepts the stored `"BUY"` name form as well as `"Buy"`, and raises `ValueError` on anything else; no hand-rolled parsing, no `assert` (research R5, Constitution II.3/II.5)
 - [x] T011 [P] Create `tests/services/test_workflow_trigger_service.py` covering: in-window vs out-of-window rows, deleted-workflow drop, unmatched-index drop, `BUY`-name parse, dry-run flag read from the workflow record, and `{}` on a raising client
 
 **Checkpoint**: Triggers can be collected and resolved. Nothing consumes them yet.

--- a/specs/028-triage-workflow-trigger/tasks.md
+++ b/specs/028-triage-workflow-trigger/tasks.md
@@ -53,7 +53,7 @@ Frontend: `frontend/src/`. Tests mirror source under `tests/`.
 - [x] T006 Create `services/workflow_trigger_service.py` with async `collect_todays_triggers(dynamodb_client, run_date, alerts) -> Dict[str, List[WorkflowTrigger]]`, returning `{}` on any exception (research R4, R10)
 - [x] T007 Implement the Paris session window in `services/workflow_trigger_service.py` using `zoneinfo.ZoneInfo("Europe/Paris")`, deriving bounds from `run_date` rather than an assumed schedule (data-model.md §5, FR-004)
 - [x] T008 Implement workflow resolution in `services/workflow_trigger_service.py`: one `get_all_workflows()` read into a `{workflow_id: (name, index, dry_run)}` map; drop triggers whose `workflow_id` is absent (research R1, FR-003)
-- [x] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log both sides of every non-match (data-model.md §4, FR-003)
+- [x] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `order_code` then `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log all candidates on every non-match (data-model.md §4, FR-003)
 - [x] T010 Parse `order_direction` with `Direction[value]` (enum **name**, not value) in `services/workflow_trigger_service.py`, raising `SaxoException` on an unknown value — no `assert` (research R5, Constitution II.5)
 - [x] T011 [P] Create `tests/services/test_workflow_trigger_service.py` covering: in-window vs out-of-window rows, deleted-workflow drop, unmatched-index drop, `BUY`-name parse, dry-run flag read from the workflow record, and `{}` on a raising client
 

--- a/specs/028-triage-workflow-trigger/tasks.md
+++ b/specs/028-triage-workflow-trigger/tasks.md
@@ -32,9 +32,13 @@ Frontend: `frontend/src/`. Tests mirror source under `tests/`.
 
 **Purpose**: Establish a known-good baseline so any later failure is attributable to this feature.
 
-- [ ] T001 Run the full backend gate on a clean tree and record the result: `poetry run pytest`, `poetry run mypy .`, `poetry run flake8`
-- [ ] T002 [P] Capture a pre-feature digest sample from `GET /api/alert-digests?limit=1` into `/tmp/digest-before.json` — the byte-comparison baseline for FR-019 and SC-004
-- [ ] T003 [P] Run quickstart step 2 (`get_all_workflows()` dump) and record which `index` values match scanned asset codes — confirms A-001 against live data before any code is written
+- [x] T001 Run the full backend gate on a clean tree and record the result: `poetry run pytest`, `poetry run mypy .`, `poetry run flake8`
+- [ ] T002 [P] ⚠️ BLOCKED — no AWS credentials in the dev container (`UnrecognizedClientException`). Capture a pre-feature digest sample from `GET /api/alert-digests?limit=1` into `/tmp/digest-before.json` — the byte-comparison baseline for FR-019 and SC-004. Must be run from an environment with AWS access before T038.
+- [ ] T003 [P] ⚠️ BLOCKED — same missing credentials. Run quickstart step 2 (`get_all_workflows()` dump) and record which `index` values match scanned asset codes — confirms A-001 against live data. Not blocking Phase 2 (the trader confirmed the overlap), but it is the cheapest way to catch an `index`-format mismatch before US1 ships.
+
+> **Phase 1 result**: T001 baseline recorded — 873 passed, 10 skipped; flake8 clean; mypy reports 4
+> pre-existing `aioboto3` missing-stub errors (unchanged by this feature). T002 and T003 need AWS
+> credentials this container does not have.
 
 ---
 
@@ -44,14 +48,14 @@ Frontend: `frontend/src/`. Tests mirror source under `tests/`.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T004 Add the `WorkflowTrigger` dataclass to `model/__init__.py` with fields `workflow_name`, `direction: Direction`, `order_price: float`, `trigger_close: Optional[float]`, `placed_at: int`, `dry_run: bool` per data-model.md §1
-- [ ] T005 Add `workflow_triggers: List[WorkflowTrigger] = field(default_factory=list)` to `TriagedAsset` in `model/__init__.py` (data-model.md §2)
-- [ ] T006 Create `services/workflow_trigger_service.py` with async `collect_todays_triggers(dynamodb_client, run_date) -> Dict[str, List[WorkflowTrigger]]`, returning `{}` on any exception (research R4, R10)
-- [ ] T007 Implement the Paris session window in `services/workflow_trigger_service.py` using `zoneinfo.ZoneInfo("Europe/Paris")`, deriving bounds from `run_date` rather than an assumed schedule (data-model.md §5, FR-004)
-- [ ] T008 Implement workflow resolution in `services/workflow_trigger_service.py`: one `get_all_workflows()` read into a `{workflow_id: (name, index, dry_run)}` map; drop triggers whose `workflow_id` is absent (research R1, FR-003)
-- [ ] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log both sides of every non-match (data-model.md §4, FR-003)
-- [ ] T010 Parse `order_direction` with `Direction[value]` (enum **name**, not value) in `services/workflow_trigger_service.py`, raising `SaxoException` on an unknown value — no `assert` (research R5, Constitution II.5)
-- [ ] T011 [P] Create `tests/services/test_workflow_trigger_service.py` covering: in-window vs out-of-window rows, deleted-workflow drop, unmatched-index drop, `BUY`-name parse, dry-run flag read from the workflow record, and `{}` on a raising client
+- [x] T004 Add the `WorkflowTrigger` dataclass to `model/__init__.py` with fields `workflow_name`, `direction: Direction`, `order_price: float`, `trigger_close: Optional[float]`, `placed_at: int`, `dry_run: bool` per data-model.md §1
+- [x] T005 Add `workflow_triggers: List[WorkflowTrigger] = field(default_factory=list)` to `TriagedAsset` in `model/__init__.py` (data-model.md §2)
+- [x] T006 Create `services/workflow_trigger_service.py` with async `collect_todays_triggers(dynamodb_client, run_date, alerts) -> Dict[str, List[WorkflowTrigger]]`, returning `{}` on any exception (research R4, R10)
+- [x] T007 Implement the Paris session window in `services/workflow_trigger_service.py` using `zoneinfo.ZoneInfo("Europe/Paris")`, deriving bounds from `run_date` rather than an assumed schedule (data-model.md §5, FR-004)
+- [x] T008 Implement workflow resolution in `services/workflow_trigger_service.py`: one `get_all_workflows()` read into a `{workflow_id: (name, index, dry_run)}` map; drop triggers whose `workflow_id` is absent (research R1, FR-003)
+- [x] T009 Implement asset matching in `services/workflow_trigger_service.py` — case-insensitive `index` against `asset_code` and `f"{asset_code}:{country_code}"`, matching on Alert **fields** not `Alert.id`; log both sides of every non-match (data-model.md §4, FR-003)
+- [x] T010 Parse `order_direction` with `Direction[value]` (enum **name**, not value) in `services/workflow_trigger_service.py`, raising `SaxoException` on an unknown value — no `assert` (research R5, Constitution II.5)
+- [x] T011 [P] Create `tests/services/test_workflow_trigger_service.py` covering: in-window vs out-of-window rows, deleted-workflow drop, unmatched-index drop, `BUY`-name parse, dry-run flag read from the workflow record, and `{}` on a raising client
 
 **Checkpoint**: Triggers can be collected and resolved. Nothing consumes them yet.
 

--- a/tests/services/test_workflow_trigger_service.py
+++ b/tests/services/test_workflow_trigger_service.py
@@ -149,8 +149,43 @@ async def test_drops_trigger_when_workflow_was_deleted():
 
 
 @pytest.mark.asyncio
-async def test_drops_trigger_when_index_matches_no_scanned_asset():
-    client = FakeDynamoDBClient([order()], [workflow(index="GER40.I")])
+async def test_matches_on_order_code_when_index_does_not():
+    client = FakeDynamoDBClient(
+        [order(order_code="AI:xpar")], [workflow(index="something-else")]
+    )
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+
+
+@pytest.mark.asyncio
+async def test_matches_on_bare_order_code():
+    client = FakeDynamoDBClient(
+        [order(order_code="AI")], [workflow(index="something-else")]
+    )
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+
+
+@pytest.mark.asyncio
+async def test_order_code_matching_is_case_insensitive():
+    client = FakeDynamoDBClient(
+        [order(order_code="ai:XPAR")], [workflow(index="something-else")]
+    )
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_when_neither_code_nor_index_matches():
+    client = FakeDynamoDBClient(
+        [order(order_code="GER40.I")], [workflow(index="GER40.I")]
+    )
 
     triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
 

--- a/tests/services/test_workflow_trigger_service.py
+++ b/tests/services/test_workflow_trigger_service.py
@@ -204,7 +204,7 @@ async def test_never_introduces_an_asset_outside_the_alert_set():
 
 
 @pytest.mark.asyncio
-async def test_direction_is_parsed_from_the_enum_name():
+async def test_direction_is_parsed_from_the_stored_enum_name():
     client = FakeDynamoDBClient([order(order_direction="SELL")], [workflow()])
 
     triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
@@ -213,8 +213,26 @@ async def test_direction_is_parsed_from_the_enum_name():
 
 
 @pytest.mark.asyncio
-async def test_drops_trigger_with_unknown_direction():
+async def test_direction_also_accepts_the_enum_value_form():
     client = FakeDynamoDBClient([order(order_direction="Buy")], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers["AI_xpar"][0].direction == Direction.BUY
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_with_unknown_direction():
+    client = FakeDynamoDBClient([order(order_direction="HOLD")], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_with_missing_direction():
+    client = FakeDynamoDBClient([order(order_direction=None)], [workflow()])
 
     triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
 

--- a/tests/services/test_workflow_trigger_service.py
+++ b/tests/services/test_workflow_trigger_service.py
@@ -1,0 +1,265 @@
+import datetime
+from decimal import Decimal
+from typing import Any, Dict, List
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from model import Alert, AlertType, Direction
+from services.workflow_trigger_service import collect_todays_triggers
+
+RUN_DATE = "2026-08-01"
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def at_hour(hour: int, minute: int = 0) -> int:
+    day = datetime.datetime.strptime(RUN_DATE, "%Y-%m-%d").date()
+    return int(
+        datetime.datetime.combine(
+            day, datetime.time(hour, minute), tzinfo=PARIS
+        ).timestamp()
+    )
+
+
+class FakeDynamoDBClient:
+    def __init__(
+        self,
+        orders: List[Dict[str, Any]],
+        workflows: List[Dict[str, Any]],
+    ) -> None:
+        self._orders = orders
+        self._workflows = workflows
+
+    async def get_all_workflow_orders(self) -> List[Dict[str, Any]]:
+        return self._orders
+
+    async def get_all_workflows(self) -> List[Dict[str, Any]]:
+        return self._workflows
+
+
+class RaisingDynamoDBClient:
+    async def get_all_workflow_orders(self) -> List[Dict[str, Any]]:
+        raise RuntimeError("DynamoDB unavailable")
+
+    async def get_all_workflows(self) -> List[Dict[str, Any]]:
+        raise RuntimeError("DynamoDB unavailable")
+
+
+def alert(code: str = "AI", country_code: str = "xpar") -> Alert:
+    return Alert(
+        alert_type=AlertType.COMBO,
+        date=datetime.datetime(2026, 8, 1, 18, 0),
+        data={},
+        asset_code=code,
+        asset_description=f"{code} SA",
+        country_code=country_code,
+    )
+
+
+def order(**overrides: Any) -> Dict[str, Any]:
+    base = {
+        "id": "order-1",
+        "workflow_id": "wf-1",
+        "workflow_name": "AI breakout H1",
+        "placed_at": at_hour(14, 30),
+        "order_code": "AIFP",
+        "order_price": Decimal("158.4"),
+        "order_quantity": Decimal("10"),
+        "order_direction": "BUY",
+        "order_type": "LIMIT",
+        "trigger_close": Decimal("157.9"),
+    }
+    base.update(overrides)
+    return base
+
+
+def workflow(**overrides: Any) -> Dict[str, Any]:
+    base = {
+        "id": "wf-1",
+        "name": "AI breakout H1",
+        "index": "AI:xpar",
+        "cfd": "AIFP",
+        "enable": True,
+        "dry_run": False,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_resolves_trigger_to_the_alert_asset():
+    client = FakeDynamoDBClient([order()], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+    trigger = triggers["AI_xpar"][0]
+    assert trigger.workflow_name == "AI breakout H1"
+    assert trigger.direction == Direction.BUY
+    assert trigger.order_price == 158.4
+    assert trigger.trigger_close == 157.9
+    assert trigger.dry_run is False
+
+
+@pytest.mark.asyncio
+async def test_matches_bare_index_without_country_code():
+    client = FakeDynamoDBClient([order()], [workflow(index="AI")])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+
+
+@pytest.mark.asyncio
+async def test_matching_is_case_insensitive():
+    client = FakeDynamoDBClient([order()], [workflow(index="ai:XPAR")])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert list(triggers) == ["AI_xpar"]
+
+
+@pytest.mark.asyncio
+async def test_drops_orders_placed_before_the_session():
+    yesterday = at_hour(14, 30) - 24 * 3600
+    client = FakeDynamoDBClient([order(placed_at=yesterday)], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_drops_orders_placed_after_now():
+    tomorrow = at_hour(14, 30) + 24 * 3600
+    client = FakeDynamoDBClient([order(placed_at=tomorrow)], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_when_workflow_was_deleted():
+    client = FakeDynamoDBClient([order(workflow_id="gone")], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_when_index_matches_no_scanned_asset():
+    client = FakeDynamoDBClient([order()], [workflow(index="GER40.I")])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_never_introduces_an_asset_outside_the_alert_set():
+    client = FakeDynamoDBClient([order()], [workflow()])
+
+    triggers = await collect_todays_triggers(
+        client, RUN_DATE, [alert(code="SAN")]
+    )
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_direction_is_parsed_from_the_enum_name():
+    client = FakeDynamoDBClient([order(order_direction="SELL")], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers["AI_xpar"][0].direction == Direction.SELL
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_with_unknown_direction():
+    client = FakeDynamoDBClient([order(order_direction="Buy")], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_dry_run_is_read_from_the_workflow_not_the_order():
+    client = FakeDynamoDBClient([order()], [workflow(dry_run=True)])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers["AI_xpar"][0].dry_run is True
+
+
+@pytest.mark.asyncio
+async def test_several_triggers_on_one_asset_are_ordered_by_time():
+    orders = [
+        order(id="order-2", placed_at=at_hour(16, 0)),
+        order(id="order-1", placed_at=at_hour(9, 30)),
+    ]
+    client = FakeDynamoDBClient(orders, [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert [t.placed_at for t in triggers["AI_xpar"]] == [
+        at_hour(9, 30),
+        at_hour(16, 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_conflicting_directions_are_both_kept():
+    orders = [
+        order(id="order-1", order_direction="BUY"),
+        order(id="order-2", order_direction="SELL", placed_at=at_hour(16)),
+    ]
+    client = FakeDynamoDBClient(orders, [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert [t.direction for t in triggers["AI_xpar"]] == [
+        Direction.BUY,
+        Direction.SELL,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_drops_trigger_with_non_positive_price():
+    client = FakeDynamoDBClient(
+        [order(order_price=Decimal("0"))], [workflow()]
+    )
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_trigger_close_is_tolerated():
+    client = FakeDynamoDBClient([order(trigger_close=None)], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [alert()])
+
+    assert triggers["AI_xpar"][0].trigger_close is None
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_storage_is_unavailable():
+    triggers = await collect_todays_triggers(
+        RaisingDynamoDBClient(), RUN_DATE, [alert()]
+    )
+
+    assert triggers == {}
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_there_are_no_alerts():
+    client = FakeDynamoDBClient([order()], [workflow()])
+
+    triggers = await collect_todays_triggers(client, RUN_DATE, [])
+
+    assert triggers == {}

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,9 +1,20 @@
 import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 from zoneinfo import ZoneInfo
 
 from model import Candle, Market, UnitTime
 from utils.logger import Logger
+
+
+def to_float(value: Any) -> Optional[float]:
+    """Normalise a DynamoDB numeric attribute to a float.
+
+    DynamoDB returns numbers as Decimal; every read path has to widen them
+    before they reach a model or a Pydantic response.
+    """
+    if value is None:
+        return None
+    return float(value)
 
 
 def _local_hour_to_utc(


### PR DESCRIPTION
Phases 1–2 of [spec 028](https://github.com/RNiveau/saxo-order/tree/main/specs/028-triage-workflow-trigger). Foundational only: this adds the domain model and the collector that matches a day's workflow orders to the alert assets they corroborate. **Nothing consumes the result yet** — `TriageAgent` is untouched, so the daily brief is byte-for-byte what it was before.

## What's here

- **`WorkflowTrigger`** dataclass in `model/__init__.py`; `TriagedAsset` gains `workflow_triggers`, defaulting to `[]`.
- **`services/workflow_trigger_service.py`** — `collect_todays_triggers(dynamodb_client, run_date, alerts)`:
  - filters `workflow_orders` to the Paris session window, derived from `run_date` rather than the 18:15 schedule, so manual runs compute their own window;
  - matches each order to a scanned asset by `order_code`, falling back to the workflow's `index`;
  - reads the workflow definitions once for the `dry_run` label;
  - returns an empty map on any failure.
- **`utils.helper.to_float`** — extracted from six duplicated `isinstance(x, Decimal)` sites across three services (review follow-up).
- **22 tests** covering the window edges, both drop paths, both matching paths, direction parsing, dry-run labelling, multiple and conflicting triggers, and the storage-unavailable path.

## Corrections made during review

- **`order_code` is the asset code, and is now the primary join key.** My first pass treated it as an opaque CFD instrument name and joined only through `Workflow.index`. The repo owner corrected this, and `WorkflowEngine._get_market` backs it up — it market-detects via `workflow.cfd.lower().endswith(":xnys")`, which only works on a `CODE:exchange` value. `index` is kept as a fallback; the workflow read stays because `dry_run` has no other source.
- **Direction parsing uses the enum's own `get_value`.** `workflow_orders` stores `order_direction` as the enum *name* (`WorkflowEngine` writes `.name`), so `Direction("BUY")` raises. `EnumWithGetValue.get_value` compares case-insensitively on the value and resolves both `"BUY"` and `"Buy"`.

## Deviations from the plan, both deliberate

- **One `get_all_workflows()` read instead of per-trigger `get_workflow_by_id`.** The workflows table is one item per workflow, so one scan replaces N lookups and N failure points.
- **The collector takes `alerts` as a third parameter.** The planning docs showed a two-argument signature; that could not satisfy FR-002, since the output is keyed by `Alert.id` and the alert set is the domain of the result. The docs are corrected in this PR.

## Verification

- `poetry run pytest` — 895 passed, 10 skipped (baseline 873; +22 new).
- `poetry run flake8` — clean. `poetry run black . && poetry run isort .` — applied.
- `poetry run mypy .` — 4 errors, all pre-existing `aioboto3` missing-stub notes, unchanged by this PR.

## Not done

Tasks **T002** and **T003** are blocked: this container has no AWS credentials (`UnrecognizedClientException` on any DynamoDB call), and both need live data. They're marked as blocked in `tasks.md`.

T003 is the dump that confirms the recorded codes actually match scanned asset codes. It matters less now that `order_code` is the primary join key — the format-mismatch risk it was insurance against is largely retired — but it's still the cheapest way to confirm the overlap before US1 ships. Unmatched triggers are dropped with every candidate logged, so a mismatch surfaces as log lines rather than silence.