### PR TITLE
feat: collapse repeated workflow triggers into a counter in the daily brief

### DIFF
--- a/frontend/src/components/DailyBriefCarousel.css
+++ b/frontend/src/components/DailyBriefCarousel.css
@@ -171,6 +171,15 @@
   color: #c9d1d9;
 }
 
+.daily-brief-trigger-count {
+  background: #21262d;
+  border-radius: 3px;
+  color: #c9d1d9;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.05rem 0.3rem;
+}
+
 .daily-brief-trigger-hour {
   color: #8b949e;
 }

--- a/frontend/src/components/DailyBriefCarousel.tsx
+++ b/frontend/src/components/DailyBriefCarousel.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import type { AlertDigest, TriagedAsset } from '../services/api';
+import type { AlertDigest, TriagedAsset, WorkflowTrigger } from '../services/api';
 import { getTradingViewUrl } from '../utils/tradingview';
 import './DailyBriefCarousel.css';
 
@@ -24,6 +24,45 @@ function formatTriggerHour(placedAt: number): string {
     minute: '2-digit',
     timeZone: 'Europe/Paris',
   });
+}
+
+interface TriggerGroup {
+  key: string;
+  workflowName: string;
+  direction: WorkflowTrigger['direction'];
+  dryRun: boolean;
+  count: number;
+  firstAt: number;
+  lastAt: number;
+}
+
+function groupTriggers(triggers: WorkflowTrigger[]): TriggerGroup[] {
+  const groups: TriggerGroup[] = [];
+  const byKey = new Map<string, TriggerGroup>();
+
+  for (const trigger of triggers) {
+    const key = `${trigger.workflow_name}|${trigger.direction}|${trigger.dry_run}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.firstAt = Math.min(existing.firstAt, trigger.placed_at);
+      existing.lastAt = Math.max(existing.lastAt, trigger.placed_at);
+      continue;
+    }
+    const group: TriggerGroup = {
+      key,
+      workflowName: trigger.workflow_name,
+      direction: trigger.direction,
+      dryRun: trigger.dry_run,
+      count: 1,
+      firstAt: trigger.placed_at,
+      lastAt: trigger.placed_at,
+    };
+    byKey.set(key, group);
+    groups.push(group);
+  }
+
+  return groups;
 }
 
 function assetSymbol(asset: TriagedAsset): string {
@@ -69,23 +108,23 @@ function AssetRow({ asset }: { asset: TriagedAsset }) {
       {asset.rationale && (
         <div className="daily-brief-asset-rationale">{asset.rationale}</div>
       )}
-      {asset.workflow_triggers?.map((trigger) => (
-        <div
-          className="daily-brief-asset-trigger"
-          key={`${trigger.workflow_name}-${trigger.placed_at}`}
-        >
+      {groupTriggers(asset.workflow_triggers ?? []).map((group) => (
+        <div className="daily-brief-asset-trigger" key={group.key}>
           <span
-            className={`daily-brief-trigger-direction ${trigger.direction.toLowerCase()}`}
+            className={`daily-brief-trigger-direction ${group.direction.toLowerCase()}`}
           >
-            {trigger.direction === 'BUY' ? '▲' : '▼'} {trigger.direction}
+            {group.direction === 'BUY' ? '▲' : '▼'} {group.direction}
           </span>
-          <span className="daily-brief-trigger-name">
-            {trigger.workflow_name}
-          </span>
+          <span className="daily-brief-trigger-name">{group.workflowName}</span>
+          {group.count > 1 && (
+            <span className="daily-brief-trigger-count">×{group.count}</span>
+          )}
           <span className="daily-brief-trigger-hour">
-            {formatTriggerHour(trigger.placed_at)}
+            {group.count > 1
+              ? `${formatTriggerHour(group.firstAt)} → ${formatTriggerHour(group.lastAt)}`
+              : formatTriggerHour(group.firstAt)}
           </span>
-          {trigger.dry_run && (
+          {group.dryRun && (
             <span className="daily-brief-trigger-dryrun">dry run</span>
           )}
         </div>


### PR DESCRIPTION
## Problem

A workflow that fires every 30 minutes rendered one line per firing in the daily brief's asset card — e.g. 14 identical `▲ BUY BUY INCLINED DAILY FRVIA` rows on a single asset, drowning the rationale.

## Change

Frontend-only. `DailyBriefCarousel` now folds identical triggers (same workflow name, direction and dry-run flag) into a single row showing the firing count and the time span:

```
▲ BUY  BUY INCLINED DAILY FRVIA  ×14  12:04 → 18:03
```

A trigger that fired only once keeps its previous rendering (no `×1`, single hour).

- `frontend/src/components/DailyBriefCarousel.tsx` — new `groupTriggers()` helper preserving first-seen order and tracking count / first / last timestamps; the trigger list renders one row per group.
- `frontend/src/components/DailyBriefCarousel.css` — new `.daily-brief-trigger-count` pill, styled to match the existing hour and dry-run elements.

No backend change: the Slack digest already collapses triggers to a single ⚡ marker, and the triage reasoning still receives every individual trigger since the repetition is part of the signal.

## Testing

`tsc --noEmit` and `eslint` both clean. No frontend test suite covers this component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sut13W2bszsCyeCuGLLMX

---
_Generated by [Claude Code](https://claude.ai/code/session_012Sut13W2bszsCyeCuGLLMX)_